### PR TITLE
Also write the description of the NodeKind when serializing to json

### DIFF
--- a/Sources/Compiler/AST/NodeIDs/NodeKind.swift
+++ b/Sources/Compiler/AST/NodeIDs/NodeKind.swift
@@ -15,6 +15,17 @@ public struct NodeKind: Hashable, Codable {
     self.rawValue = rawValue
   }
 
+  enum MyCodingKeys: String, CodingKey {
+      case rawValue
+      case description
+  }
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: MyCodingKeys.self)
+    try? container.encode(rawValue, forKey: .rawValue)
+    // Also write the description in the generated output, to be easily read
+    try? container.encode(description, forKey: .description)
+  }
+
   public static func <= (l: Self, r: Self) -> Bool {
     precondition(r.rawValue >> 16 == 0, "RHS is not a node category")
     return l.rawValue & r.rawValue == r.rawValue

--- a/Sources/Compiler/Parse/SourceRange.swift
+++ b/Sources/Compiler/Parse/SourceRange.swift
@@ -46,6 +46,11 @@ public struct SourceRange: Hashable {
     return SourceRange(in: l.source, from: l.lowerBound, to: r.lowerBound)
   }
 
+  /// Returns the textual description of the source range -- useful for debugging
+  public var text: Substring {
+    return source[self]
+  }
+
 }
 
 extension SourceRange: Codable {
@@ -53,6 +58,7 @@ extension SourceRange: Codable {
   fileprivate enum CodingKeys: String, CodingKey {
 
     case source, lowerBound, upperBound
+    case text
 
   }
 
@@ -72,6 +78,7 @@ extension SourceRange: Codable {
     try container.encode(source, forKey: .source)
     try container.encode(lowerBound.utf16Offset(in: source.contents), forKey: .lowerBound)
     try container.encode(upperBound.utf16Offset(in: source.contents), forKey: .upperBound)
+    try container.encode(String(text), forKey: .text)
   }
 
 }


### PR DESCRIPTION
**Why**
Better readability (by humans) of the generated AST of Val nodes

**How**
- Also write the `description` field of NodeKind
- Also write the source text corresponding to a source range

**Testing**
Manually inspected the generated ast.json