### PR TITLE
Treat warnings as errors for all targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,11 @@
 // swift-tools-version:5.6
 import PackageDescription
 
+/// Settings to be passed to swiftc for all targets.
+let allTargetsSwiftSettings: [SwiftSetting] = [
+  .unsafeFlags(["-warnings-as-errors"])
+]
+
 let package = Package(
   name: "Val",
 
@@ -31,7 +36,8 @@ let package = Package(
       dependencies: [
         "Compiler",
         .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ]),
+      ],
+      swiftSettings: allTargetsSwiftSettings),
 
     // Targets related to the compiler's internal library.
     .target(
@@ -42,18 +48,23 @@ let package = Package(
         .product(name: "Collections", package: "swift-collections"),
         .product(name: "Durian", package: "Durian"),
       ],
-      exclude: ["CXX/README.md"]),
+      exclude: ["CXX/README.md"],
+      swiftSettings: allTargetsSwiftSettings),
 
     .target(
       name: "ValModule",
       path: "Library",
-      resources: [.copy("Core")]),
+      resources: [.copy("Core")],
+      swiftSettings: allTargetsSwiftSettings),
 
-    .target(name: "Utils"),
+    .target(
+      name: "Utils",
+      swiftSettings: allTargetsSwiftSettings),
 
     // Test targets.
     .testTarget(
       name: "ValTests",
       dependencies: ["Compiler"],
-      resources: [.copy("TestCases")]),
+      resources: [.copy("TestCases")],
+      swiftSettings: allTargetsSwiftSettings),
   ])

--- a/Sources/Compiler/Parse/Parser.swift
+++ b/Sources/Compiler/Parse/Parser.swift
@@ -176,6 +176,8 @@ public enum Parser {
 
   /// Parses a declaration in `state`.
   static func parseDecl(in state: inout ParserState) throws -> AnyDeclID? {
+    return try parseDeclPrologue(in: &state, then: continuation)
+
     func continuation(
       prologue: DeclPrologue,
       state: inout ParserState
@@ -262,10 +264,6 @@ public enum Parser {
         throw DiagnosedError(expected("declaration", at: state.currentLocation))
       }
     }
-
-    // Note: this return statement must follow the declaration of `continuation` to work around
-    // an apparent bug in swiftc. See: https://github.com/apple/swift/issues/62136
-    return try parseDeclPrologue(in: &state, then: continuation)
   }
 
   /// Parses the body of a type declaration, adding `context` to `state.contexts` while parsing

--- a/Sources/Compiler/Parse/Parser.swift
+++ b/Sources/Compiler/Parse/Parser.swift
@@ -176,8 +176,6 @@ public enum Parser {
 
   /// Parses a declaration in `state`.
   static func parseDecl(in state: inout ParserState) throws -> AnyDeclID? {
-    return try parseDeclPrologue(in: &state, then: continuation)
-
     func continuation(
       prologue: DeclPrologue,
       state: inout ParserState
@@ -264,6 +262,10 @@ public enum Parser {
         throw DiagnosedError(expected("declaration", at: state.currentLocation))
       }
     }
+
+    // Note: this return statement must follow the declaration of `continuation` to work around
+    // an apparent bug in swiftc. See: https://github.com/apple/swift/issues/62136
+    return try parseDeclPrologue(in: &state, then: continuation)
   }
 
   /// Parses the body of a type declaration, adding `context` to `state.contexts` while parsing

--- a/Sources/Utils/BitPattern.swift
+++ b/Sources/Utils/BitPattern.swift
@@ -94,7 +94,7 @@ public struct BitPattern: Hashable {
   ///
   /// - Returns: A bit pattern or `nil` if `string` contains non-decimal characters.
   public init?<T: Collection>(fromDecimal string: T)
-    where T.Element == Character, T.SubSequence == Substring
+    where T.SubSequence == Substring
   {
     // Transform the string into an array of digits, ignoring leading zeroes.
     var input: [UInt8] = []
@@ -149,7 +149,7 @@ public struct BitPattern: Hashable {
   ///
   /// - Returns: A bit pattern or `nil` if `string` contains non-hexadecimal characters.
   public init?<T: Collection>(fromHexadecimal string: T)
-    where T.Element == Character, T.SubSequence == Substring
+    where T.SubSequence == Substring
   {
     // Ignore leading zeros.
     var input = string.drop(while: { $0 == "0" })


### PR DESCRIPTION
Also fix two redundant type constraint warnings.