### PR TITLE
Fact return type int

### DIFF
--- a/Sources/Compiler/CXX/CXXTypeExpr.swift
+++ b/Sources/Compiler/CXX/CXXTypeExpr.swift
@@ -16,6 +16,14 @@ public struct CXXTypeExpr: CustomStringConvertible {
     case .void:
       description = isReturnType ? "void" : "std::monostate"
 
+    case .product(let productType):
+      switch productType.name.value {
+      case "Int":
+        description = "int"
+      default:
+        description = productType.name.value
+      }
+
     default:
       return nil
     }

--- a/Sources/Compiler/CXX/CXXTypeExpr.swift
+++ b/Sources/Compiler/CXX/CXXTypeExpr.swift
@@ -17,10 +17,11 @@ public struct CXXTypeExpr: CustomStringConvertible {
       description = isReturnType ? "void" : "std::monostate"
 
     case .product(let productType):
-      switch productType.name.value {
-      case "Int":
+      // TODO: we should translate this to an "int" struct
+      let intType = ast.coreType(named: "Int")
+      if productType == intType {
         description = "int"
-      default:
+      } else {
         description = productType.name.value
       }
 

--- a/Sources/Compiler/CXX/CXXTypeExpr.swift
+++ b/Sources/Compiler/CXX/CXXTypeExpr.swift
@@ -18,8 +18,7 @@ public struct CXXTypeExpr: CustomStringConvertible {
 
     case .product(let productType):
       // TODO: we should translate this to an "int" struct
-      let intType = ast.coreType(named: "Int")
-      if productType == intType {
+      if productType == ast.coreType(named: "Int") {
         description = "int"
       } else {
         description = productType.name.value

--- a/Tests/ValTests/TestCases/CXX/FunRetInt.val
+++ b/Tests/ValTests/TestCases/CXX/FunRetInt.val
@@ -1,0 +1,10 @@
+/*! cpp
+    int myFun();
+    int main() {}
+ */
+public fun myFun() -> Int {
+    return 0;
+}
+
+public fun main() {
+}


### PR DESCRIPTION
**Why**
Make progress on transpiler the factorial example. In this step we translate the factorial function (without parameters).

**How**
* treated the case of product types in CXXTypeExpr
* if the Val type is `Int`, transform it to C++ `int`
* add test for functions returning `Int`

**Testing**
* transpiling factorial.val should not crash -> manual inspection
* add test case for function returning `Int`