### PR TITLE
Add CXX/README.md to the compiler's resources to silence warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,9 @@ let package = Package(
         .product(name: "Collections", package: "swift-collections"),
         .product(name: "LLVM", package: "LLVMSwift"),
         .product(name: "Durian", package: "Durian"),
-      ]),
+      ],
+      resources: [.copy("CXX/README.md")]
+      ),
 
     .target(
       name: "Library",


### PR DESCRIPTION
Without this, `swift build -c release` produces a warning:

```
'val': warning: found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    //path-to-val/Sources/Compiler/CXX/README.md
```