### PR TITLE
Remove 'converting:' label on initializers.

### DIFF
--- a/Sources/Compiler/AST/Decl/FunDecl.swift
+++ b/Sources/Compiler/AST/Decl/FunDecl.swift
@@ -85,7 +85,7 @@ public struct FunDecl: GenericDecl, GenericScope {
   /// The declaration of the implicit receiver parameter, if any.
   public var implicitReceiverDecl: NodeID<ParameterDecl>? {
     if let parameter = implicitParameterDecls.first, parameter.name == "self" {
-      return NodeID(converting: parameter.decl)
+      return NodeID(parameter.decl)
     } else {
       return nil
     }

--- a/Sources/Compiler/AST/NodeIDs/NodeID.swift
+++ b/Sources/Compiler/AST/NodeIDs/NodeID.swift
@@ -20,7 +20,7 @@ public struct NodeID<Subject: Node>: NodeIDProtocol {
   public var kind: NodeKind { Subject.kind }
 
   /// Creates an instance with the same raw value as `x` failing iff `x.kind != Subject.kind`.
-  public init?<Other: NodeIDProtocol>(converting x: Other) {
+  public init?<Other: NodeIDProtocol>(_ x: Other) {
     if x.kind == Subject.kind {
       self.init(rawValue: x.rawValue)
     } else {

--- a/Sources/Compiler/AST/NodeIDs/ScopeID.swift
+++ b/Sources/Compiler/AST/NodeIDs/ScopeID.swift
@@ -16,10 +16,11 @@ public struct AnyScopeID: ScopeID {
     base = AnyNodeID(other)
   }
 
-  /// Converts `n` to a scope ID; fails if `n` denotes a node that is not a lexical scope.
-  public init?<Other: NodeIDProtocol>(converting other: Other) {
-    if other.kind <= .lexicalScope {
-      base = AnyNodeID(other)
+  /// Creates an instance referring to the same node as `x`, failing if `x` does not identify a
+  /// lexical scope.
+  public init?<Other: NodeIDProtocol>(_ x: Other) {
+    if x.kind <= .lexicalScope {
+      base = AnyNodeID(x)
     } else {
       return nil
     }

--- a/Sources/Compiler/IR/AbstractTypeLayout.swift
+++ b/Sources/Compiler/IR/AbstractTypeLayout.swift
@@ -51,7 +51,7 @@ extension TypedProgram {
     switch type {
     case .product(let type):
       for m in ast[type.decl].members {
-        guard let binding = NodeID<BindingDecl>(converting: m) else { continue }
+        guard let binding = NodeID<BindingDecl>(m) else { continue }
         for (_, name) in ast.names(in: ast[binding].pattern) {
           let decl = ast[name].decl
           indices[ast[decl].name] = types.count

--- a/Sources/Compiler/IR/Emitter.swift
+++ b/Sources/Compiler/IR/Emitter.swift
@@ -476,7 +476,7 @@ public struct Emitter {
     funCall expr: NodeID<FunCallExpr>,
     into module: inout Module
   ) -> Operand {
-    let calleeType = LambdaType(converting: program.exprTypes[program.ast[expr].callee]!)!
+    let calleeType = LambdaType(program.exprTypes[program.ast[expr].callee]!)!
 
     // Determine the callee's convention.
     var conventions: [PassingConvention]
@@ -491,7 +491,7 @@ public struct Emitter {
     var arguments: [Operand] = []
 
     for (parameter, argument) in zip(calleeType.inputs, program.ast[expr].arguments) {
-      let parameterType = ParameterType(converting: parameter.type)!
+      let parameterType = ParameterType(parameter.type)!
       conventions.append(parameterType.convention)
 
       switch parameterType.convention {
@@ -513,7 +513,7 @@ public struct Emitter {
     // function object the arguments.
     let callee: Operand
 
-    if let calleeID = NodeID<NameExpr>(converting: program.ast[expr].callee) {
+    if let calleeID = NodeID<NameExpr>(program.ast[expr].callee) {
       switch program.referredDecls[calleeID] {
       case .direct(let calleeDeclID) where calleeDeclID.kind == .builtinDecl:
         // Callee refers to a built-in function.

--- a/Sources/Compiler/Parse/Parser.swift
+++ b/Sources/Compiler/Parse/Parser.swift
@@ -2091,7 +2091,7 @@ public enum Parser {
   static let nameTypeExpr = (
     compoundTypeExpr
       .map({ (context, id) -> NodeID<NameTypeExpr> in
-        if let converted = NodeID<NameTypeExpr>(converting: id) {
+        if let converted = NodeID<NameTypeExpr>(id) {
           return converted
         } else {
           throw ParseError("expected type name", at: context.ast.ranges[id]!.first())

--- a/Sources/Compiler/TypeChecking/ConstraintGenerator.swift
+++ b/Sources/Compiler/TypeChecking/ConstraintGenerator.swift
@@ -219,7 +219,7 @@ struct ConstraintGenerator: ExprVisitor {
     }
 
     // 2nd case
-    if let c = NodeID<NameExpr>(converting: callee),
+    if let c = NodeID<NameExpr>(callee),
        let d = checker.referredDecls[c]?.decl,
        d.kind <= .typeDecl
     {
@@ -230,14 +230,14 @@ struct ConstraintGenerator: ExprVisitor {
           labels: [],
           notation: nil,
           introducer: nil,
-          inDeclSpaceOf: AnyScopeID(converting: d)!)
+          inDeclSpaceOf: AnyScopeID(d)!)
 
         // Select suitable candidates based on argument labels.
         let labels = checker.ast[id].arguments.map({ $0.label?.value })
         var candidates: [Constraint.OverloadCandidate] = []
         for initializer in initializers {
           // Remove the receiver from the parameter list.
-          let ctor = LambdaType(converting: initializer.type)!.ctor()!
+          let ctor = LambdaType(initializer.type)!.ctor()!
 
           if labels.elementsEqual(ctor.labels) {
             let (ty, cs) = checker.open(type: .lambda(ctor))
@@ -262,7 +262,7 @@ struct ConstraintGenerator: ExprVisitor {
           inferredTypes[c] = candidates[0].type
 
           // Propagate the type of the constructor down.
-          let calleeType = LambdaType(converting: candidates[0].type)!
+          let calleeType = LambdaType(candidates[0].type)!
           propagateDown(calleeType: calleeType, calleeConstraints: candidates[0].constraints)
 
         default:
@@ -271,7 +271,7 @@ struct ConstraintGenerator: ExprVisitor {
         }
 
       case .traitDecl:
-        let trait = TraitType(decl: NodeID(converting: d)!, ast: checker.ast)
+        let trait = TraitType(decl: NodeID(d)!, ast: checker.ast)
         diagnostics.append(.cannotConstruct(trait: trait, at: checker.ast.ranges[callee]))
         assignToError(id)
 
@@ -503,7 +503,7 @@ struct ConstraintGenerator: ExprVisitor {
       // If we determined that the domain refers to a nominal type declaration, create a static
       // member constraint. Otherwise, create a non-static member constraint.
       let constraint: Constraint
-      if let base = NodeID<NameExpr>(converting: domain),
+      if let base = NodeID<NameExpr>(domain),
          let decl = checker.referredDecls[base]?.decl,
          decl.kind <= .typeDecl
       {
@@ -625,7 +625,7 @@ struct ConstraintGenerator: ExprVisitor {
     // If the looked up name has a method introducer, it must refer to a method implementation.
     if let introducer = introducer {
       matches = Set(matches.compactMap({ match in
-        guard let method = NodeID<FunDecl>(converting: match),
+        guard let method = NodeID<FunDecl>(match),
               let body = checker.ast[method].body,
               case .bundle(let impls) = body
         else { return nil }

--- a/Sources/Compiler/TypeChecking/ConstraintSolver.swift
+++ b/Sources/Compiler/TypeChecking/ConstraintSolver.swift
@@ -327,7 +327,7 @@ struct ConstraintSolver {
     }
 
     // Get the name expression associated with the constraint, if any.
-    let nameBoundByCurrentConstraint = location.node.flatMap(NodeID<NameExpr>.init(converting:))
+    let nameBoundByCurrentConstraint = location.node.flatMap(NodeID<NameExpr>.init)
 
     // Fast path when there's only one candidate.
     if candidates.count == 1 {
@@ -391,7 +391,7 @@ struct ConstraintSolver {
     if candidates.count == 1 {
       solve(candidates[0].type, equalsTo: r, location: location)
       if let node = location.node,
-         let name = NodeID<NameExpr>(converting: node)
+         let name = NodeID<NameExpr>(node)
       {
         bindingAssumptions[name] = .direct(candidates[0].decl)
       }

--- a/Sources/Compiler/TypeChecking/GenericEnvironment.swift
+++ b/Sources/Compiler/TypeChecking/GenericEnvironment.swift
@@ -22,7 +22,7 @@ struct GenericEnvironment {
   init?<T: DeclID>(decl: T, constraints: [Constraint], into checker: inout TypeChecker) {
     self.constraints = constraints
 
-    let scope = AnyScopeID(converting: decl)!
+    let scope = AnyScopeID(decl)!
     for c in constraints {
       switch c {
       case .equality(let l, let r):

--- a/Sources/Compiler/TypeChecking/ScopeHierarchy.swift
+++ b/Sources/Compiler/TypeChecking/ScopeHierarchy.swift
@@ -143,7 +143,7 @@ public struct ScopeHierarchy {
     while let parent = parent[last] {
       last = parent
     }
-    return NodeID(converting: last)
+    return NodeID(last)
   }
 
 }

--- a/Sources/Compiler/TypeChecking/TypeChecker.swift
+++ b/Sources/Compiler/TypeChecking/TypeChecker.swift
@@ -474,7 +474,7 @@ public struct TypeChecker {
       decl = ast[id]
 
       // Set its type.
-      let type = LambdaType(converting: declTypes[id]!)!
+      let type = LambdaType(declTypes[id]!)!
       if decl.introducer.value == .`init` {
         // The receiver of an initializer is its first parameter.
         declTypes[param] = type.inputs[0].type
@@ -581,7 +581,7 @@ public struct TypeChecker {
 
     // Type check the default value, if any.
     if let defaultValue = ast[id].defaultValue {
-      let parameterType = ParameterType(converting: declTypes[id]!)!
+      let parameterType = ParameterType(declTypes[id]!)!
       let defaultValueType = Type.variable(TypeVariable(node: defaultValue.base))
 
       let constraints = [
@@ -609,7 +609,7 @@ public struct TypeChecker {
   }
 
   private mutating func check(operator id: NodeID<OperatorDecl>) -> Bool {
-    guard let source = NodeID<TopLevelDeclSet>(converting: scopeHierarchy.container[id]!) else {
+    guard let source = NodeID<TopLevelDeclSet>(scopeHierarchy.container[id]!) else {
       diagnostics.insert(.nestedOperatorDeclaration(at: ast.ranges[id]))
       return false
     }
@@ -1127,7 +1127,7 @@ public struct TypeChecker {
       return e
     }
 
-    let declScope = AnyScopeID(converting: id)!
+    let declScope = AnyScopeID(id)!
     let parentScope = scopeHierarchy.parent[declScope]!
     var success = true
     var constraints: [Constraint] = []
@@ -1831,7 +1831,7 @@ public struct TypeChecker {
 
   /// Returns the names and declarations introduced in `scope`.
   private func names<T: NodeIDProtocol>(introducedIn scope: T) -> LookupTable {
-    if let module = NodeID<ModuleDecl>(converting: scope) {
+    if let module = NodeID<ModuleDecl>(scope) {
       return ast[module].sources.reduce(into: [:], { (table, s) in
         table.merge(names(introducedIn: s), uniquingKeysWith: { (l, _) in l })
       })
@@ -2305,7 +2305,7 @@ public struct TypeChecker {
 
     // Handle memberwise initializers.
     if ast[id].introducer.value == .memberwiseInit {
-      guard let productTypeDecl = NodeID<ProductTypeDecl>(converting: parentScope) else {
+      guard let productTypeDecl = NodeID<ProductTypeDecl>(parentScope) else {
         diagnostics.insert(.illegalMemberwiseInit(at: ast[id].introducer.range))
         return .error(ErrorType())
       }
@@ -2680,7 +2680,7 @@ public struct TypeChecker {
         }
 
         // Capture-less local functions are not captured.
-        if let funDecl = NodeID<FunDecl>(converting: captureDecl) {
+        if let funDecl = NodeID<FunDecl>(captureDecl) {
           guard case .lambda(let lambda) = realize(funDecl: funDecl) else { continue }
           if lambda.environment == .unit { continue }
         }
@@ -2736,7 +2736,7 @@ public struct TypeChecker {
 
     // List and realize the type of all stored bindings.
     for m in ast[decl].members {
-      guard let member = NodeID<BindingDecl>(converting: m) else { continue }
+      guard let member = NodeID<BindingDecl>(m) else { continue }
       if realize(bindingDecl: member).isError { return nil }
 
       for (_, name) in ast.names(in: ast[member].pattern) {
@@ -2831,7 +2831,7 @@ public struct TypeChecker {
         // Identify the generic environment that introduces the parameter.
         let origin: AnyScopeID
         if base.decl.kind == .traitDecl {
-          origin = AnyScopeID(converting: base.decl)!
+          origin = AnyScopeID(base.decl)!
         } else {
           origin = scopeHierarchy.container[base.decl]!
         }

--- a/Sources/Compiler/Types/LambdaType.swift
+++ b/Sources/Compiler/Types/LambdaType.swift
@@ -45,8 +45,9 @@ public struct LambdaType: TypeProtocol, Hashable {
     flags = fs
   }
 
-  public init?(converting type: Type) {
-    if case .lambda(let t) = type {
+  /// Creates an instance identifying `x`, failing if `x` is not a lambda type.
+  public init?(_ x: Type) {
+    if case .lambda(let t) = x {
       self = t
     } else {
       return nil

--- a/Sources/Compiler/Types/ParameterType.swift
+++ b/Sources/Compiler/Types/ParameterType.swift
@@ -17,8 +17,9 @@ public struct ParameterType: TypeProtocol, Hashable {
     self.flags = bareType.flags
   }
 
-  public init?(converting type: Type) {
-    if case .parameter(let t) = type {
+  /// Creates an instance identifying `x`, failing if `x` is not a parameter type.
+  public init?(_ x: Type) {
+    if case .parameter(let t) = x {
       self = t
     } else {
       return nil

--- a/Sources/Compiler/Types/ProductType.swift
+++ b/Sources/Compiler/Types/ProductType.swift
@@ -27,7 +27,7 @@ extension ProductType {
   public init?(standardLibraryTypeNamed name: String, ast: AST) {
     let stdlib = ast.stdlib ?? preconditionFailure("standard library is not loaded")
     for id in ast.topLevelDecls(stdlib) where id.kind == .productTypeDecl {
-      let id = NodeID<ProductTypeDecl>(converting: id)!
+      let id = NodeID<ProductTypeDecl>(id)!
       if ast[id].name == name {
         self.init(decl: id, ast: ast)
         return


### PR DESCRIPTION
These are standard value-preserving conversions just like `Int.init?(_: String)`, for which the explicitly established convention is "no parameter label."