### PR TITLE
Transpile to C++ function parameters

### DIFF
--- a/Sources/Compiler/CXX/CXXModule.swift
+++ b/Sources/Compiler/CXX/CXXModule.swift
@@ -31,11 +31,8 @@ public struct CXXModule {
 
     assert(program.isGlobal(valFunDecl))
 
-    // The actual fun decl
-    let funDeclAst = program.ast[valFunDecl]
-
     /// The identifier of the function.
-    let identifier = CXXIdentifier(funDeclAst.identifier?.value ?? "")
+    let identifier = CXXIdentifier(program.ast[valFunDecl].identifier?.value ?? "")
 
     // Determine the output type of the function.
     let output: CXXTypeExpr
@@ -69,9 +66,9 @@ public struct CXXModule {
     }
 
     // Determine the parameters of the function.
-    assert(paramTypes.count == funDeclAst.parameters.count)
+    assert(paramTypes.count == program.ast[valFunDecl].parameters.count)
     var cxxParams: [CXXFunDecl.Parameter] = []
-    for (i, paramID) in funDeclAst.parameters.enumerated() {
+    for (i, paramID) in program.ast[valFunDecl].parameters.enumerated() {
       let name = CXXIdentifier(program.ast[paramID].name)
       let type = CXXTypeExpr(paramTypes[i].type, ast: program.ast)
       cxxParams.append(CXXFunDecl.Parameter(name, type!))

--- a/Sources/Compiler/CXX/CXXTypeExpr.swift
+++ b/Sources/Compiler/CXX/CXXTypeExpr.swift
@@ -24,6 +24,11 @@ public struct CXXTypeExpr: CustomStringConvertible {
         description = productType.name.value
       }
 
+    case .parameter(let parameterType):
+      // TODO: convention
+      let bareDescription = CXXTypeExpr(parameterType.bareType, ast: ast)!.description
+      description = bareDescription
+
     default:
       return nil
     }

--- a/Tests/ValTests/TestCases/CXX/FunIntParam.val
+++ b/Tests/ValTests/TestCases/CXX/FunIntParam.val
@@ -1,5 +1,5 @@
 /*! cpp
-    std::monostate myFun(int x);
+    void myFun(int x);
     int main() {}
  */
 public fun myFun(_ x: Int) {

--- a/Tests/ValTests/TestCases/CXX/FunIntParam.val
+++ b/Tests/ValTests/TestCases/CXX/FunIntParam.val
@@ -1,0 +1,9 @@
+/*! cpp
+    std::monostate myFun(int x);
+    int main() {}
+ */
+public fun myFun(_ x: Int) {
+}
+
+public fun main() {
+}


### PR DESCRIPTION
**Why**
Make progress on transpiler the factorial example. In this step we translate the factorial function parameters.

**How**
- translate Val function parameter types to CXX types
- take the bare type from the parameter type when translating a parameter type to C++
- currently ignore the passing convention

**Testing**
- transpiling factorial.val should produce the right declaration for the factorial function
- add test case for function taking an `Int`
