### PR TITLE
Add a simple test case for the AST's conformance to 'Codable'

### DIFF
--- a/Tests/ValTests/ASTTests.swift
+++ b/Tests/ValTests/ASTTests.swift
@@ -30,4 +30,29 @@ final class ASTTests: XCTestCase {
     XCTAssert(ast[ast[ast[module].sources.first!].decls.first!] is TraitDecl)
   }
 
+  func testCodableRoundtrip() throws {
+    var ast = AST()
+
+    // Create a module.
+    let module = try ast.insert(wellFormed: ModuleDecl(name: "Val"))
+    let source = try ast.insert(wellFormed: TopLevelDeclSet(
+      decls: [
+        AnyDeclID(ast.insert(wellFormed: FunctionDecl(
+          introducerRange: nil,
+          identifier: SourceRepresentable(value: "foo")))),
+      ]))
+    ast[module].addSourceFile(source)
+
+    // Serialize the AST.
+    let encoder = JSONEncoder()
+    let serialized = try encoder.encode(ast)
+
+    // Deserialize the AST.
+    let decoder = JSONDecoder()
+    let deserialized = try decoder.decode(AST.self, from: serialized)
+
+    // Deserialized AST should containt a function `foo`.
+    XCTAssertEqual(deserialized[source].decls.first?.kind, .functionDecl)
+  }
+
 }


### PR DESCRIPTION
There is absolutely no test for the AST's conformance to `Codable`. This PR creates a simple one that just serializes and deserializes an AST.