### PR TITLE
Add the missing overload of ?? and use instead of ?>

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A more formal and authoritative documentation is on the way.
 
 ### Build Val
 
-Val is distributed in the form of a Swift package, which can be built with [Swift Package Manager](swift package manager).
+Val is distributed in the form of a Swift package, which can be built with [Swift Package Manager](https://www.swift.org/package-manager/).
 
 Clone this repository and simply run `swift build -c release` to build the project.
 This command will create an executable `.build/release/val`.

--- a/Sources/AST/GenericEnv.swift
+++ b/Sources/AST/GenericEnv.swift
@@ -95,7 +95,7 @@ public final class GenericEnv {
     self.typeReqs = typeReqs
 
     // Initialize semantic properties.
-    let prepare = context.prepareGenericEnv ?< fatalError("no generic environment delegate")
+    let prepare = context.prepareGenericEnv ?? fatalError("no generic environment delegate")
     guard prepare(self) else { return nil }
   }
 

--- a/Sources/Basic/Swift+Extensions.swift
+++ b/Sources/Basic/Swift+Extensions.swift
@@ -72,22 +72,8 @@ extension Sequence {
 
 }
 
-infix operator ?< : NilCoalescingPrecedence
-
-/// Performs a nil-coalescing operation, returning the wrapped value of an Optional instance or
-/// calling the specified closure for a default value.
-public func ?< <T>(lhs: T?, rhs: () -> T?) -> T? {
-  return lhs ?? rhs()
-}
-
-/// Performs a nil-coalescing operation, returning the wrapped value of an Optional instance or
-/// calling the specified closure for a default value.
-public func ?< <T>(lhs: T?, rhs: () -> T) -> T {
-  return lhs ?? rhs()
-}
-
-/// Unwraps the left operand or evaluates the specified non-terminating expression.
-public func ?< <T>(lhs: T?, rhs: @autoclosure () -> Never) -> T {
+/// Returns `lhs!` if `lhs` is non-`nil`; evaluates `rhs()`, which never returns, otherwise.
+public func ?? <T>(lhs: T?, rhs: @autoclosure () -> Never) -> T {
   if let lhs = lhs {
     return lhs
   } else {

--- a/Sources/Eval/Interpreter.swift
+++ b/Sources/Eval/Interpreter.swift
@@ -115,7 +115,7 @@ public struct Interpreter {
     ]
 
     // Invoke the program's entry point.
-    let main = funTable[VILName("main")] ?< fatalError("no main function")
+    let main = funTable[VILName("main")] ?? fatalError("no main function")
     invoke(fun: functions[main], threadID: 0, callerAddr: .null, args: [], returnKey: nil)
     run()
 
@@ -172,7 +172,7 @@ public struct Interpreter {
     returnKey: RegisterTableKey?
   ) where Arguments: Sequence, Arguments.Element == RuntimeValue {
     let entryID = fun.entryID
-      ?< fatalError("function '\(fun.name)' has no entry block")
+      ?? fatalError("function '\(fun.name)' has no entry block")
 
     // Reserve the return register, if any.
     if let key = returnKey {
@@ -307,7 +307,7 @@ public struct Interpreter {
     switch inst.callee {
     case let literal as BuiltinFunRef:
       let callee = BuiltinFunction(literal: literal)
-        ?< fatalError("no built-in function named '\(literal.decl.name)'")
+        ?? fatalError("no built-in function named '\(literal.decl.name)'")
       let args = inst.args.map({ eval(value: $0) })
 
       let result = callee.apply(to: Array(args), in: &self)
@@ -593,7 +593,7 @@ public struct Interpreter {
   private mutating func eval(inst: RecordMemberInst) {
     let record = eval(value: inst.record)
     let offset = layout.offset(of: inst.memberDecl.name, in: inst.record.type)
-      ?< fatalError("failed to compute member offset")
+      ?? fatalError("failed to compute member offset")
 
     let byteCount = layout.size(of: inst.type)
     let member = record.withUnsafeBytes({ bytes in
@@ -608,7 +608,7 @@ public struct Interpreter {
   private mutating func eval(inst: RecordMemberAddrInst) {
     let base = eval(value: inst.record).open(as: ValueAddr.self)
     let offset = layout.offset(of: inst.memberDecl.name, in: inst.record.type.object)
-      ?< fatalError("failed to compute member offset")
+      ?? fatalError("failed to compute member offset")
 
     activeThread.registerStack.assign(native: base.advanced(by: offset), to: .value(inst))
     increment(counter: &activeThread.programCounter)
@@ -630,7 +630,7 @@ public struct Interpreter {
       // frame when the function was invoked. Hence, that memory won't be overridden if we only
       // move it to the return register without allocating anything else.
       let callerInst = load(instAddr: callerAddr) as? ApplyInst
-        ?< fatalError("bad caller address")
+        ?? fatalError("bad caller address")
 
       result.withUnsafeBytes({ bytes in
         activeThread.registerStack.assignNoAlloc(contentsOf: bytes, to: .value(callerInst))

--- a/Sources/Eval/RegisterStack.swift
+++ b/Sources/Eval/RegisterStack.swift
@@ -195,7 +195,7 @@ struct RegisterStack {
     let header = memory.baseAddress!
       .advanced(by: lastFrameOffset)
       .assumingMemoryBound(to: FrameHeader.self)
-    let info = header.pointee.table[key] ?< fatalError("register is not reserved")
+    let info = header.pointee.table[key] ?? fatalError("register is not reserved")
     precondition(!info.busy, "register is assigned")
     precondition(info.count >= buffer.count, "buffer is too large")
 

--- a/Sources/Parse/Parser.swift
+++ b/Sources/Parse/Parser.swift
@@ -813,11 +813,11 @@ public struct Parser {
       // We're parsing a type alias declaration.
       _ = state.take()
 
-      let sign = parseSign(state: &state) ?< { () -> Sign in
+      let sign = parseSign(state: &state) ?? { () -> Sign in
         context.report("expected type signature", anchor: state.errorRange())
         state.hasError = true
         return ErrorSign(type: context.errorType, range: state.errorRange())
-      }
+      }()
       upperLoc = sign.range!.upperBound
 
       let decl = AliasTypeDecl(name: head.ident.name, aliasedSign: sign, type: unresolved)
@@ -1129,11 +1129,11 @@ public struct Parser {
     }
 
     // Parse the right operand of the requirement.
-    let rhs = parseSign(state: &state) ?< { () -> Sign in
+    let rhs = parseSign(state: &state) ?? { () -> Sign in
       context.report("expected type signature", anchor: state.errorRange())
       state.hasError = true
       return ErrorSign(type: context.errorType, range: state.errorRange())
-    }
+    }()
 
     return TypeReq(kind: kind, lhs: identSign, rhs: rhs, range: lhs.range! ..< rhs.range!)
   }
@@ -1289,10 +1289,10 @@ public struct Parser {
       if let ident = state.takeOperator() {
         // The operator is a standard non-cast infix operator,.
         oper = ident
-        group = PrecedenceGroup(for: ident.name) ?< {
+        group = PrecedenceGroup(for: ident.name) ?? {
           context.report("unknown infix operator '\(oper.name)'", anchor: oper.range)
           return nil
-        }
+        }()
       } else if let name = state.peek(), name.kind == .name {
         // The next token might be an infix identifier. However, we require that it be on the same
         // line as the left operand, to to avoid any ambiguity with statements that may begin with
@@ -1718,11 +1718,11 @@ public struct Parser {
   private func parseMatchExpr(state: inout State) -> Expr? {
     guard let introducer = state.take(.match) else { return nil }
 
-    let subject = parseExpr(state: &state) ?< { () -> Expr in
+    let subject = parseExpr(state: &state) ?? { () -> Expr in
       context.report("expected expression", anchor: state.errorRange())
       state.hasError = true
       return ErrorExpr(type: context.errorType, range: state.errorRange())
-    }
+    }()
 
     let expr = MatchExpr(
       isSubexpr: true, subject: subject, cases: [], type: unresolved, range: introducer.range)
@@ -1753,28 +1753,28 @@ public struct Parser {
   private func parseMatchCase(state: inout State) -> MatchCaseStmt? {
     guard let introducer = state.take(.case) else { return nil }
 
-    let pattern = parsePattern(state: &state) ?< { () -> Pattern in
+    let pattern = parsePattern(state: &state) ?? { () -> Pattern in
       context.report("expected pattern", anchor: state.errorRange())
       state.hasError = true
       return WildcardPattern(type: context.errorType, range: state.errorRange())
-    }
+    }()
 
     let condition: Expr?
     if state.take(.where) != nil {
-      condition = parseExpr(state: &state) ?< {
+      condition = parseExpr(state: &state) ?? {
         context.report("expected condition", anchor: state.errorRange())
         state.hasError = true
         return nil
-      }
+      }()
     } else {
       condition = nil
     }
 
-    let body = parseBraceStmt(state: &state) ?< { () -> BraceStmt in
+    let body = parseBraceStmt(state: &state) ?? { () -> BraceStmt in
       context.report("expected '{' after case pattern", anchor: state.errorRange())
       state.hasError = true
       return BraceStmt(statements: [], range: state.errorRange())
-    }
+    }()
 
     let stmt = MatchCaseStmt(pattern: pattern, condition: condition, body: body)
     stmt.range = introducer.range.lowerBound ..< body.range!.upperBound

--- a/Sources/Sema/StmtChecker.swift
+++ b/Sources/Sema/StmtChecker.swift
@@ -45,7 +45,7 @@ struct StmtChecker: StmtVisitor {
     retStmts.append(node)
 
     // Use the return type of the function as the fixed type of the returned value.
-    let funDecl = node.funDecl ?< fatalError("return statement outside of a function")
+    let funDecl = node.funDecl ?? fatalError("return statement outside of a function")
     assert(funDecl.state >= .realized)
     let funType = funDecl.type as! FunType
     var fixedRetType = funType.retType

--- a/Sources/VIL/Analysis/Typestate.swift
+++ b/Sources/VIL/Analysis/Typestate.swift
@@ -213,7 +213,7 @@ public struct TypestateAnalysis {
   public init() {}
 
   public func run(_ funName: VILName, with builder: inout Builder) -> Bool {
-    let fun = builder.module.functions[funName] ?< fatalError("function does not exist")
+    let fun = builder.module.functions[funName] ?? fatalError("function does not exist")
     guard let entryID = fun.entryID else { return true }
 
     // Build the function's dominator tree to establish the initial visiting order.

--- a/Sources/VIL/Builder.swift
+++ b/Sources/VIL/Builder.swift
@@ -304,7 +304,7 @@ public struct Builder {
   ///   - args: The arguments of the function application.
   public mutating func buildApply(callee: Value, args: [Value]) -> ApplyInst {
     let calleeType = callee.type as? VILFunType
-      ?< preconditionFailure("apply on non-function operand")
+      ?? preconditionFailure("apply on non-function operand")
 
     // Validate the arguments according to the function's parameter convention.
     for (arg, conv) in zip(args, calleeType.paramConvs) {


### PR DESCRIPTION
Dropping `()` was is worth learning a new operator for, and the overload set
creates a potential ambiguity (at least for users): when passed a
never-returning function as 2nd operand, is it being called or just returned?

I think this improves comprehensibility overall.