### PR TITLE
Tests improvements

### DIFF
--- a/Tests/ValTests/CXXTests.swift
+++ b/Tests/ValTests/CXXTests.swift
@@ -1,10 +1,14 @@
 import XCTest
 import Compiler
 
-func check(_ haystack: String, contains needle: String.SubSequence) {
+func check(_ haystack: String, contains needle: String.SubSequence, for testFile: String) {
   XCTAssert(
     haystack.contains(needle),
     """
+
+
+    Test file: \(testFile)
+    ===========\(String(repeating: "=", count: testFile.count))
 
     \(String(reflecting: needle))
     not found in source
@@ -71,9 +75,9 @@ final class CXXTests: XCTestCase {
           let specifications = annotation.argument?.split(separator: "\n", maxSplits: 1) ?? []
           assert((1...2).contains(specifications.count))
           if specifications.count > 1 {
-            check(cxxHeader, contains: specifications.first!)
+            check(cxxHeader, contains: specifications.first!, for: tc.name)
           }
-          check(cxxSource, contains: specifications.last!)
+          check(cxxSource, contains: specifications.last!, for: tc.name)
 
         default:
           XCTFail("\(tc.name): unexpected test command: '\(annotation.command)'")

--- a/Tests/ValTests/CXXTests.swift
+++ b/Tests/ValTests/CXXTests.swift
@@ -88,7 +88,7 @@ final class CXXTests: XCTestCase {
         case "cpp":
           check(cxxSource, contains: code, for: tc.name)
 
-        case "hpp":
+        case "h":
           check(cxxHeader, contains: code, for: tc.name)
 
         default:

--- a/Tests/ValTests/CXXTests.swift
+++ b/Tests/ValTests/CXXTests.swift
@@ -18,7 +18,8 @@ func check(_ haystack: String, contains needle: String.SubSequence, for testFile
     """)
 }
 
-/// Remove trailing newlines from the given string subsequence
+/// Removes trailing newlines from the given string subsequence.
+func removingTrailingNewlines(_ s: Substring) -> Substring {
 func rtrim(_ s: String.SubSequence) -> String.SubSequence {
   var str = s
   while !str.isEmpty && str.last! == "\n" {

--- a/Tests/ValTests/CXXTests.swift
+++ b/Tests/ValTests/CXXTests.swift
@@ -18,6 +18,15 @@ func check(_ haystack: String, contains needle: String.SubSequence, for testFile
     """)
 }
 
+/// Remove trailing newlines from the given string subsequence
+func rtrim(_ s: String.SubSequence) -> String.SubSequence {
+  var str = s
+  while !str.isEmpty && str.last! == "\n" {
+    str = str.prefix(str.count-1)
+  }
+  return str
+}
+
 final class CXXTests: XCTestCase {
 
   func testTranspiler() throws {
@@ -70,14 +79,13 @@ final class CXXTests: XCTestCase {
 
       // Process the test annotations.
       for annotation in tc.annotations {
+        let code = rtrim(annotation.argument![...])
         switch annotation.command {
         case "cpp":
-          let specifications = annotation.argument?.split(separator: "\n", maxSplits: 1) ?? []
-          assert((1...2).contains(specifications.count))
-          if specifications.count > 1 {
-            check(cxxHeader, contains: specifications.first!, for: tc.name)
-          }
-          check(cxxSource, contains: specifications.last!, for: tc.name)
+          check(cxxSource, contains: code, for: tc.name)
+
+        case "hpp":
+          check(cxxHeader, contains: code, for: tc.name)
 
         default:
           XCTFail("\(tc.name): unexpected test command: '\(annotation.command)'")

--- a/Tests/ValTests/CXXTests.swift
+++ b/Tests/ValTests/CXXTests.swift
@@ -18,14 +18,17 @@ func check(_ haystack: String, contains needle: String.SubSequence, for testFile
     """)
 }
 
-/// Removes trailing newlines from the given string subsequence.
-func removingTrailingNewlines(_ s: Substring) -> Substring {
-func rtrim(_ s: String.SubSequence) -> String.SubSequence {
-  var str = s
-  while !str.isEmpty && str.last! == "\n" {
-    str = str.prefix(str.count-1)
+extension StringProtocol {
+
+  /// Removes trailing newlines from the given string subsequence.
+  func removingTrailingNewlines() -> Self.SubSequence {
+    if let i = self.lastIndex(where: { !$0.isNewline }) {
+      return self.prefix(through: i)
+    } else {
+      return self.prefix(upTo: startIndex)
+    }
   }
-  return str
+
 }
 
 final class CXXTests: XCTestCase {
@@ -80,7 +83,7 @@ final class CXXTests: XCTestCase {
 
       // Process the test annotations.
       for annotation in tc.annotations {
-        let code = rtrim(annotation.argument![...])
+        let code = annotation.argument!.removingTrailingNewlines()
         switch annotation.command {
         case "cpp":
           check(cxxSource, contains: code, for: tc.name)

--- a/Tests/ValTests/TestCases/CXX/EmptyMain.val
+++ b/Tests/ValTests/TestCases/CXX/EmptyMain.val
@@ -1,4 +1,4 @@
-/*! hpp
+/*! h
     int main();
  */
 /*! cpp

--- a/Tests/ValTests/TestCases/CXX/EmptyMain.val
+++ b/Tests/ValTests/TestCases/CXX/EmptyMain.val
@@ -1,5 +1,7 @@
-/*! cpp
+/*! hpp
     int main();
+ */
+/*! cpp
     int main() {
  */
 public fun main() {

--- a/Tests/ValTests/TestCases/CXX/FactorialExample.val
+++ b/Tests/ValTests/TestCases/CXX/FactorialExample.val
@@ -1,4 +1,4 @@
-/*! hpp
+/*! h
     int factorial(int n);
     int main();
  */

--- a/Tests/ValTests/TestCases/CXX/FactorialExample.val
+++ b/Tests/ValTests/TestCases/CXX/FactorialExample.val
@@ -1,0 +1,19 @@
+/*! hpp
+    int factorial(int n);
+    int main();
+ */
+/*! cpp
+    int factorial(int n) {
+    // expr
+    }
+    int main() {
+    // block
+    }
+ */
+fun factorial(_ n: Int) -> Int {
+  if n < 2 { 1 } else { n * factorial(n - 1) }
+}
+
+public fun main() {
+  let _ = factorial(6)
+}

--- a/Tests/ValTests/TestCases/CXX/VoidReturn.val
+++ b/Tests/ValTests/TestCases/CXX/VoidReturn.val
@@ -1,5 +1,7 @@
-/*! cpp
+/*! hpp
     void returns_void();
+ */
+/*! cpp
     void returns_void() {
  */
 public fun returns_void() {

--- a/Tests/ValTests/TestCases/CXX/VoidReturn.val
+++ b/Tests/ValTests/TestCases/CXX/VoidReturn.val
@@ -1,4 +1,4 @@
-/*! hpp
+/*! h
     void returns_void();
  */
 /*! cpp


### PR DESCRIPTION
**Why?**
Improve CXX transpiler tests, to ease the development of CXX transpiler

**What?**
- display the name of the test file when a test fails
- separate the `cpp` annotations into two annotations: one for source files, and one for headers
- add test for factorial transpilation -- this may be brittle at the beginning, but it will help in the development

**Testing**
- all unit tests must pass
- manual testing to ensure testing framework work as expected