### PR TITLE
Omit needless and misleading words, etc.

### DIFF
--- a/Sources/Compiler/AST/AST.swift
+++ b/Sources/Compiler/AST/AST.swift
@@ -1,33 +1,32 @@
-/// A collection of module declarations representing an abstract syntax tree.
+/// An abstract syntax tree.
 public struct AST {
 
-  /// The nodes in the AST.
-  ///
-  /// - Notes: Should be an array with tombstones once .
+  /// The nodes in `self`.
+  // FIXME: Should be an array with tombstones.
   private var nodes: [Any] = []
 
-  /// A collection with the indices of the modules of the AST.
+  /// The indices of the modules.
   public private(set) var modules: [NodeIndex<ModuleDecl>] = []
 
-  /// The source range annotations of the nodes.
+  /// The source range of each node.
   public var ranges = NodeMap<SourceRange>()
 
   /// Creates an empty AST.
   public init() {}
 
-  /// The index of the module containing Val's standard library, if present in the AST.
+  /// The index of the module containing Val's standard library, if any.
   public var std: NodeIndex<ModuleDecl>?
 
-  /// Returns the scope hierarchy of the AST.
+  /// Returns the scope hierarchy.
   func scopeHierarchy() -> ScopeHierarchy {
     var builder = ScopeHierarchyBuilder()
     return builder.build(hierarchyOf: self)
   }
 
-  /// Inserts a node in the AST.
-  public mutating func insert<T: Node>(_ node: T) -> NodeIndex<T> {
+  /// Inserts `n` into `self`.
+  public mutating func insert<T: Node>(_ n: T) -> NodeIndex<T> {
     let i = NodeIndex<T>(rawValue: nodes.count)
-    nodes.append(node)
+    nodes.append(n)
     if node is ModuleDecl { modules.append(i as! NodeIndex<ModuleDecl>) }
     return i
   }


### PR DESCRIPTION
1. It isn't a Collection
2. The thing you get by subscripting it is not the module declaration
3. That it “represents” an AST isn't any different from saying it *is* an AST.
4. Notes to the implementor don't go in doc comments
5. Saying that an array is "a collection with" something is needless.  Saying the modules are “of the AST” is needless; it's a property!
6. Calling the source range of each node a “source range annotation” is needless.
7. Referring to “the AST” is a convention that doesn't scale.  What happens when there's a parameter of `Self` type? 
8. Referring to “the node,” ditto.

If tooling isn't telling us whether a subscript is just for reading or for read/write, without reading a comment, that's pretty sad.