### PR TITLE
Encapsulate node origin

### DIFF
--- a/Sources/Compiler/AST/AST+Diagnostics.swift
+++ b/Sources/Compiler/AST/AST+Diagnostics.swift
@@ -7,7 +7,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "duplicate access modifier '\(m.value)'",
-      range: m.range)
+      range: m.origin)
   }
 
   static func diagnose(
@@ -15,7 +15,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "duplicate implementation introducer '\(i.value)'",
-      range: i.range)
+      range: i.origin)
   }
 
   static func diagnose(
@@ -23,7 +23,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "duplicate member modifier '\(m.value)'",
-      range: m.range)
+      range: m.origin)
   }
 
   static func diagnose(
@@ -31,7 +31,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "global binding must be introduced by 'let'",
-      range: i.range)
+      range: i.origin)
   }
 
   static func diagnose(
@@ -39,7 +39,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "member binding must be introduced by 'let' or 'var'",
-      range: i.range)
+      range: i.origin)
   }
 
   static func diagnose(
@@ -71,7 +71,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     return .error(
       "member modifier '\(member.value)' must appear after access modifier '\(access.value)'",
-      range: member.range)
+      range: member.origin)
   }
 
   static func diagnose(
@@ -101,7 +101,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "missing identifier in subscript declaration",
-      range: d.introducer.range)
+      range: d.introducer.origin)
   }
 
   static func diagnose(
@@ -119,7 +119,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "missing type annotation",
-      range: p.identifier.range)
+      range: p.identifier.origin)
   }
 
   static func diagnose(
@@ -127,7 +127,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "unexpected access modifier '\(m.value)'",
-      range: m.range)
+      range: m.origin)
   }
 
   static func diagnose(
@@ -151,7 +151,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "unexpected attribute modifier '\(a.value.name.value)'",
-      range: a.value.name.range)
+      range: a.value.name.origin)
   }
 
   static func diagnose(
@@ -159,7 +159,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "explicit capture is not allowed here",
-      range: p.introducer.range)
+      range: p.introducer.origin)
   }
 
   static func diagnose(
@@ -175,7 +175,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "generic type parameter declaration is not allowed here",
-      range: d.identifier.range)
+      range: d.identifier.origin)
   }
 
   static func diagnose(
@@ -183,7 +183,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "generic value parameter declaration is not allowed here",
-      range: d.identifier.range)
+      range: d.identifier.origin)
   }
 
   static func diagnose(
@@ -191,7 +191,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "initializer declaration is not allowed here",
-      range: d.introducer.range)
+      range: d.introducer.origin)
   }
 
   static func diagnose(
@@ -199,7 +199,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "unexpected member modifier '\(m.value)'",
-      range: m.range)
+      range: m.origin)
   }
 
   static func diagnose(
@@ -215,7 +215,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "method implementation declaration is not allowed here",
-      range: d.introducer.range)
+      range: d.introducer.origin)
   }
 
   static func diagnose(
@@ -239,7 +239,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "parameter declaration is not allowed here",
-      range: d.identifier.range)
+      range: d.identifier.origin)
   }
 
   static func diagnose(
@@ -247,7 +247,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "property declaration is not allowed here",
-      range: d.introducer.range)
+      range: d.introducer.origin)
   }
 
   static func diagnose(
@@ -255,7 +255,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "unexpected effect '\(e.value)'",
-      range: e.range)
+      range: e.origin)
   }
 
   static func diagnose(
@@ -263,7 +263,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "subscript implementation declaration is not allowed here",
-      range: d.introducer.range)
+      range: d.introducer.origin)
   }
 
   static func diagnose(
@@ -271,7 +271,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "trait declaration is not allowed here",
-      range: d.identifier.range)
+      range: d.identifier.origin)
   }
 
   static func diagnose(
@@ -279,7 +279,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "variable declaration is not allowed here",
-      range: d.identifier.range)
+      range: d.identifier.origin)
   }
 
 }

--- a/Sources/Compiler/AST/AST+Diagnostics.swift
+++ b/Sources/Compiler/AST/AST+Diagnostics.swift
@@ -110,7 +110,7 @@ extension Diagnostic {
   ) -> Diagnostic {
     .error(
       "missing type annotation",
-      range: ast.ranges[p.subpattern])
+      range: ast[p.subpattern].origin)
   }
 
   static func diagnose(

--- a/Sources/Compiler/AST/AST.swift
+++ b/Sources/Compiler/AST/AST.swift
@@ -210,7 +210,7 @@ public struct AST: Codable {
 
     case .infix(_, let lhs, let rhs):
       if let lhsRange = origin(of: lhs), let rhsRange = origin(of: rhs) {
-        return lhsRange.upperBounded(by: rhsRange.upperBound)
+        return lhsRange.extended(upTo: rhsRange.upperBound)
       } else {
         return nil
       }

--- a/Sources/Compiler/AST/AST.swift
+++ b/Sources/Compiler/AST/AST.swift
@@ -202,7 +202,7 @@ public struct AST: Codable {
     return result
   }
 
-  /// Returns the source range of `expr`, if any.
+  /// Returns the source origin of `expr`, if any.
   public func origin(of expr: FoldedSequenceExpr) -> SourceRange? {
     switch expr {
     case .leaf(let i):

--- a/Sources/Compiler/AST/AST.swift
+++ b/Sources/Compiler/AST/AST.swift
@@ -15,9 +15,6 @@ public struct AST: Codable {
   /// The ID of the module containing Val's core library, if any.
   public var corelib: NodeID<ModuleDecl>?
 
-  /// The source range of each node.
-  public internal(set) var ranges = ASTProperty<SourceRange>()
-
   /// Creates an empty AST.
   public init() {}
 
@@ -209,7 +206,7 @@ public struct AST: Codable {
   public func origin(of expr: FoldedSequenceExpr) -> SourceRange? {
     switch expr {
     case .leaf(let i):
-      return ranges[i]
+      return self[i].origin
 
     case .infix(_, let lhs, let rhs):
       if let lhsRange = origin(of: lhs), let rhsRange = origin(of: rhs) {

--- a/Sources/Compiler/AST/AST.swift
+++ b/Sources/Compiler/AST/AST.swift
@@ -71,6 +71,15 @@ public struct AST: Codable {
     nodes[position].node
   }
 
+  /// Modifies the node at `position`.
+  mutating func modify<T: Node>(at position: NodeID<T>, _ transform: (T) -> T) throws {
+    let newNode = transform(self[position])
+    if case .failure(let error) = newNode.validateForm(in: self) {
+      throw DiagnosedError(error)
+    }
+    nodes[position.rawValue] = AnyNode(newNode)
+  }
+
   // MARK: Core library
 
   /// Indicates whether the Core library has been loaded.

--- a/Sources/Compiler/AST/Decl/AssociatedTypeDecl.swift
+++ b/Sources/Compiler/AST/Decl/AssociatedTypeDecl.swift
@@ -4,6 +4,8 @@ public protocol TypeDecl: SingleEntityDecl {}
 /// An associated type declaration.
 public struct AssociatedTypeDecl: TypeDecl {
 
+  public let origin: SourceRange?
+
   /// The source range of the declaration's introducer, if any.
   public let introducerRange: SourceRange?
 
@@ -25,8 +27,10 @@ public struct AssociatedTypeDecl: TypeDecl {
     identifier: SourceRepresentable<Identifier>,
     conformances: [NodeID<NameExpr>],
     whereClause: SourceRepresentable<WhereClause>?,
-    defaultValue: AnyTypeExprID?
+    defaultValue: AnyTypeExprID?,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.introducerRange = introducerRange
     self.identifier = identifier
     self.conformances = conformances

--- a/Sources/Compiler/AST/Decl/AssociatedValueDecl.swift
+++ b/Sources/Compiler/AST/Decl/AssociatedValueDecl.swift
@@ -1,6 +1,8 @@
 /// An associated value declaration.
 public struct AssociatedValueDecl: SingleEntityDecl {
 
+  public let origin: SourceRange?
+
   /// The source range of the declaration's introducer, if any.
   public let introducerRange: SourceRange?
 
@@ -18,8 +20,10 @@ public struct AssociatedValueDecl: SingleEntityDecl {
     introducerRange: SourceRange?,
     identifier: SourceRepresentable<Identifier>,
     whereClause: SourceRepresentable<WhereClause>?,
-    defaultValue: AnyExprID?
+    defaultValue: AnyExprID?,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.introducerRange = introducerRange
     self.identifier = identifier
     self.whereClause = whereClause

--- a/Sources/Compiler/AST/Decl/BindingDecl.swift
+++ b/Sources/Compiler/AST/Decl/BindingDecl.swift
@@ -1,6 +1,8 @@
 /// A binding declaration.
 public struct BindingDecl: Decl {
 
+  public let origin: SourceRange?
+
   /// The attributes of the declaration, if any.
   public let attributes: [SourceRepresentable<Attribute>]
 
@@ -22,8 +24,10 @@ public struct BindingDecl: Decl {
     accessModifier: SourceRepresentable<AccessModifier>? = nil,
     memberModifier: SourceRepresentable<MemberModifier>? = nil,
     pattern: NodeID<BindingPattern>,
-    initializer: AnyExprID?
+    initializer: AnyExprID?,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.attributes = attributes
     self.accessModifier = accessModifier
     self.memberModifier = memberModifier

--- a/Sources/Compiler/AST/Decl/BuiltinDecl.swift
+++ b/Sources/Compiler/AST/Decl/BuiltinDecl.swift
@@ -1,4 +1,6 @@
 /// An abstract node representing a built-in declaration.
 public struct BuiltinDecl: Decl {
 
+  public var origin: SourceRange? { nil }
+
 }

--- a/Sources/Compiler/AST/Decl/ConformanceDecl.swift
+++ b/Sources/Compiler/AST/Decl/ConformanceDecl.swift
@@ -1,6 +1,8 @@
 /// A declaration that extends a type with new conformances.
 public struct ConformanceDecl: TypeExtendingDecl {
 
+  public let origin: SourceRange?
+
   /// The access modifier of the declaration, if any.
   public let accessModifier: SourceRepresentable<AccessModifier>?
 
@@ -22,8 +24,10 @@ public struct ConformanceDecl: TypeExtendingDecl {
     subject: AnyTypeExprID,
     conformances: [NodeID<NameExpr>],
     whereClause: SourceRepresentable<WhereClause>?,
-    members: [AnyDeclID]
+    members: [AnyDeclID],
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.accessModifier = accessModifier
     self.subject = subject
     self.conformances = conformances

--- a/Sources/Compiler/AST/Decl/ExtensionDecl.swift
+++ b/Sources/Compiler/AST/Decl/ExtensionDecl.swift
@@ -1,6 +1,8 @@
 /// A declaration that extends a type with new members.
 public struct ExtensionDecl: TypeExtendingDecl {
 
+  public let origin: SourceRange?
+
   /// The access modifier of the declaration, if any.
   public let accessModifier: SourceRepresentable<AccessModifier>?
 
@@ -18,8 +20,10 @@ public struct ExtensionDecl: TypeExtendingDecl {
     accessModifier: SourceRepresentable<AccessModifier>?,
     subject: AnyTypeExprID,
     whereClause: SourceRepresentable<WhereClause>?,
-    members: [AnyDeclID]
+    members: [AnyDeclID],
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.accessModifier = accessModifier
     self.subject = subject
     self.whereClause = whereClause

--- a/Sources/Compiler/AST/Decl/FunctionDecl.swift
+++ b/Sources/Compiler/AST/Decl/FunctionDecl.swift
@@ -11,6 +11,8 @@ public struct FunctionDecl: GenericDecl, GenericScope {
 
   }
 
+  public let origin: SourceRange?
+
   /// The source range of the `fun` introducer, if any.
   public let introducerRange: SourceRange?
 
@@ -70,8 +72,10 @@ public struct FunctionDecl: GenericDecl, GenericScope {
     receiver: NodeID<ParameterDecl>? = nil,
     output: AnyTypeExprID? = nil,
     body: Body? = nil,
-    isInExprContext: Bool = false
+    isInExprContext: Bool = false,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.introducerRange = introducerRange
     self.attributes = attributes
     self.accessModifier = accessModifier

--- a/Sources/Compiler/AST/Decl/GenericTypeParamDecl.swift
+++ b/Sources/Compiler/AST/Decl/GenericTypeParamDecl.swift
@@ -1,6 +1,8 @@
 /// A generic type parameter declaration.
 public struct GenericTypeParamDecl: TypeDecl {
 
+  public let origin: SourceRange?
+
   /// The identifier of the parameter.
   public let identifier: SourceRepresentable<Identifier>
 
@@ -13,8 +15,10 @@ public struct GenericTypeParamDecl: TypeDecl {
   public init(
     identifier: SourceRepresentable<Identifier>,
     conformances: [NodeID<NameExpr>] = [],
-    defaultValue: AnyTypeExprID? = nil
+    defaultValue: AnyTypeExprID? = nil,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.identifier = identifier
     self.conformances = conformances
     self.defaultValue = defaultValue

--- a/Sources/Compiler/AST/Decl/GenericValueParamDecl.swift
+++ b/Sources/Compiler/AST/Decl/GenericValueParamDecl.swift
@@ -1,6 +1,8 @@
 /// A generic value parameter declaration.
 public struct GenericValueParamDecl: SingleEntityDecl {
 
+  public let origin: SourceRange?
+
   /// The identifier of the parameter.
   public let identifier: SourceRepresentable<Identifier>
 
@@ -13,8 +15,10 @@ public struct GenericValueParamDecl: SingleEntityDecl {
   public init(
     identifier: SourceRepresentable<Identifier>,
     annotation: AnyTypeExprID,
-    defaultValue: AnyExprID? = nil
+    defaultValue: AnyExprID? = nil,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.identifier = identifier
     self.annotation = annotation
     self.defaultValue = defaultValue

--- a/Sources/Compiler/AST/Decl/ImportDecl.swift
+++ b/Sources/Compiler/AST/Decl/ImportDecl.swift
@@ -1,6 +1,8 @@
 /// An import declaration.
 public struct ImportDecl: TypeDecl {
 
+  public let origin: SourceRange?
+
   /// The source range of the declaration's introducer, if any.
   public let introducerRange: SourceRange?
 
@@ -8,7 +10,12 @@ public struct ImportDecl: TypeDecl {
   public let identifier: SourceRepresentable<Identifier>
 
   /// Creates an instance with the given properties.
-  public init(introducerRange: SourceRange?, identifier: SourceRepresentable<Identifier>) {
+  public init(
+    introducerRange: SourceRange?,
+    identifier: SourceRepresentable<Identifier>,
+    origin: SourceRange?
+  ) {
+    self.origin = origin
     self.introducerRange = introducerRange
     self.identifier = identifier
   }

--- a/Sources/Compiler/AST/Decl/InitializerDecl.swift
+++ b/Sources/Compiler/AST/Decl/InitializerDecl.swift
@@ -12,6 +12,8 @@ public struct InitializerDecl: GenericDecl, GenericScope {
 
   }
 
+  public let origin: SourceRange?
+
   /// The introducer of the declaration.
   public let introducer: SourceRepresentable<Introducer>
 
@@ -43,10 +45,12 @@ public struct InitializerDecl: GenericDecl, GenericScope {
     genericClause: SourceRepresentable<GenericClause>?,
     parameters: [NodeID<ParameterDecl>],
     receiver: NodeID<ParameterDecl>,
-    body: NodeID<BraceStmt>?
+    body: NodeID<BraceStmt>?,
+    origin: SourceRange?
   ) {
     precondition((introducer.value == .`init`) || (body == nil))
 
+    self.origin = origin
     self.introducer = introducer
     self.attributes = attributes
     self.accessModifier = accessModifier

--- a/Sources/Compiler/AST/Decl/MethodDecl.swift
+++ b/Sources/Compiler/AST/Decl/MethodDecl.swift
@@ -1,6 +1,8 @@
 /// A method declaration.
 public struct MethodDecl: GenericDecl, GenericScope {
 
+  public let origin: SourceRange?
+
   /// The source range of the `fun` introducer, if any.
   public let introducerRange: SourceRange?
 
@@ -40,8 +42,10 @@ public struct MethodDecl: GenericDecl, GenericScope {
     genericClause: SourceRepresentable<GenericClause>?,
     parameters: [NodeID<ParameterDecl>],
     output: AnyTypeExprID?,
-    impls: [NodeID<MethodImplDecl>]
+    impls: [NodeID<MethodImplDecl>],
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.introducerRange = introducerRange
     self.attributes = attributes
     self.accessModifier = accessModifier

--- a/Sources/Compiler/AST/Decl/MethodImplDecl.swift
+++ b/Sources/Compiler/AST/Decl/MethodImplDecl.swift
@@ -11,6 +11,8 @@ public struct MethodImplDecl: Decl, LexicalScope {
 
   }
 
+  public let origin: SourceRange?
+
   /// The introducer of the method.
   public let introducer: SourceRepresentable<ImplIntroducer>
 
@@ -24,8 +26,10 @@ public struct MethodImplDecl: Decl, LexicalScope {
   public init(
     introducer: SourceRepresentable<ImplIntroducer>,
     receiver: NodeID<ParameterDecl>,
-    body: Body? = nil
+    body: Body? = nil,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.introducer = introducer
     self.receiver = receiver
     self.body = body

--- a/Sources/Compiler/AST/Decl/ModuleDecl.swift
+++ b/Sources/Compiler/AST/Decl/ModuleDecl.swift
@@ -11,6 +11,8 @@ public struct ModuleDecl: TypeDecl, LexicalScope {
     self.name = name
   }
 
+  public var origin: SourceRange? { nil }
+
   /// Adds the given source file to our list of sources.
   public mutating func addSourceFile(_ s: NodeID<TopLevelDeclSet>) {
     sources.append(s)

--- a/Sources/Compiler/AST/Decl/NamespaceDecl.swift
+++ b/Sources/Compiler/AST/Decl/NamespaceDecl.swift
@@ -1,6 +1,8 @@
 /// A namespace declaration.
 public struct NamespaceDecl: TypeDecl, LexicalScope {
 
+  public let origin: SourceRange?
+
   /// The source range of the declaration's introducer, if any.
   public let introducerRange: SourceRange?
 
@@ -18,8 +20,10 @@ public struct NamespaceDecl: TypeDecl, LexicalScope {
     introducerRange: SourceRange?,
     accessModifier: SourceRepresentable<AccessModifier>?,
     identifier: SourceRepresentable<Identifier>,
-    members: [AnyDeclID]
+    members: [AnyDeclID],
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.introducerRange = introducerRange
     self.accessModifier = accessModifier
     self.identifier = identifier

--- a/Sources/Compiler/AST/Decl/OperatorDecl.swift
+++ b/Sources/Compiler/AST/Decl/OperatorDecl.swift
@@ -1,6 +1,8 @@
 /// An operator declaration.
 public struct OperatorDecl: Decl {
 
+  public let origin: SourceRange?
+
   /// The source range of the declaration's introducer, if any.
   public let introducerRange: SourceRange?
 
@@ -22,8 +24,10 @@ public struct OperatorDecl: Decl {
     accessModifier: SourceRepresentable<AccessModifier>?,
     notation: SourceRepresentable<OperatorNotation>,
     name: SourceRepresentable<Identifier>,
-    precedenceGroup: SourceRepresentable<PrecedenceGroup>?
+    precedenceGroup: SourceRepresentable<PrecedenceGroup>?,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.introducerRange = introducerRange
     self.accessModifier = accessModifier
     self.notation = notation

--- a/Sources/Compiler/AST/Decl/ParameterDecl.swift
+++ b/Sources/Compiler/AST/Decl/ParameterDecl.swift
@@ -1,6 +1,8 @@
 /// A parameter declaration in a function or subscript declaration.
 public struct ParameterDecl: SingleEntityDecl {
 
+  public let origin: SourceRange?
+
   /// The label of the parameter.
   public let label: SourceRepresentable<Identifier>?
 
@@ -17,8 +19,10 @@ public struct ParameterDecl: SingleEntityDecl {
     label: SourceRepresentable<Identifier>? = nil,
     identifier: SourceRepresentable<Identifier>,
     annotation: NodeID<ParameterTypeExpr>? = nil,
-    defaultValue: AnyExprID? = nil
+    defaultValue: AnyExprID? = nil,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.label = label
     self.identifier = identifier
     self.annotation = annotation

--- a/Sources/Compiler/AST/Decl/ProductTypeDecl.swift
+++ b/Sources/Compiler/AST/Decl/ProductTypeDecl.swift
@@ -1,6 +1,8 @@
 /// A (nominal) product type declaration.
 public struct ProductTypeDecl: GenericDecl, TypeDecl, GenericScope {
 
+  public let origin: SourceRange?
+
   /// The access modifier of the declaration, if any.
   public let accessModifier: SourceRepresentable<AccessModifier>?
 
@@ -26,9 +28,12 @@ public struct ProductTypeDecl: GenericDecl, TypeDecl, GenericScope {
     genericClause: SourceRepresentable<GenericClause>?,
     conformances: [NodeID<NameExpr>],
     members: [AnyDeclID],
-    memberwiseInit: NodeID<InitializerDecl>
+    memberwiseInit: NodeID<InitializerDecl>,
+    origin: SourceRange?
   ) {
     precondition(members.contains(AnyDeclID(memberwiseInit)))
+
+    self.origin = origin
     self.accessModifier = accessModifier
     self.identifier = identifier
     self.genericClause = genericClause

--- a/Sources/Compiler/AST/Decl/SubscriptDecl.swift
+++ b/Sources/Compiler/AST/Decl/SubscriptDecl.swift
@@ -11,6 +11,8 @@ public struct SubscriptDecl: GenericDecl, GenericScope {
 
   }
 
+  public let origin: SourceRange?
+
   /// The introducer of the declaration.
   public let introducer: SourceRepresentable<Introducer>
 
@@ -54,8 +56,10 @@ public struct SubscriptDecl: GenericDecl, GenericScope {
     explicitCaptures: [NodeID<BindingDecl>],
     parameters: [NodeID<ParameterDecl>]?,
     output: AnyTypeExprID,
-    impls: [NodeID<SubscriptImplDecl>]
+    impls: [NodeID<SubscriptImplDecl>],
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.introducer = introducer
     self.attributes = attributes
     self.accessModifier = accessModifier

--- a/Sources/Compiler/AST/Decl/SubscriptImplDecl.swift
+++ b/Sources/Compiler/AST/Decl/SubscriptImplDecl.swift
@@ -12,6 +12,8 @@ public struct SubscriptImplDecl: Decl, LexicalScope {
 
   }
 
+  public let origin: SourceRange?
+
   /// The introducer of the subscript.
   public let introducer: SourceRepresentable<ImplIntroducer>
 
@@ -24,8 +26,10 @@ public struct SubscriptImplDecl: Decl, LexicalScope {
   public init(
     introducer: SourceRepresentable<ImplIntroducer>,
     receiver: NodeID<ParameterDecl>?,
-    body: Body?
+    body: Body?,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.introducer = introducer
     self.receiver = receiver
     self.body = body

--- a/Sources/Compiler/AST/Decl/TopLevelDeclSet.swift
+++ b/Sources/Compiler/AST/Decl/TopLevelDeclSet.swift
@@ -9,6 +9,8 @@ public struct TopLevelDeclSet: Node, LexicalScope {
     self.decls = decls
   }
 
+  public var origin: SourceRange? { nil }
+
   public func validateForm(in ast: AST) -> SuccessOrDiagnostics {
     let ds: [Diagnostic] = decls.reduce(into: [], { (ds, member) in
       ds.append(contentsOf: ast.validateGlobalScopeMember(member, atTopLevel: true).diagnostics)

--- a/Sources/Compiler/AST/Decl/TraitDecl.swift
+++ b/Sources/Compiler/AST/Decl/TraitDecl.swift
@@ -3,6 +3,8 @@
 /// - Note: `TraitDecl` does not conform to `GenericDecl`.
 public struct TraitDecl: TypeDecl, GenericScope {
 
+  public let origin: SourceRange?
+
   /// The access modifier of the declaration, if any.
   public let accessModifier: SourceRepresentable<AccessModifier>?
 
@@ -20,8 +22,10 @@ public struct TraitDecl: TypeDecl, GenericScope {
     accessModifier: SourceRepresentable<AccessModifier>?,
     identifier: SourceRepresentable<Identifier>,
     refinements: [NodeID<NameExpr>],
-    members: [AnyDeclID]
+    members: [AnyDeclID],
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.accessModifier = accessModifier
     self.identifier = identifier
     self.refinements = refinements

--- a/Sources/Compiler/AST/Decl/TypeAliasDecl.swift
+++ b/Sources/Compiler/AST/Decl/TypeAliasDecl.swift
@@ -11,6 +11,8 @@ public struct TypeAliasDecl: GenericDecl, TypeDecl, GenericScope {
 
   }
 
+  public let origin: SourceRange?
+
   /// The access modifier of the declaration, if any.
   public let accessModifier: SourceRepresentable<AccessModifier>?
 
@@ -28,8 +30,10 @@ public struct TypeAliasDecl: GenericDecl, TypeDecl, GenericScope {
     accessModifier: SourceRepresentable<AccessModifier>?,
     identifier: SourceRepresentable<Identifier>,
     genericClause: SourceRepresentable<GenericClause>?,
-    body: Body
+    body: Body,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.accessModifier = accessModifier
     self.identifier = identifier
     self.genericClause = genericClause

--- a/Sources/Compiler/AST/Decl/VarDecl.swift
+++ b/Sources/Compiler/AST/Decl/VarDecl.swift
@@ -8,6 +8,8 @@ public struct VarDecl: SingleEntityDecl {
     self.identifier = identifier
   }
 
+  public var origin: SourceRange? { identifier.range }
+
   public var name: String { identifier.value }
 
 }

--- a/Sources/Compiler/AST/Decl/VarDecl.swift
+++ b/Sources/Compiler/AST/Decl/VarDecl.swift
@@ -8,7 +8,7 @@ public struct VarDecl: SingleEntityDecl {
     self.identifier = identifier
   }
 
-  public var origin: SourceRange? { identifier.range }
+  public var origin: SourceRange? { identifier.origin }
 
   public var name: String { identifier.value }
 

--- a/Sources/Compiler/AST/Expr/AssignExpr.swift
+++ b/Sources/Compiler/AST/Expr/AssignExpr.swift
@@ -1,13 +1,16 @@
 /// An assignment expression.
 public struct AssignExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The left operand.
   public let left: AnyExprID
 
   /// The right operand.
   public let right: AnyExprID
 
-  public init(left: AnyExprID, right: AnyExprID) {
+  public init(left: AnyExprID, right: AnyExprID, origin: SourceRange?) {
+    self.origin = origin
     self.left = left
     self.right = right
   }

--- a/Sources/Compiler/AST/Expr/AsyncExpr.swift
+++ b/Sources/Compiler/AST/Expr/AsyncExpr.swift
@@ -1,10 +1,13 @@
 /// An expression ran in a future.
 public struct AsyncExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The declaration of the underlying anonymous function.
   public let decl: NodeID<FunctionDecl>
 
-  public init(decl: NodeID<FunctionDecl>) {
+  public init(decl: NodeID<FunctionDecl>, origin: SourceRange?) {
+    self.origin = origin
     self.decl = decl
   }
 

--- a/Sources/Compiler/AST/Expr/AwaitExpr.swift
+++ b/Sources/Compiler/AST/Expr/AwaitExpr.swift
@@ -1,10 +1,13 @@
 /// An await expression.
 public struct AwaitExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The expression of the awaited value.
   public let operand: AnyExprID
 
-  public init(operand: AnyExprID) {
+  public init(operand: AnyExprID, origin: SourceRange) {
+    self.origin = origin
     self.operand = operand
   }
 

--- a/Sources/Compiler/AST/Expr/BooleanLiteralExpr.swift
+++ b/Sources/Compiler/AST/Expr/BooleanLiteralExpr.swift
@@ -1,10 +1,13 @@
 /// A boolean literal expression.
 public struct BooleanLiteralExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The value of the literal.
   public let value: Bool
 
-  public init(value: Bool) {
+  public init(value: Bool, origin: SourceRange?) {
+    self.origin = origin
     self.value = value
   }
 

--- a/Sources/Compiler/AST/Expr/BufferLiteralExpr.swift
+++ b/Sources/Compiler/AST/Expr/BufferLiteralExpr.swift
@@ -1,10 +1,13 @@
 /// A buffer literal expression.
 public struct BufferLiteralExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The elements of the literal.
   public let elements: [AnyExprID]
 
-  public init(elements: [AnyExprID]) {
+  public init(elements: [AnyExprID], origin: SourceRange?) {
+    self.origin = origin
     self.elements = elements
   }
 

--- a/Sources/Compiler/AST/Expr/CastExpr.swift
+++ b/Sources/Compiler/AST/Expr/CastExpr.swift
@@ -18,6 +18,8 @@ public struct CastExpr: Expr {
 
   }
 
+  public let origin: SourceRange?
+
   /// The left operand.
   public let left: AnyExprID
 
@@ -27,7 +29,8 @@ public struct CastExpr: Expr {
   /// The kind of the cast.
   public let kind: Kind
 
-  public init(left: AnyExprID, right: AnyTypeExprID, kind: Kind) {
+  public init(left: AnyExprID, right: AnyTypeExprID, kind: Kind, origin: SourceRange?) {
+    self.origin = origin
     self.left = left
     self.right = right
     self.kind = kind

--- a/Sources/Compiler/AST/Expr/CondExpr.swift
+++ b/Sources/Compiler/AST/Expr/CondExpr.swift
@@ -11,6 +11,8 @@ public struct CondExpr: Expr, LexicalScope {
 
   }
 
+  public let origin: SourceRange?
+
   /// The condition of the expression.
   ///
   /// - Requires: `condition.count > 0`
@@ -25,9 +27,12 @@ public struct CondExpr: Expr, LexicalScope {
   public init(
     condition: [ConditionItem],
     success: CondExpr.Body,
-    failure: CondExpr.Body? = nil
+    failure: CondExpr.Body?,
+    origin: SourceRange?
   ) {
     precondition(condition.count > 0)
+
+    self.origin = origin
     self.condition = condition
     self.success = success
     self.failure = failure

--- a/Sources/Compiler/AST/Expr/ErrorExpr.swift
+++ b/Sources/Compiler/AST/Expr/ErrorExpr.swift
@@ -1,6 +1,10 @@
 /// A placeholder representing a semantically erroneous expression in the AST.
 public struct ErrorExpr: Expr {
 
-  public init() {}
+  public let origin: SourceRange?
+
+  public init(origin: SourceRange?) {
+    self.origin = origin
+  }
 
 }

--- a/Sources/Compiler/AST/Expr/FloatLiteralExpr.swift
+++ b/Sources/Compiler/AST/Expr/FloatLiteralExpr.swift
@@ -1,10 +1,13 @@
 /// A floating-point number literal expression.
 public struct FloatLiteralExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The value of the literal.
   public let value: String
 
-  public init(value: String) {
+  public init(value: String, origin: SourceRange?) {
+    self.origin = origin
     self.value = value
   }
 

--- a/Sources/Compiler/AST/Expr/FunCallExpr.swift
+++ b/Sources/Compiler/AST/Expr/FunCallExpr.swift
@@ -1,13 +1,16 @@
 /// A function call.
 public struct FunCallExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The callee.
   public let callee: AnyExprID
 
   /// The arguments of the call.
   public let arguments: [CallArgument]
 
-  public init(callee: AnyExprID, arguments: [CallArgument] = []) {
+  public init(callee: AnyExprID, arguments: [CallArgument], origin: SourceRange?) {
+    self.origin = origin
     self.callee = callee
     self.arguments = arguments
   }

--- a/Sources/Compiler/AST/Expr/InoutExpr.swift
+++ b/Sources/Compiler/AST/Expr/InoutExpr.swift
@@ -1,13 +1,16 @@
 /// An expression evaluated in place.
 public struct InoutExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The source range of the `&` operator.
   public let operatorRange: SourceRange?
 
   /// The underlying expression.
   public let subject: AnyExprID
 
-  public init(operatorRange: SourceRange? = nil, subject: AnyExprID) {
+  public init(operatorRange: SourceRange?, subject: AnyExprID, origin: SourceRange?) {
+    self.origin = origin
     self.operatorRange = operatorRange
     self.subject = subject
   }

--- a/Sources/Compiler/AST/Expr/IntegerLiteralExpr.swift
+++ b/Sources/Compiler/AST/Expr/IntegerLiteralExpr.swift
@@ -1,10 +1,13 @@
 /// An integer literal expression.
 public struct IntegerLiteralExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The value of the literal.
   public let value: String
 
-  public init(value: String) {
+  public init(value: String, origin: SourceRange?) {
+    self.origin = origin
     self.value = value
   }
 

--- a/Sources/Compiler/AST/Expr/LambdaExpr.swift
+++ b/Sources/Compiler/AST/Expr/LambdaExpr.swift
@@ -1,10 +1,13 @@
 /// A lambda.
 public struct LambdaExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The declaration of the underlying anonymous function.
   public let decl: NodeID<FunctionDecl>
 
-  public init(decl: NodeID<FunctionDecl>) {
+  public init(decl: NodeID<FunctionDecl>, origin: SourceRange?) {
+    self.origin = origin
     self.decl = decl
   }
 

--- a/Sources/Compiler/AST/Expr/MapLiteralExpr.swift
+++ b/Sources/Compiler/AST/Expr/MapLiteralExpr.swift
@@ -10,10 +10,13 @@ public struct MapLiteralExpr: Expr {
 
   }
 
+  public let origin: SourceRange?
+
   /// The key-value pairs of the literal.
   public let elements: [Element]
 
-  public init(elements: [Element]) {
+  public init(elements: [Element], origin: SourceRange?) {
+    self.origin = origin
     self.elements = elements
   }
 

--- a/Sources/Compiler/AST/Expr/MatchCase.swift
+++ b/Sources/Compiler/AST/Expr/MatchCase.swift
@@ -11,6 +11,8 @@ public struct MatchCase: Node, LexicalScope {
 
   }
 
+  public let origin: SourceRange?
+
   /// The pattern of the case.
   public let pattern: AnyPatternID
 
@@ -20,7 +22,13 @@ public struct MatchCase: Node, LexicalScope {
   /// The body of the case.
   public let body: Body
 
-  public init(pattern: AnyPatternID, condition: AnyExprID? = nil, body: MatchCase.Body) {
+  public init(
+    pattern: AnyPatternID,
+    condition: AnyExprID?,
+    body: MatchCase.Body,
+    origin: SourceRange?
+  ) {
+    self.origin = origin
     self.pattern = pattern
     self.condition = condition
     self.body = body

--- a/Sources/Compiler/AST/Expr/MatchExpr.swift
+++ b/Sources/Compiler/AST/Expr/MatchExpr.swift
@@ -1,13 +1,16 @@
 /// A match expression.
 public struct MatchExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The subject of the match.
   public let subject: AnyExprID
 
   /// The cases of the match.
   public let cases: [NodeID<MatchCase>]
 
-  public init(subject: AnyExprID, cases: [NodeID<MatchCase>]) {
+  public init(subject: AnyExprID, cases: [NodeID<MatchCase>], origin: SourceRange?) {
+    self.origin = origin
     self.subject = subject
     self.cases = cases
   }

--- a/Sources/Compiler/AST/Expr/NameExpr.swift
+++ b/Sources/Compiler/AST/Expr/NameExpr.swift
@@ -18,7 +18,7 @@ public struct NameExpr: Expr {
   }
 
   /// The domain of the name, if it is qualified.
-  public private(set) var domain: Domain
+  public let domain: Domain
 
   /// The name of the referred entity.
   public let name: SourceRepresentable<Name>
@@ -29,18 +29,11 @@ public struct NameExpr: Expr {
   public init(
     domain: Domain = .none,
     name: SourceRepresentable<Name>,
-    arguments: [GenericArgument] = []
+    arguments: [GenericArgument] = [],
   ) {
     self.domain = domain
     self.name = name
     self.arguments = arguments
   }
 
-  /// Incorporates `domain` into `self`.
-  ///
-  /// - Precondition: `self.domain == .none`
-  internal mutating func incorporate(domain: Domain) {
-    precondition(self.domain == .none)
-    self.domain = domain
-  }
 }

--- a/Sources/Compiler/AST/Expr/NameExpr.swift
+++ b/Sources/Compiler/AST/Expr/NameExpr.swift
@@ -17,6 +17,8 @@ public struct NameExpr: Expr {
 
   }
 
+  public let origin: SourceRange?
+
   /// The domain of the name, if it is qualified.
   public let domain: Domain
 
@@ -30,7 +32,9 @@ public struct NameExpr: Expr {
     domain: Domain = .none,
     name: SourceRepresentable<Name>,
     arguments: [GenericArgument] = [],
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.domain = domain
     self.name = name
     self.arguments = arguments

--- a/Sources/Compiler/AST/Expr/NilExpr.swift
+++ b/Sources/Compiler/AST/Expr/NilExpr.swift
@@ -1,6 +1,10 @@
 /// A nil expression.
 public struct NilExpr: Expr {
 
-  public init() {}
+  public let origin: SourceRange?
+
+  public init(origin: SourceRange?) {
+    self.origin = origin
+  }
 
 }

--- a/Sources/Compiler/AST/Expr/SequenceExpr.swift
+++ b/Sources/Compiler/AST/Expr/SequenceExpr.swift
@@ -41,7 +41,7 @@ public struct SequenceExpr: Expr {
         report.append(.diagnose(
           invalidOperatorNotation: notation,
           expected: .infix,
-          at: ast[element.operator].name.range))
+          at: ast[element.operator].name.origin))
       }
     }
 

--- a/Sources/Compiler/AST/Expr/SequenceExpr.swift
+++ b/Sources/Compiler/AST/Expr/SequenceExpr.swift
@@ -17,6 +17,8 @@ public struct SequenceExpr: Expr {
 
   }
 
+  public let origin: SourceRange?
+
   /// The leftmost operand of the expression.
   public let head: AnyExprID
 
@@ -24,7 +26,8 @@ public struct SequenceExpr: Expr {
   public let tail: [TailElement]
 
   /// Creates an instance with the given properties.
-  public init(head: AnyExprID, tail: [TailElement]) {
+  public init(head: AnyExprID, tail: [TailElement], origin: SourceRange?) {
+    self.origin = origin
     self.head = head
     self.tail = tail
   }

--- a/Sources/Compiler/AST/Expr/StringLiteralExpr.swift
+++ b/Sources/Compiler/AST/Expr/StringLiteralExpr.swift
@@ -1,10 +1,13 @@
 /// A string literal expression.
 public struct StringLiteralExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The value of the literal.
   public let value: String
 
-  public init(value: String) {
+  public init(value: String, origin: SourceRange?) {
+    self.origin = origin
     self.value = value
   }
 

--- a/Sources/Compiler/AST/Expr/SubscriptCallExpr.swift
+++ b/Sources/Compiler/AST/Expr/SubscriptCallExpr.swift
@@ -1,13 +1,16 @@
 /// A subscript call.
 public struct SubscriptCallExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The callee.
   public let callee: AnyExprID
 
   /// The arguments of the call.
   public let arguments: [CallArgument]
 
-  public init(callee: AnyExprID, arguments: [CallArgument] = []) {
+  public init(callee: AnyExprID, arguments: [CallArgument], origin: SourceRange?) {
+    self.origin = origin
     self.callee = callee
     self.arguments = arguments
   }

--- a/Sources/Compiler/AST/Expr/TupleExpr.swift
+++ b/Sources/Compiler/AST/Expr/TupleExpr.swift
@@ -17,10 +17,13 @@ public struct TupleExpr: Expr {
 
   }
 
+  public let origin: SourceRange?
+
   /// The elements of the tuple.
   public let elements: [Element]
 
-  public init(elements: [Element]) {
+  public init(elements: [Element], origin: SourceRange?) {
+    self.origin = origin
     self.elements = elements
   }
 

--- a/Sources/Compiler/AST/Expr/TupleMemberExpr.swift
+++ b/Sources/Compiler/AST/Expr/TupleMemberExpr.swift
@@ -1,6 +1,8 @@
 /// The expression of a tuple member, referred by its index.
 public struct TupleMemberExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The parent tuple.
   public let tuple: AnyExprID
 
@@ -8,7 +10,8 @@ public struct TupleMemberExpr: Expr {
   public let index: Int
 
 
-  public init(tuple: AnyExprID, index: Int) {
+  public init(tuple: AnyExprID, index: Int, origin: SourceRange?) {
+    self.origin = origin
     self.tuple = tuple
     self.index = index
   }

--- a/Sources/Compiler/AST/Expr/UnicodeScalarLiteralExpr.swift
+++ b/Sources/Compiler/AST/Expr/UnicodeScalarLiteralExpr.swift
@@ -1,10 +1,13 @@
 /// A unicode scalar literal expression.
 public struct UnicodeScalarLiteralExpr: Expr {
 
+  public let origin: SourceRange?
+
   /// The value of the literal.
   public let value: Unicode.Scalar
 
-  public init(value: Unicode.Scalar) {
+  public init(value: Unicode.Scalar, origin: SourceRange?) {
+    self.origin = origin
     self.value = value
   }
 
@@ -14,16 +17,23 @@ extension UnicodeScalarLiteralExpr: Codable {
 
   public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
+
+    // Decode the source origin.
+    origin = try container.decode(SourceRange?.self)
+
+    // Decode the unicode scalar value.
     if let scalar = Unicode.Scalar(try container.decode(UInt32.self)) {
       value = scalar
     } else {
       throw DecodingError.dataCorrupted(DecodingError.Context(
-        codingPath: decoder.codingPath, debugDescription: "Invalid Unicode scalar value"))
+        codingPath: decoder.codingPath,
+        debugDescription: "Invalid Unicode scalar value"))
     }
   }
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
+    try container.encode(origin)
     try container.encode(value.value)
   }
 

--- a/Sources/Compiler/AST/Name.swift
+++ b/Sources/Compiler/AST/Name.swift
@@ -114,7 +114,7 @@ extension SourceRepresentable where Part == Name {
   func introduced(by introducer: SourceRepresentable<ImplIntroducer>) -> Self {
     return .init(
       value: self.value.introduced(by: introducer.value),
-      range: self.range!.upperBounded(by: introducer.range!.upperBound))
+      range: self.range!.extended(upTo: introducer.range!.upperBound))
   }
 
 }

--- a/Sources/Compiler/AST/Name.swift
+++ b/Sources/Compiler/AST/Name.swift
@@ -114,7 +114,7 @@ extension SourceRepresentable where Part == Name {
   func introduced(by introducer: SourceRepresentable<ImplIntroducer>) -> Self {
     return .init(
       value: self.value.introduced(by: introducer.value),
-      range: self.range!.extended(upTo: introducer.range!.upperBound))
+      range: self.origin!.extended(upTo: introducer.origin!.upperBound))
   }
 
 }

--- a/Sources/Compiler/AST/Node.swift
+++ b/Sources/Compiler/AST/Node.swift
@@ -2,6 +2,9 @@
 /// A protocol describing the API of an AST node.
 public protocol Node: Codable {
 
+  /// The source range from which `self` was parsed, if any.
+  var origin: SourceRange? { get }
+
   /// Returns `.success` if `self` is well-formed given the containing `ast`. Otherwise, returns
   /// `.failure` with the diagnostics of the broken invariants.
   func validateForm(in ast: AST) -> SuccessOrDiagnostics

--- a/Sources/Compiler/AST/Pattern/BindingPattern.swift
+++ b/Sources/Compiler/AST/Pattern/BindingPattern.swift
@@ -16,6 +16,8 @@ public struct BindingPattern: Pattern {
 
   }
 
+  public let origin: SourceRange?
+
   /// The introducer of the pattern.
   public let introducer: SourceRepresentable<Introducer>
 
@@ -30,8 +32,10 @@ public struct BindingPattern: Pattern {
   public init(
     introducer: SourceRepresentable<BindingPattern.Introducer>,
     subpattern: AnyPatternID,
-    annotation: AnyTypeExprID? = nil
+    annotation: AnyTypeExprID?,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.introducer = introducer
     self.subpattern = subpattern
     self.annotation = annotation

--- a/Sources/Compiler/AST/Pattern/ExprPattern.swift
+++ b/Sources/Compiler/AST/Pattern/ExprPattern.swift
@@ -1,10 +1,13 @@
 /// A pattern that matches the value of an equatable expression.
 public struct ExprPattern: Pattern {
 
+  public let origin: SourceRange?
+
   /// The expression of the pattern.
   public let expr: AnyExprID
 
-  public init(expr: AnyExprID) {
+  public init(expr: AnyExprID, origin: SourceRange?) {
+    self.origin = origin
     self.expr = expr
   }
 

--- a/Sources/Compiler/AST/Pattern/NamePattern.swift
+++ b/Sources/Compiler/AST/Pattern/NamePattern.swift
@@ -1,10 +1,13 @@
 /// A pattern which binds an identifier.
 public struct NamePattern: Pattern {
 
+  public let origin: SourceRange?
+
   /// The variable declaration introducing the pattern's name.
   public let decl: NodeID<VarDecl>
 
-  public init(decl: NodeID<VarDecl>) {
+  public init(decl: NodeID<VarDecl>, origin: SourceRange?) {
+    self.origin = origin
     self.decl = decl
   }
 

--- a/Sources/Compiler/AST/Pattern/TuplePattern.swift
+++ b/Sources/Compiler/AST/Pattern/TuplePattern.swift
@@ -10,17 +10,20 @@ public struct TuplePattern: Pattern {
     /// The pattern of the element.
     public var pattern: AnyPatternID
 
-    public init(label: SourceRepresentable<String>? = nil, pattern: AnyPatternID) {
+    public init(label: SourceRepresentable<String>?, pattern: AnyPatternID) {
       self.label = label
       self.pattern = pattern
     }
 
   }
 
+  public let origin: SourceRange?
+
   /// The elements of the tuple.
   public let elements: [Element]
 
-  public init(elements: [Element] = []) {
+  public init(elements: [Element], origin: SourceRange?) {
+    self.origin = origin
     self.elements = elements
   }
 

--- a/Sources/Compiler/AST/Pattern/WildcardPattern.swift
+++ b/Sources/Compiler/AST/Pattern/WildcardPattern.swift
@@ -1,6 +1,10 @@
 /// A wildcard pattern.
 public struct WildcardPattern: Pattern {
 
-  public init() {}
+  public let origin: SourceRange?
+
+  public init(origin: SourceRange?) {
+    self.origin = origin
+  }
 
 }

--- a/Sources/Compiler/AST/SourceRepresentable.swift
+++ b/Sources/Compiler/AST/SourceRepresentable.swift
@@ -6,13 +6,13 @@ public struct SourceRepresentable<Part> {
   /// The part.
   public let value: Part
 
-  /// The source range of the node's textual representation.
-  public let range: SourceRange?
+  /// The source range from which `part` was extracted, if any.
+  public let origin: SourceRange?
 
   /// Creates a source representable container, annotating a value with an optional source range.
   public init(value: Part, range: SourceRange? = nil) {
     self.value = value
-    self.range = range
+    self.origin = range
   }
 
 }
@@ -45,16 +45,16 @@ extension SourceRepresentable: Codable where Part: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     value = try container.decode(Part.self, forKey: .value)
     do {
-      range = try container.decode(SourceRange?.self, forKey: .range)
+      origin = try container.decode(SourceRange?.self, forKey: .range)
     } catch {
-      range = nil
+      origin = nil
     }
   }
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(value, forKey: .value)
-    try container.encode(range, forKey: .range)
+    try container.encode(origin, forKey: .range)
   }
 
 }

--- a/Sources/Compiler/AST/Stmt/BraceStmt.swift
+++ b/Sources/Compiler/AST/Stmt/BraceStmt.swift
@@ -1,10 +1,13 @@
 /// A brace statement (a.k.a. a code block).
 public struct BraceStmt: Stmt, LexicalScope {
 
+  public let origin: SourceRange?
+
   /// The statements in the block.
   public let stmts: [AnyStmtID]
 
-  public init(stmts: [AnyStmtID] = []) {
+  public init(stmts: [AnyStmtID], origin: SourceRange?) {
+    self.origin = origin
     self.stmts = stmts
   }
 

--- a/Sources/Compiler/AST/Stmt/BreakStmt.swift
+++ b/Sources/Compiler/AST/Stmt/BreakStmt.swift
@@ -1,6 +1,10 @@
 /// A break statement.
 public struct BreakStmt: Stmt {
 
-  public init() {}
+  public let origin: SourceRange?
+
+  public init(origin: SourceRange?) {
+    self.origin = origin
+  }
 
 }

--- a/Sources/Compiler/AST/Stmt/CondBindingStmt.swift
+++ b/Sources/Compiler/AST/Stmt/CondBindingStmt.swift
@@ -9,13 +9,16 @@ public struct CondBindingStmt: Stmt {
 
   }
 
+  public let origin: SourceRange?
+
   /// The conditional binding.
   public let binding: NodeID<BindingDecl>
 
   /// The fallback expression or statement.
   public let fallback: Fallback
 
-  public init(binding: NodeID<BindingDecl>, fallback: Fallback) {
+  public init(binding: NodeID<BindingDecl>, fallback: Fallback, origin: SourceRange?) {
+    self.origin = origin
     self.binding = binding
     self.fallback = fallback
   }

--- a/Sources/Compiler/AST/Stmt/ContinueStmt.swift
+++ b/Sources/Compiler/AST/Stmt/ContinueStmt.swift
@@ -1,6 +1,10 @@
 /// A continue statement.
 public struct ContinueStmt: Stmt {
 
-  public init() {}
+  public let origin: SourceRange?
+
+  public init(origin: SourceRange?) {
+    self.origin = origin
+  }
 
 }

--- a/Sources/Compiler/AST/Stmt/DeclStmt.swift
+++ b/Sources/Compiler/AST/Stmt/DeclStmt.swift
@@ -1,10 +1,13 @@
 /// A declaration statement.
 public struct DeclStmt: Stmt {
 
+  public let origin: SourceRange?
+
   /// The declaration.
   public let decl: AnyDeclID
 
-  public init(decl: AnyDeclID) {
+  public init(decl: AnyDeclID, origin: SourceRange?) {
+    self.origin = origin
     self.decl = decl
   }
 

--- a/Sources/Compiler/AST/Stmt/DiscardStmt.swift
+++ b/Sources/Compiler/AST/Stmt/DiscardStmt.swift
@@ -1,10 +1,13 @@
 /// A discard statement.
 public struct DiscardStmt: Stmt {
 
+  public let origin: SourceRange?
+
   /// The expression whose value is discarded.
   public let expr: AnyExprID
 
-  public init(expr: AnyExprID) {
+  public init(expr: AnyExprID, origin: SourceRange?) {
+    self.origin = origin
     self.expr = expr
   }
 

--- a/Sources/Compiler/AST/Stmt/DoWhileStmt.swift
+++ b/Sources/Compiler/AST/Stmt/DoWhileStmt.swift
@@ -1,6 +1,8 @@
 /// A do-while loop.
 public struct DoWhileStmt: Stmt {
 
+  public let origin: SourceRange?
+
   /// The body of the loop.
   public let body: NodeID<BraceStmt>
 
@@ -9,7 +11,8 @@ public struct DoWhileStmt: Stmt {
   /// - Note: The condition is evaluated in the lexical scope of the body.
   public let condition: AnyExprID
 
-  public init(body: NodeID<BraceStmt>, condition: AnyExprID) {
+  public init(body: NodeID<BraceStmt>, condition: AnyExprID, origin: SourceRange?) {
+    self.origin = origin
     self.body = body
     self.condition = condition
   }

--- a/Sources/Compiler/AST/Stmt/ExprStmt.swift
+++ b/Sources/Compiler/AST/Stmt/ExprStmt.swift
@@ -1,10 +1,13 @@
 /// An expression statement.
 public struct ExprStmt: Stmt {
 
+  public let origin: SourceRange?
+
   /// The expression.
   public let expr: AnyExprID
 
-  public init(expr: AnyExprID) {
+  public init(expr: AnyExprID, origin: SourceRange?) {
+    self.origin = origin
     self.expr = expr
   }
 

--- a/Sources/Compiler/AST/Stmt/ForStmt.swift
+++ b/Sources/Compiler/AST/Stmt/ForStmt.swift
@@ -1,6 +1,8 @@
 /// A for loop.
 public struct ForStmt: Stmt, LexicalScope {
 
+  public let origin: SourceRange?
+
   /// The conditional binding of the loop.
   public let binding: NodeID<BindingDecl>
 
@@ -16,9 +18,11 @@ public struct ForStmt: Stmt, LexicalScope {
   internal init(
     binding: NodeID<BindingDecl>,
     domain: AnyExprID,
-    filter: AnyExprID? = nil,
-    body: NodeID<BraceStmt>
+    filter: AnyExprID?,
+    body: NodeID<BraceStmt>,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.binding = binding
     self.domain = domain
     self.filter = filter

--- a/Sources/Compiler/AST/Stmt/ReturnStmt.swift
+++ b/Sources/Compiler/AST/Stmt/ReturnStmt.swift
@@ -1,10 +1,13 @@
 /// A return statement.
 public struct ReturnStmt: Stmt {
 
+  public let origin: SourceRange?
+
   /// The return value, if any.
   public let value: AnyExprID?
 
-  public init(value: AnyExprID? = nil) {
+  public init(value: AnyExprID?, origin: SourceRange?) {
+    self.origin = origin
     self.value = value
   }
 

--- a/Sources/Compiler/AST/Stmt/WhileStmt.swift
+++ b/Sources/Compiler/AST/Stmt/WhileStmt.swift
@@ -1,6 +1,8 @@
 /// A while loop.
 public struct WhileStmt: Stmt, LexicalScope {
 
+  public let origin: SourceRange?
+
   /// The condition of the loop.
   ///
   /// - Requires `condition.count > 0`
@@ -9,8 +11,10 @@ public struct WhileStmt: Stmt, LexicalScope {
   /// The body of the loop.
   public let body: NodeID<BraceStmt>
 
-  internal init(condition: [ConditionItem], body: NodeID<BraceStmt>) {
+  internal init(condition: [ConditionItem], body: NodeID<BraceStmt>, origin: SourceRange?) {
     precondition(condition.count > 0)
+
+    self.origin = origin
     self.condition = condition
     self.body = body
   }

--- a/Sources/Compiler/AST/Stmt/YieldStmt.swift
+++ b/Sources/Compiler/AST/Stmt/YieldStmt.swift
@@ -1,10 +1,13 @@
 /// A yield statement.
 public struct YieldStmt: Stmt {
 
+  public let origin: SourceRange?
+
   /// The yielded value.
   public let value: AnyExprID
 
-  public init(value: AnyExprID) {
+  public init(value: AnyExprID, origin: SourceRange?) {
+    self.origin = origin
     self.value = value
   }
 

--- a/Sources/Compiler/AST/TypeExpr/ConformanceLensTypeExpr.swift
+++ b/Sources/Compiler/AST/TypeExpr/ConformanceLensTypeExpr.swift
@@ -1,13 +1,16 @@
 /// A conformance lens.
 public struct ConformanceLensTypeExpr: TypeExpr {
 
+  public let origin: SourceRange?
+
   /// The expression of the subject type.
   public let subject: AnyTypeExprID
 
   /// The expression of the trait in which the lens focuses.
   public let lens: AnyTypeExprID
 
-  public init(subject: AnyTypeExprID, lens: AnyTypeExprID) {
+  public init(subject: AnyTypeExprID, lens: AnyTypeExprID, origin: SourceRange?) {
+    self.origin = origin
     self.subject = subject
     self.lens = lens
   }

--- a/Sources/Compiler/AST/TypeExpr/ExistentialTypeExpr.swift
+++ b/Sources/Compiler/AST/TypeExpr/ExistentialTypeExpr.swift
@@ -1,13 +1,20 @@
 /// The expression of an existential type.
 public struct ExistentialTypeExpr: TypeExpr {
 
+  public let origin: SourceRange?
+
   /// The traits to which the witness conforms.
   public let traits: TraitComposition
 
   /// The where clause of the expression, if any.
   public let whereClause: SourceRepresentable<WhereClause>?
 
-  public init(traits: TraitComposition, whereClause: SourceRepresentable<WhereClause>? = nil) {
+  public init(
+    traits: TraitComposition,
+    whereClause: SourceRepresentable<WhereClause>?,
+    origin: SourceRange?
+  ) {
+    self.origin = origin
     self.traits = traits
     self.whereClause = whereClause
   }

--- a/Sources/Compiler/AST/TypeExpr/LambdaTypeExpr.swift
+++ b/Sources/Compiler/AST/TypeExpr/LambdaTypeExpr.swift
@@ -53,7 +53,7 @@ public struct LambdaTypeExpr: TypeExpr {
     if let l = environment?.range,
        let u = origin?.upperBound
     {
-      self.origin = l.upperBounded(by: u)
+      self.origin = l.extended(upTo: u)
     }
   }
 }

--- a/Sources/Compiler/AST/TypeExpr/LambdaTypeExpr.swift
+++ b/Sources/Compiler/AST/TypeExpr/LambdaTypeExpr.swift
@@ -50,7 +50,7 @@ public struct LambdaTypeExpr: TypeExpr {
     precondition(self.environment == nil)
 
     self.environment = environment
-    if let l = environment?.range,
+    if let l = environment?.origin,
        let u = origin?.upperBound
     {
       self.origin = l.extended(upTo: u)

--- a/Sources/Compiler/AST/TypeExpr/LambdaTypeExpr.swift
+++ b/Sources/Compiler/AST/TypeExpr/LambdaTypeExpr.swift
@@ -17,6 +17,8 @@ public struct LambdaTypeExpr: TypeExpr {
 
   }
 
+  public private(set) var origin: SourceRange?
+
   /// The effect of the lambda's call operator.
   public let receiverEffect: SourceRepresentable<ReceiverEffect>?
 
@@ -30,10 +32,12 @@ public struct LambdaTypeExpr: TypeExpr {
   public let output: AnyTypeExprID
 
   public init(
-    receiverEffect: SourceRepresentable<ReceiverEffect>? = nil,
-    parameters: [Parameter] = [],
-    output: AnyTypeExprID
+    receiverEffect: SourceRepresentable<ReceiverEffect>?,
+    parameters: [Parameter],
+    output: AnyTypeExprID,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.receiverEffect = receiverEffect
     self.parameters = parameters
     self.output = output
@@ -44,6 +48,12 @@ public struct LambdaTypeExpr: TypeExpr {
   /// - Precondition: `self.environment == nil`
   internal mutating func incorporate(environment: SourceRepresentable<AnyTypeExprID>?) {
     precondition(self.environment == nil)
+
     self.environment = environment
+    if let l = environment?.range,
+       let u = origin?.upperBound
+    {
+      self.origin = l.upperBounded(by: u)
+    }
   }
 }

--- a/Sources/Compiler/AST/TypeExpr/ParameterTypeExpr.swift
+++ b/Sources/Compiler/AST/TypeExpr/ParameterTypeExpr.swift
@@ -1,6 +1,8 @@
 /// A parameter in a lambda type expression.
 public struct ParameterTypeExpr: TypeExpr {
 
+  public let origin: SourceRange?
+
   /// The passing convention of the parameter.
   public let convention: SourceRepresentable<PassingConvention>
 
@@ -9,8 +11,10 @@ public struct ParameterTypeExpr: TypeExpr {
 
   public init(
     convention: SourceRepresentable<PassingConvention>,
-    bareType: AnyTypeExprID
+    bareType: AnyTypeExprID,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.convention = convention
     self.bareType = bareType
   }

--- a/Sources/Compiler/AST/TypeExpr/RemoteTypeExpr.swift
+++ b/Sources/Compiler/AST/TypeExpr/RemoteTypeExpr.swift
@@ -1,6 +1,8 @@
 /// The type expression of a remote type (e.g., `remote let Int`).
 public struct RemoteTypeExpr: TypeExpr {
 
+  public let origin: SourceRange?
+
   /// The source range of the expression's introducer, if any.
   public let introducerRange: SourceRange?
 
@@ -13,8 +15,10 @@ public struct RemoteTypeExpr: TypeExpr {
   public init(
     introducerRange: SourceRange?,
     convention: SourceRepresentable<PassingConvention>,
-    operand: AnyTypeExprID
+    operand: AnyTypeExprID,
+    origin: SourceRange?
   ) {
+    self.origin = origin
     self.introducerRange = introducerRange
     self.convention = convention
     self.operand = operand

--- a/Sources/Compiler/AST/TypeExpr/TupleTypeExpr.swift
+++ b/Sources/Compiler/AST/TypeExpr/TupleTypeExpr.swift
@@ -17,10 +17,13 @@ public struct TupleTypeExpr: TypeExpr {
 
   }
 
+  public let origin: SourceRange?
+
   /// The elements of the tuple.
   public let elements: [Element]
 
-  public init(elements: [Element] = []) {
+  public init(elements: [Element], origin: SourceRange?) {
+    self.origin = origin
     self.elements = elements
   }
 

--- a/Sources/Compiler/AST/TypeExpr/UnionTypeExpr.swift
+++ b/Sources/Compiler/AST/TypeExpr/UnionTypeExpr.swift
@@ -1,10 +1,13 @@
 /// A union type expression.
 public struct UnionTypeExpr: TypeExpr {
 
+  public let origin: SourceRange?
+
   /// The elements of the union.
   public let elements: [AnyTypeExprID]
 
-  public init(elements: [AnyTypeExprID] = []) {
+  public init(elements: [AnyTypeExprID], origin: SourceRange?) {
+    self.origin = origin
     self.elements = elements
   }
 

--- a/Sources/Compiler/AST/TypeExpr/WildcardTypeExpr.swift
+++ b/Sources/Compiler/AST/TypeExpr/WildcardTypeExpr.swift
@@ -1,6 +1,10 @@
 /// A wildcard type expression.
 public struct WildcardTypeExpr: TypeExpr {
 
-  public init() {}
+  public let origin: SourceRange?
+
+  public init(origin: SourceRange?) {
+    self.origin = origin
+  }
 
 }

--- a/Sources/Compiler/IR/Emitter.swift
+++ b/Sources/Compiler/IR/Emitter.swift
@@ -258,7 +258,7 @@ public struct Emitter {
             from: source,
             at: path,
             binding: decl,
-            range: program.ast.ranges[decl]),
+            range: program.ast[decl].origin),
           at: insertionPoint!)[0]
       }
     }
@@ -314,7 +314,7 @@ public struct Emitter {
 
     emitStackDeallocs(in: &module)
     module.insert(
-      ReturnInst(value: value, range: program.ast.ranges[stmt]),
+      ReturnInst(value: value, range: program.ast[stmt].origin),
       at: insertionPoint!)
   }
 

--- a/Sources/Compiler/Parse/Lexer.swift
+++ b/Sources/Compiler/Parse/Lexer.swift
@@ -50,7 +50,7 @@ public struct Lexer: IteratorProtocol, Sequence {
           } else {
             return Token(
               kind: .unterminatedBlockComment,
-              range: SourceRange(in: source, from: start, to: index))
+              origin: SourceRange(in: source, from: start, to: index))
           }
         }
 
@@ -64,12 +64,12 @@ public struct Lexer: IteratorProtocol, Sequence {
 
     // Scan a new token.
     let head = source.contents[index]
-    var token = Token(kind: .invalid, range: location ..< location)
+    var token = Token(kind: .invalid, origin: location ..< location)
 
     // Scan names and keywords.
     if head.isLetter || (head == "_") {
       let word = take(while: { $0.isLetter || $0.isDecDigit })
-      token.range = SourceRange(in: source, from: token.range.lowerBound, to: index)
+      token.origin = SourceRange(in: source, from: token.origin.lowerBound, to: index)
 
       switch word {
       case "_"          : token.kind = .under
@@ -125,7 +125,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       case "as":
         _ = take("!")
         _ = take("!")
-        token.range.upperBound = index
+        token.origin.upperBound = index
         token.kind = .cast
 
       default:
@@ -145,9 +145,9 @@ public struct Lexer: IteratorProtocol, Sequence {
 
         if peek() == "`" {
           let start = SourceLocation(
-            source: source, index: source.contents.index(after: token.range.lowerBound))
+            source: source, index: source.contents.index(after: token.origin.lowerBound))
           token.kind = .name
-          token.range = start ..< location
+          token.origin = start ..< location
           discard()
           return token
         } else {
@@ -155,7 +155,7 @@ public struct Lexer: IteratorProtocol, Sequence {
         }
       }
 
-      token.range.upperBound = index
+      token.origin.upperBound = index
       return token
     }
 
@@ -170,7 +170,7 @@ public struct Lexer: IteratorProtocol, Sequence {
           discard()
           if let c = peek(), c.isHexDigit {
             _ = take(while: { $0.isHexDigit })
-            token.range.upperBound = index
+            token.origin.upperBound = index
             return token
           }
 
@@ -178,7 +178,7 @@ public struct Lexer: IteratorProtocol, Sequence {
           discard()
           if let c = peek(), c.isOctDigit {
             _ = take(while: { $0.isOctDigit })
-            token.range.upperBound = index
+            token.origin.upperBound = index
             return token
           }
 
@@ -186,7 +186,7 @@ public struct Lexer: IteratorProtocol, Sequence {
           discard()
           if let c = peek(), c.isBinDigit {
             _ = take(while: { $0.isBinDigit })
-            token.range.upperBound = index
+            token.origin.upperBound = index
             return token
           }
 
@@ -220,7 +220,7 @@ public struct Lexer: IteratorProtocol, Sequence {
         }
       }
 
-      token.range.upperBound = index
+      token.origin.upperBound = index
       return token
     }
 
@@ -232,7 +232,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       while index < source.contents.endIndex {
         if !escape && (take("\"") != nil) {
           token.kind = .string
-          token.range.upperBound = index
+          token.origin.upperBound = index
           return token
         } else if take("\\") != nil {
           escape = !escape
@@ -243,7 +243,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       }
 
       token.kind = .unterminatedString
-      token.range.upperBound = index
+      token.origin.upperBound = index
       return token
     }
 
@@ -253,7 +253,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       token.kind = take(while: { $0.isLetter || ($0 == "_") }).isEmpty
         ? .invalid
         : .attribute
-      token.range.upperBound = index
+      token.origin.upperBound = index
       return token
     }
 
@@ -264,7 +264,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       case "<", ">":
         // Leading angle brackets are tokenized individually, to parse generic clauses.
         discard()
-        oper = source.contents[token.range.lowerBound ..< index]
+        oper = source.contents[token.origin.lowerBound ..< index]
 
       default:
         oper = take(while: { $0.isOperator })
@@ -281,7 +281,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       default  : token.kind = .oper
       }
 
-      token.range.upperBound = index
+      token.origin.upperBound = index
       return token
     }
 
@@ -300,7 +300,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       // Scan range operators.
       if (take(prefix: "...") ?? take(prefix: "..<")) != nil {
         token.kind = .oper
-        token.range.upperBound = index
+        token.origin.upperBound = index
         return token
       }
 
@@ -311,7 +311,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       // Scan double colons.
       if take(prefix: "::") != nil {
         token.kind = .twoColons
-        token.range.upperBound = index
+        token.origin.upperBound = index
         return token
       }
 
@@ -324,7 +324,7 @@ public struct Lexer: IteratorProtocol, Sequence {
 
     // Either the token is punctuation, or it's kind is `invalid`.
     discard()
-    token.range.upperBound = index
+    token.origin.upperBound = index
     return token
   }
 

--- a/Sources/Compiler/Parse/Parser.swift
+++ b/Sources/Compiler/Parse/Parser.swift
@@ -366,8 +366,8 @@ public enum Parser {
       identifier: SourceRepresentable(token: parts.0.0.0.1, in: state.lexer.source),
       conformances: parts.0.0.1 ?? [],
       whereClause: parts.0.1,
-      defaultValue: parts.1))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      defaultValue: parts.1,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -404,8 +404,8 @@ public enum Parser {
       introducerRange: parts.0.0.0.range,
       identifier: SourceRepresentable(token: parts.0.0.1, in: state.lexer.source),
       whereClause: parts.0.1,
-      defaultValue: parts.1))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      defaultValue: parts.1,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -429,8 +429,8 @@ public enum Parser {
       accessModifier: prologue.accessModifiers.first,
       memberModifier: prologue.memberModifiers.first,
       pattern: pattern,
-      initializer: initializer))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      initializer: initializer,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -466,8 +466,8 @@ public enum Parser {
       subject: parts.0.0.0.1,
       conformances: parts.0.0.1,
       whereClause: parts.0.1,
-      members: parts.1))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      members: parts.1,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -505,8 +505,8 @@ public enum Parser {
       accessModifier: prologue.accessModifiers.first,
       subject: parts.0.0.1,
       whereClause: parts.0.1,
-      members: parts.1))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      members: parts.1,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -562,7 +562,8 @@ public enum Parser {
     let receiver: NodeID<ParameterDecl>?
     if state.atTypeScope && !prologue.isStatic {
       receiver = try state.ast.insert(wellFormed: ParameterDecl(
-        identifier: SourceRepresentable(value: "self")))
+        identifier: SourceRepresentable(value: "self"),
+        origin: nil))
     } else {
       receiver = nil
     }
@@ -583,8 +584,8 @@ public enum Parser {
       parameters: signature.parameters,
       receiver: receiver,
       output: signature.output,
-      body: body))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      body: body,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -622,8 +623,8 @@ public enum Parser {
       genericClause: head.genericClause,
       parameters: signature.parameters,
       output: signature.output,
-      impls: impls))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      impls: impls,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -656,8 +657,8 @@ public enum Parser {
     // Create a new `ImportDecl`.
     let decl = try state.ast.insert(wellFormed: ImportDecl(
       introducerRange: parts.0.range,
-      identifier: SourceRepresentable(token: parts.1, in: state.lexer.source)))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      identifier: SourceRepresentable(token: parts.1, in: state.lexer.source),
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -681,7 +682,8 @@ public enum Parser {
 
     // Init declarations require an implicit receiver parameter.
     let receiver = try state.ast.insert(wellFormed: ParameterDecl(
-      identifier: SourceRepresentable(value: "self")))
+      identifier: SourceRepresentable(value: "self"),
+      origin: nil))
 
     // Create a new `InitializerDecl`.
     assert(prologue.accessModifiers.count <= 1)
@@ -693,8 +695,8 @@ public enum Parser {
       genericClause: head.genericClause,
       parameters: signature,
       receiver: receiver,
-      body: body))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      body: body,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -716,7 +718,8 @@ public enum Parser {
 
     // Init declarations require an implicit receiver parameter.
     let receiver = try state.ast.insert(wellFormed: ParameterDecl(
-      identifier: SourceRepresentable(value: "self")))
+      identifier: SourceRepresentable(value: "self"),
+      origin: nil))
 
     // Create a new `InitializerDecl`.
     assert(prologue.accessModifiers.count <= 1)
@@ -727,8 +730,8 @@ public enum Parser {
       genericClause: nil,
       parameters: [],
       receiver: receiver,
-      body: nil))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      body: nil,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -761,8 +764,8 @@ public enum Parser {
       introducerRange: parts.0.0.range,
       accessModifier: prologue.accessModifiers.first,
       identifier: SourceRepresentable(token: parts.0.1, in: state.lexer.source),
-      members: parts.1))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      members: parts.1,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -797,8 +800,8 @@ public enum Parser {
       accessModifier: prologue.accessModifiers.first,
       notation: parts.0.0.1,
       name: parts.0.1,
-      precedenceGroup: parts.1))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      precedenceGroup: parts.1,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -830,8 +833,8 @@ public enum Parser {
       explicitCaptures: [],
       parameters: nil,
       output: signature,
-      impls: impls))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      impls: impls,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -863,8 +866,8 @@ public enum Parser {
       explicitCaptures: head.captures,
       parameters: signature.parameters,
       output: signature.output,
-      impls: impls))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      impls: impls,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -936,27 +939,30 @@ public enum Parser {
     let receiver: NodeID<ParameterDecl>?
     if isNonStaticMember {
       receiver = try state.ast.insert(wellFormed: ParameterDecl(
-        identifier: SourceRepresentable(value: "self")))
+        identifier: SourceRepresentable(value: "self"),
+        origin: nil))
     } else {
       receiver = nil
+    }
+
+    let origin: SourceRange
+    if let startIndex = introducer.range?.lowerBound {
+      origin = state.range(from: startIndex)
+    } else {
+      switch body! {
+      case .expr(let id):
+        origin = state.ast[id].origin!
+      case .block(let id):
+        origin = state.ast[id].origin!
+      }
     }
 
     // Create a new `SubscriptImplDecl`.
     let decl = try state.ast.insert(wellFormed: SubscriptImplDecl(
       introducer: introducer,
       receiver: receiver,
-      body: body))
-
-    if let startIndex = introducer.range?.lowerBound {
-      state.ast.ranges[decl] = state.range(from: startIndex)
-    } else {
-      switch body! {
-      case .expr(let id):
-        state.ast.ranges[decl] = state.ast.ranges[id]
-      case .block(let id):
-        state.ast.ranges[decl] = state.ast.ranges[id]
-      }
-    }
+      body: body,
+      origin: origin))
 
     return decl
   }
@@ -985,8 +991,8 @@ public enum Parser {
       accessModifier: prologue.accessModifiers.first,
       identifier: SourceRepresentable(token: parts.0.0.1, in: state.lexer.source),
       refinements: parts.0.1 ?? [],
-      members: parts.1))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      members: parts.1,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -1027,9 +1033,8 @@ public enum Parser {
       genericClause: parts.0.0.1,
       conformances: parts.0.1 ?? [],
       members: members,
-      memberwiseInit: memberwiseInit
-    ))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      memberwiseInit: memberwiseInit,
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -1045,7 +1050,8 @@ public enum Parser {
     }
 
     let receiver = try! state.ast.insert(wellFormed: ParameterDecl(
-      identifier: SourceRepresentable(value: "self")))
+      identifier: SourceRepresentable(value: "self"),
+      origin: nil))
     let m = try! state.ast.insert(wellFormed: InitializerDecl(
       introducer: SourceRepresentable(value: .memberwiseInit),
       attributes: [],
@@ -1053,7 +1059,8 @@ public enum Parser {
       genericClause: nil,
       parameters: [],
       receiver: receiver,
-      body: nil))
+      body: nil,
+      origin: nil))
     members.append(AnyDeclID(m))
     return m
   }
@@ -1089,8 +1096,8 @@ public enum Parser {
       accessModifier: prologue.accessModifiers.first,
       identifier: SourceRepresentable(token: parts.0.0.0.1, in: state.lexer.source),
       genericClause: parts.0.0.1,
-      body: .typeExpr(parts.1)))
-    state.ast.ranges[decl] = state.range(from: prologue.startIndex)
+      body: .typeExpr(parts.1),
+      origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
@@ -1202,13 +1209,13 @@ public enum Parser {
     methodIntroducer.and(maybe(methodImplBody))
       .map({ (state, tree) -> NodeID<MethodImplDecl> in
         let receiver = try state.ast.insert(wellFormed: ParameterDecl(
-          identifier: SourceRepresentable(value: "self")))
-        let id = try state.ast.insert(wellFormed: MethodImplDecl(
+          identifier: SourceRepresentable(value: "self"),
+          origin: nil))
+        return try state.ast.insert(wellFormed: MethodImplDecl(
           introducer: tree.0,
           receiver: receiver,
-          body: tree.1))
-        state.ast.ranges[id] = tree.0.range!.upperBounded(by: state.currentIndex)
-        return id
+          body: tree.1,
+          origin: tree.0.range!.upperBounded(by: state.currentIndex)))
       })
   )
 
@@ -1329,17 +1336,15 @@ public enum Parser {
       .and(maybe(take(.colon).and(parameterTypeExpr)))
       .and(maybe(take(.assign).and(expr)))
       .map({ (state, tree) -> NodeID<ParameterDecl> in
-        let id = try state.ast.insert(wellFormed: ParameterDecl(
+        try state.ast.insert(wellFormed: ParameterDecl(
           label: tree.0.0.label,
           identifier: tree.0.0.name,
           annotation: tree.0.1?.1,
-          defaultValue: tree.1?.1))
-
-        state.ast.ranges[id] = SourceRange(
-          in: state.lexer.source,
-          from: tree.0.0.label?.range!.lowerBound ?? tree.0.0.name.range!.lowerBound,
-          to: state.currentIndex)
-        return id
+          defaultValue: tree.1?.1,
+          origin: SourceRange(
+            in: state.lexer.source,
+            from: tree.0.0.label?.range!.lowerBound ?? tree.0.0.name.range!.lowerBound,
+            to: state.currentIndex)))
       })
   )
 
@@ -1428,12 +1433,11 @@ public enum Parser {
         let id = try state.ast.insert(wellFormed: GenericTypeParamDecl(
           identifier: SourceRepresentable(token: tree.0.0.1, in: state.lexer.source),
           conformances: tree.0.1?.1 ?? [],
-          defaultValue: tree.1?.1))
-
-        state.ast.ranges[id] = SourceRange(
-          in: state.lexer.source,
-          from: tree.0.0.0?.range.lowerBound ?? tree.0.0.1.range.lowerBound,
-          to: state.currentIndex)
+          defaultValue: tree.1?.1,
+          origin: SourceRange(
+            in: state.lexer.source,
+            from: tree.0.0.0?.range.lowerBound ?? tree.0.0.1.range.lowerBound,
+            to: state.currentIndex)))
         return .type(id)
       })
   )
@@ -1446,9 +1450,8 @@ public enum Parser {
         let id = try state.ast.insert(wellFormed: GenericValueParamDecl(
           identifier: SourceRepresentable(token: tree.0.0.1, in: state.lexer.source),
           annotation: tree.0.1.1,
-          defaultValue: tree.1?.1))
-
-        state.ast.ranges[id] = tree.0.0.0.range.upperBounded(by: state.currentIndex)
+          defaultValue: tree.1?.1,
+          origin: tree.0.0.0.range.upperBounded(by: state.currentIndex)))
         return .value(id)
       })
   )
@@ -1526,8 +1529,11 @@ public enum Parser {
       unreachable()
     }
 
-    let expr = try state.ast.insert(wellFormed: CastExpr(left: lhs, right: rhs, kind: castKind))
-    state.ast.ranges[expr] = state.ast.ranges[lhs]!.upperBounded(by: state.currentIndex)
+    let expr = try state.ast.insert(wellFormed: CastExpr(
+      left: lhs,
+      right: rhs,
+      kind: castKind,
+      origin: state.ast[lhs].origin!.upperBounded(by: state.currentIndex)))
     lhs = AnyExprID(expr)
   }
 
@@ -1545,8 +1551,10 @@ public enum Parser {
       throw DiagnosedError(expected("expression", at: state.currentLocation))
     }
 
-    let expr = try state.ast.insert(wellFormed: AssignExpr(left: lhs, right: rhs))
-    state.ast.ranges[expr] = state.ast.ranges[lhs]!.upperBounded(by: state.currentIndex)
+    let expr = try state.ast.insert(wellFormed: AssignExpr(
+      left: lhs,
+      right: rhs,
+      origin: state.ast[lhs].origin!.upperBounded(by: state.currentIndex)))
     lhs = AnyExprID(expr)
   }
 
@@ -1568,7 +1576,7 @@ public enum Parser {
       if !state.hasLeadingWhitespace {
         // If there isn't any leading whitespace before the next expression but the operator is on
         // a different line, we may be looking at the start of a prefix expression.
-        let rangeBefore = state.ast.ranges[lhs]!.upperBound ..< operatorStem.range!.lowerBound
+        let rangeBefore = state.ast[lhs].origin!.upperBound ..< operatorStem.range!.lowerBound
         if state.lexer.source.contents[rangeBefore].contains(where: { $0.isNewline }) {
           state.restore(from: backup)
           break
@@ -1586,16 +1594,18 @@ public enum Parser {
       }
 
       let `operator` = try state.ast.insert(wellFormed: NameExpr(
-        name: SourceRepresentable(
-          value: Name(stem: operatorStem.value, notation: .infix))))
+        name: SourceRepresentable(value: Name(stem: operatorStem.value, notation: .infix)),
+        origin: operatorStem.range))
       tail.append(SequenceExpr.TailElement(operator: `operator`, operand: operand))
     }
 
     // Nothing to transform if the tail is empty.
     if tail.isEmpty { return false }
 
-    let expr = try state.ast.insert(wellFormed: SequenceExpr(head: lhs, tail: tail))
-    state.ast.ranges[expr] = state.ast.ranges[lhs]!.upperBounded(by: state.currentIndex)
+    let expr = try state.ast.insert(wellFormed: SequenceExpr(
+      head: lhs,
+      tail: tail,
+      origin: state.ast[lhs].origin!.upperBounded(by: state.currentIndex)))
     lhs = AnyExprID(expr)
     return true
   }
@@ -1617,12 +1627,12 @@ public enum Parser {
           receiverEffect: tree.0.0.0.1,
           output: tree.0.1,
           body: .block(tree.1),
-          isInExprContext: true))
-        state.ast.ranges[decl] = tree.0.0.0.0.0.range.upperBounded(by: state.currentIndex)
+          isInExprContext: true,
+          origin: tree.0.0.0.0.0.range.upperBounded(by: state.currentIndex)))
 
-        let id = try state.ast.insert(wellFormed: AsyncExpr(decl: decl))
-        state.ast.ranges[id] = state.ast.ranges[decl]
-        return id
+        return try state.ast.insert(wellFormed: AsyncExpr(
+          decl: decl,
+          origin: state.ast[decl].origin))
       })
   )
 
@@ -1636,12 +1646,12 @@ public enum Parser {
           receiverEffect: tree.0.1,
           explicitCaptures: tree.0.0.1 ?? [],
           body: .expr(tree.1),
-          isInExprContext: true))
-        state.ast.ranges[decl] = tree.0.0.0.range.upperBounded(by: state.currentIndex)
+          isInExprContext: true,
+          origin: tree.0.0.0.range.upperBounded(by: state.currentIndex)))
 
-        let id = try state.ast.insert(wellFormed: AsyncExpr(decl: decl))
-        state.ast.ranges[id] = state.ast.ranges[decl]
-        return id
+        return try state.ast.insert(wellFormed: AsyncExpr(
+          decl: decl,
+          origin: state.ast[decl].origin))
       })
   )
 
@@ -1652,10 +1662,9 @@ public enum Parser {
   static let awaitExpr = (
     take(.await).and(expr)
       .map({ (state, tree) -> NodeID<AwaitExpr> in
-        let id = try state.ast.insert(wellFormed: AwaitExpr(operand: tree.1))
-        state.ast.ranges[id] = tree.0.range.upperBounded(
-          by: state.ast.ranges[tree.1]!.upperBound)
-        return id
+        try state.ast.insert(wellFormed: AwaitExpr(
+          operand: tree.1,
+          origin: tree.0.range.upperBounded(by: state.ast[tree.1].origin!.upperBound)))
       })
   )
 
@@ -1667,12 +1676,13 @@ public enum Parser {
           domain: .expr(tree.1),
           name: SourceRepresentable(
             value: Name(stem: tree.0.value, notation: .prefix),
-            range: tree.0.range)))
-        state.ast.ranges[callee] = tree.0.range!.upperBounded(
-          by: state.ast.ranges[tree.1]!.upperBound)
+            range: tree.0.range),
+          origin: tree.0.range!.upperBounded(by: state.ast[tree.1].origin!.upperBound)))
 
-        let call = try state.ast.insert(wellFormed: FunCallExpr(callee: AnyExprID(callee)))
-        state.ast.ranges[call] = state.ast.ranges[callee]
+        let call = try state.ast.insert(wellFormed: FunCallExpr(
+          callee: AnyExprID(callee),
+          arguments: [],
+          origin: state.ast[callee]?.origin))
         return AnyExprID(call)
       })
   )
@@ -1694,12 +1704,13 @@ public enum Parser {
           let callee = try state.ast.insert(wellFormed: NameExpr(
             domain: .expr(tree.0),
             name: SourceRepresentable(
-              value: Name(stem: oper.value, notation: .postfix), range: oper.range)))
-          state.ast.ranges[callee] = state.ast.ranges[tree.0]!.upperBounded(
-            by: oper.range!.upperBound)
+              value: Name(stem: oper.value, notation: .postfix), range: oper.range),
+            origin: state.ast[tree.0].origin!.upperBounded(by: oper.range!.upperBound)))
 
-          let call = try state.ast.insert(wellFormed: FunCallExpr(callee: AnyExprID(callee)))
-          state.ast.ranges[call] = state.ast.ranges[callee]
+          let call = try state.ast.insert(wellFormed: FunCallExpr(
+            callee: AnyExprID(callee),
+            arguments: [],
+            origin: state.ast[callee]?.origin))
           return AnyExprID(call)
         } else {
           return tree.0
@@ -1745,7 +1756,7 @@ public enum Parser {
       } else {
         return nil
       }
-      let headRange = state.ast.ranges[head]!
+      let headRange = state.ast[head].origin!
 
       while true {
         // value-member-expr
@@ -1761,7 +1772,6 @@ public enum Parser {
                 origin: origin)
             })
 
-            state.ast.ranges[member] = headRange.upperBounded(by: state.currentIndex)
             head = AnyExprID(member)
             continue
           }
@@ -1770,8 +1780,8 @@ public enum Parser {
           if let index = state.takeMemberIndex() {
             head = try AnyExprID(state.ast.insert(wellFormed: TupleMemberExpr(
               tuple: head,
-              index: index)))
-            state.ast.ranges[head] = headRange.upperBounded(by: state.currentIndex)
+              index: index,
+              origin: headRange.upperBounded(by: state.currentIndex))))
             continue
           }
 
@@ -1789,8 +1799,9 @@ public enum Parser {
           }
 
           head = try AnyExprID(state.ast.insert(wellFormed: FunCallExpr(
-            callee: head, arguments: arguments)))
-          state.ast.ranges[head] = headRange.upperBounded(by: state.currentIndex)
+            callee: head,
+            arguments: arguments,
+            origin: headRange.upperBounded(by: state.currentIndex))))
           continue
         }
 
@@ -1802,8 +1813,9 @@ public enum Parser {
           }
 
           head = try AnyExprID(state.ast.insert(wellFormed: SubscriptCallExpr(
-            callee: head, arguments: arguments)))
-          state.ast.ranges[head] = headRange.upperBounded(by: state.currentIndex)
+            callee: head,
+            arguments: arguments,
+            origin: headRange.upperBounded(by: state.currentIndex))))
           continue
         }
 
@@ -1856,9 +1868,6 @@ public enum Parser {
             arguments: node.arguments,
             origin: origin)
         })
-
-        state.ast.ranges[tree.1] = state.ast.ranges[tree.0.0]!.upperBounded(
-          by: state.ast.ranges[tree.1]!.upperBound)
         return tree.1
       })
   )
@@ -1884,40 +1893,36 @@ public enum Parser {
   static let booleanLiteral = (
     take(.bool)
       .map({ (state, token) -> NodeID<BooleanLiteralExpr> in
-        let id = try state.ast.insert(wellFormed: BooleanLiteralExpr(
-          value: state.lexer.source[token.range] == "true"))
-        state.ast.ranges[id] = token.range
-        return id
+        try state.ast.insert(wellFormed: BooleanLiteralExpr(
+          value: state.lexer.source[token.range] == "true",
+          origin: token.range))
       })
   )
 
   static let integerLiteral = (
     take(.int)
       .map({ (state, token) -> NodeID<IntegerLiteralExpr> in
-        let id = try state.ast.insert(wellFormed: IntegerLiteralExpr(
-          value: state.lexer.source[token.range].filter({ $0 != "_" })))
-        state.ast.ranges[id] = token.range
-        return id
+        try state.ast.insert(wellFormed: IntegerLiteralExpr(
+          value: state.lexer.source[token.range].filter({ $0 != "_" }),
+          origin: token.range))
       })
   )
 
   static let floatingPointLiteral = (
     take(.float)
       .map({ (state, token) -> NodeID<FloatLiteralExpr> in
-        let id = try state.ast.insert(wellFormed: FloatLiteralExpr(
-          value: state.lexer.source[token.range].filter({ $0 != "_" })))
-        state.ast.ranges[id] = token.range
-        return id
+        try state.ast.insert(wellFormed: FloatLiteralExpr(
+          value: state.lexer.source[token.range].filter({ $0 != "_" }),
+          origin: token.range))
       })
   )
 
   static let stringLiteral = (
     take(.string)
       .map({ (state, token) -> NodeID<StringLiteralExpr> in
-        let id = try state.ast.insert(wellFormed: StringLiteralExpr(
-          value: String(state.lexer.source[token.range].dropFirst().dropLast())))
-        state.ast.ranges[id] = token.range
-        return id
+        try state.ast.insert(wellFormed: StringLiteralExpr(
+          value: String(state.lexer.source[token.range].dropFirst().dropLast()),
+          origin: token.range))
       })
   )
 
@@ -1930,9 +1935,9 @@ public enum Parser {
   static let bufferLiteral = (
     take(.lBrack).and(maybe(bufferComponentList)).and(take(.rBrack))
       .map({ (state, tree) -> NodeID<BufferLiteralExpr> in
-        let id = try state.ast.insert(wellFormed: BufferLiteralExpr(elements: tree.0.1 ?? []))
-        state.ast.ranges[id] = tree.0.0.range.upperBounded(by: state.currentIndex)
-        return id
+        try state.ast.insert(wellFormed: BufferLiteralExpr(
+          elements: tree.0.1 ?? [],
+          origin: tree.0.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
@@ -1944,9 +1949,9 @@ public enum Parser {
   static let mapLiteral = (
     take(.lBrack).and(mapComponentList.or(mapComponentEmptyList)).and(take(.rBrack))
       .map({ (state, tree) -> NodeID<MapLiteralExpr> in
-        let id = try state.ast.insert(wellFormed: MapLiteralExpr(elements: tree.0.1))
-        state.ast.ranges[id] = tree.0.0.range.upperBounded(by: state.currentIndex)
-        return id
+        try state.ast.insert(wellFormed: MapLiteralExpr(
+          elements: tree.0.1,
+          origin: tree.0.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
@@ -1970,9 +1975,10 @@ public enum Parser {
   static let primaryDeclRef = (
     identifierExpr.and(maybe(staticArgumentList))
       .map({ (state, tree) -> NodeID<NameExpr> in
-        let id = try state.ast.insert(wellFormed: NameExpr(name: tree.0, arguments: tree.1 ?? []))
-        state.ast.ranges[id] = tree.0.range!.upperBounded(by: state.currentIndex)
-        return id
+        try state.ast.insert(wellFormed: NameExpr(
+          name: tree.0,
+          arguments: tree.1 ?? [],
+          origin: tree.0.range!.upperBounded(by: state.currentIndex)))
       })
   )
 
@@ -2002,12 +2008,12 @@ public enum Parser {
           parameters: signature.parameters,
           output: signature.output,
           body: tree.1,
-          isInExprContext: true))
-        state.ast.ranges[decl] = tree.0.0.0.range.upperBounded(by: state.currentIndex)
+          isInExprContext: true,
+          origin: tree.0.0.0.range.upperBounded(by: state.currentIndex)))
 
-        let id = try state.ast.insert(wellFormed: LambdaExpr(decl: decl))
-        state.ast.ranges[id] = state.ast.ranges[decl]
-        return id
+        return try state.ast.insert(wellFormed: LambdaExpr(
+          decl: decl,
+          origin: state.ast[decl].origin))
       })
   )
 
@@ -2021,24 +2027,21 @@ public enum Parser {
   static let matchExpr = (
     take(.match).and(expr).and(take(.lBrace)).and(zeroOrMany(matchCase)).and(take(.rBrace))
       .map({ (state, tree) -> NodeID<MatchExpr> in
-        let id = try state.ast.insert(wellFormed: MatchExpr(
+        try state.ast.insert(wellFormed: MatchExpr(
           subject: tree.0.0.0.1,
-          cases: tree.0.1))
-        state.ast.ranges[id] = tree.0.0.0.0.range.upperBounded(by: state.currentIndex)
-        return id
+          cases: tree.0.1,
+          origin: tree.0.0.0.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
   static let matchCase = (
     pattern.and(maybe(take(.where).and(expr))).and(matchCaseBody)
       .map({ (state, tree) -> NodeID<MatchCase> in
-        let id = try state.ast.insert(wellFormed: MatchCase(
+        try state.ast.insert(wellFormed: MatchCase(
           pattern: tree.0.0,
           condition: tree.0.1?.1,
-          body: tree.1))
-        state.ast.ranges[id] = state.ast.ranges[tree.0.0]!.upperBounded(
-          by: state.currentIndex)
-        return id
+          body: tree.1,
+          origin: state.ast[tree.0.0].origin!.upperBounded(by: state.currentIndex)))
       })
   )
 
@@ -2056,12 +2059,11 @@ public enum Parser {
   private static let _conditionalExpr = (
     take(.if).and(conditionalClause).and(conditionalExprBody).and(maybe(conditionalTail))
       .map({ (state, tree) -> NodeID<CondExpr> in
-        let id = try state.ast.insert(wellFormed: CondExpr(
+        try state.ast.insert(wellFormed: CondExpr(
           condition: tree.0.0.1,
           success: tree.0.1,
-          failure: tree.1))
-        state.ast.ranges[id] = tree.0.0.0.range.upperBounded(by: state.currentIndex)
-        return id
+          failure: tree.1,
+          origin: tree.0.0.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
@@ -2075,9 +2077,8 @@ public enum Parser {
       .map({ (state, tree) -> ConditionItem in
         let id = try state.ast.insert(wellFormed: BindingDecl(
           pattern: tree.0.0,
-          initializer: tree.1))
-        state.ast.ranges[id] = state.ast.ranges[tree.0.0]!.upperBounded(
-          by: state.currentIndex)
+          initializer: tree.1,
+          origin: state.ast[tree.0.0].origin!.upperBounded(by: state.currentIndex)))
         return .decl(id)
       }),
     or: expr
@@ -2103,20 +2104,19 @@ public enum Parser {
   static let inoutExpr = (
     take(.ampersand).and(withoutLeadingWhitespace(expr))
       .map({ (state, tree) -> NodeID<InoutExpr> in
-        let id = try state.ast.insert(wellFormed: InoutExpr(
+        try state.ast.insert(wellFormed: InoutExpr(
           operatorRange: tree.0.range,
-          subject: tree.1))
-        state.ast.ranges[id] = tree.0.range.upperBounded(by: state.currentIndex)
-        return id
+          subject: tree.1,
+          origin: tree.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
   static let tupleExpr = (
     take(.lParen).and(maybe(tupleExprElementList)).and(take(.rParen))
       .map({ (state, tree) -> NodeID<TupleExpr> in
-        let id = try state.ast.insert(wellFormed: TupleExpr(elements: tree.0.1 ?? []))
-        state.ast.ranges[id] = tree.0.0.range.upperBounded(by: state.currentIndex)
-        return id
+        try state.ast.insert(wellFormed: TupleExpr(
+          elements: tree.0.1 ?? [],
+          origin: tree.0.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
@@ -2153,9 +2153,7 @@ public enum Parser {
   static let nilExpr = (
     take(.nil)
       .map({ (state, token) -> NodeID<NilExpr> in
-        let id = try state.ast.insert(wellFormed: NilExpr())
-        state.ast.ranges[id] = token.range
-        return id
+        try state.ast.insert(wellFormed: NilExpr(origin: token.range))
       })
   )
 
@@ -2193,12 +2191,11 @@ public enum Parser {
       ])))
       .and(maybe(take(.colon).and(typeExpr)))
       .map({ (state, tree) -> NodeID<BindingPattern> in
-        let id = try state.ast.insert(wellFormed: BindingPattern(
+        try state.ast.insert(wellFormed: BindingPattern(
           introducer: tree.0.0,
           subpattern: tree.0.1,
-          annotation: tree.1?.1))
-        state.ast.ranges[id] = tree.0.0.range!.upperBounded(by: state.currentIndex)
-        return id
+          annotation: tree.1?.1,
+          origin: tree.0.0.range!.upperBounded(by: state.currentIndex)))
       })
   )
 
@@ -2253,8 +2250,9 @@ public enum Parser {
 
       // Default to an expression.
       guard let exprID = try expr.parse(&state) else { return nil }
-      let id = try state.ast.insert(wellFormed: ExprPattern(expr: exprID))
-      state.ast.ranges[id] = state.ast.ranges[exprID]
+      let id = try state.ast.insert(wellFormed: ExprPattern(
+        expr: exprID,
+        origin: state.ast[exprID].origin))
       return AnyPatternID(id)
     })
   )
@@ -2264,20 +2262,16 @@ public enum Parser {
       .map({ (state, token) -> NodeID<NamePattern> in
         let declID = try state.ast.insert(wellFormed: VarDecl(
           identifier: SourceRepresentable(token: token, in: state.lexer.source)))
-        state.ast.ranges[declID] = token.range
-
-        let id = try state.ast.insert(wellFormed: NamePattern(decl: declID))
-        state.ast.ranges[id] = token.range
-        return id
+        return try state.ast.insert(wellFormed: NamePattern(decl: declID, origin: token.range))
       })
   )
 
   static let tuplePattern = (
     take(.lParen).and(maybe(tuplePatternElementList)).and(take(.rParen))
       .map({ (state, tree) -> NodeID<TuplePattern> in
-        let id = try state.ast.insert(wellFormed: TuplePattern(elements: tree.0.1 ?? []))
-        state.ast.ranges[id] = tree.0.0.range.upperBounded(by: tree.1.range.upperBound)
-        return id
+        try state.ast.insert(wellFormed: TuplePattern(
+          elements: tree.0.1 ?? [],
+          origin: tree.0.0.range.upperBounded(by: tree.1.range.upperBound)))
       })
   )
 
@@ -2304,7 +2298,7 @@ public enum Parser {
       // Backtrack and parse an unlabeled element.
       state.restore(from: backup)
       if let value = try pattern.parse(&state) {
-        return TuplePattern.Element(pattern: value)
+        return TuplePattern.Element(label: nil, pattern: value)
       }
 
       return nil
@@ -2314,9 +2308,7 @@ public enum Parser {
   static let wildcardPattern = (
     take(.under)
       .map({ (state, token) -> NodeID<WildcardPattern> in
-        let id = try state.ast.insert(wellFormed: WildcardPattern())
-        state.ast.ranges[id] = token.range
-        return id
+        try state.ast.insert(wellFormed: WildcardPattern(origin: token.range))
       })
   )
 
@@ -2359,36 +2351,38 @@ public enum Parser {
       .and(zeroOrMany(stmt.and(zeroOrMany(take(.semi))).first))
       .and(take(.rBrace))
       .map({ (state, tree) -> NodeID<BraceStmt> in
-        let id = try state.ast.insert(wellFormed: BraceStmt(stmts: tree.0.1))
-        state.ast.ranges[id] = tree.0.0.0.range.upperBounded(by: state.currentIndex)
-        return id
+        try state.ast.insert(wellFormed: BraceStmt(
+          stmts: tree.0.1,
+          origin: tree.0.0.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
   static let discardStmt = (
     take(.under).and(take(.assign)).and(expr)
       .map({ (state, tree) -> NodeID<DiscardStmt> in
-        let id = try state.ast.insert(wellFormed: DiscardStmt(expr: tree.1))
-        state.ast.ranges[id] = tree.0.0.range.upperBounded(by: state.currentIndex)
-        return id
+        try state.ast.insert(wellFormed: DiscardStmt(
+          expr: tree.1,
+          origin: tree.0.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
   static let doWhileStmt = (
     take(.do).and(loopBody).and(take(.while)).and(expr)
       .map({ (state, tree) -> NodeID<DoWhileStmt> in
-        let id = try state.ast.insert(wellFormed: DoWhileStmt(body: tree.0.0.1, condition: tree.1))
-        state.ast.ranges[id] = tree.0.0.0.range.upperBounded(by: state.currentIndex)
-        return id
+        try state.ast.insert(wellFormed: DoWhileStmt(
+          body: tree.0.0.1,
+          condition: tree.1,
+          origin: tree.0.0.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
   static let whileStmt = (
     take(.while).and(conditionalClause).and(loopBody)
       .map({ (state, tree) -> NodeID<WhileStmt> in
-        let id = try state.ast.insert(wellFormed: WhileStmt(condition: tree.0.1, body: tree.1))
-        state.ast.ranges[id] = tree.0.0.range.upperBounded(by: state.currentIndex)
-        return id
+        try state.ast.insert(wellFormed: WhileStmt(
+          condition: tree.0.1,
+          body: tree.1,
+          origin: tree.0.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
@@ -2397,16 +2391,14 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<ForStmt> in
         let decl = try state.ast.insert(wellFormed: BindingDecl(
           pattern: tree.0.0.0.1,
-          initializer: nil))
-        state.ast.ranges[decl] = state.ast.ranges[tree.0.0.0.1]
-
-        let id = try state.ast.insert(wellFormed: ForStmt(
+          initializer: nil,
+          origin: state.ast[tree.0.0.0.1].origin))
+        return try state.ast.insert(wellFormed: ForStmt(
           binding: decl,
           domain: tree.0.0.1,
           filter: tree.0.1,
-          body: tree.1))
-        state.ast.ranges[id] = tree.0.0.0.0.range.upperBounded(by: state.currentIndex)
-        return id
+          body: tree.1,
+          origin: tree.0.0.0.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
@@ -2423,36 +2415,32 @@ public enum Parser {
   static let returnStmt = (
     take(.return).and(maybe(onSameLine(expr)))
       .map({ (state, tree) -> NodeID<ReturnStmt> in
-        let id = try state.ast.insert(wellFormed: ReturnStmt(value: tree.1))
-        state.ast.ranges[id] = tree.0.range.upperBounded(by: state.currentIndex)
-        return id
+        try state.ast.insert(wellFormed: ReturnStmt(
+          value: tree.1,
+          origin: tree.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
   static let yieldStmt = (
     take(.yield).and(onSameLine(expr))
       .map({ (state, tree) -> NodeID<YieldStmt> in
-        let id = try state.ast.insert(wellFormed: YieldStmt(value: tree.1))
-        state.ast.ranges[id] = tree.0.range.upperBounded(by: state.currentIndex)
-        return id
+        try state.ast.insert(wellFormed: YieldStmt(
+          value: tree.1,
+          origin: tree.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
   static let breakStmt = (
     take(.break)
       .map({ (state, token) -> NodeID<BreakStmt> in
-        let id = try state.ast.insert(wellFormed: BreakStmt())
-        state.ast.ranges[id] = token.range
-        return id
+        try state.ast.insert(wellFormed: BreakStmt(origin: token.range))
       })
   )
 
   static let continueStmt = (
     take(.break)
       .map({ (state, token) -> NodeID<ContinueStmt> in
-        let id = try state.ast.insert(wellFormed: ContinueStmt())
-        state.ast.ranges[id] = token.range
-        return id
+        try state.ast.insert(wellFormed: ContinueStmt(origin: token.range))
       })
   )
 
@@ -2465,8 +2453,9 @@ public enum Parser {
       state.restore(from: backup)
 
       if let decl = try bindingDecl.parse(&state) {
-        let id = try state.ast.insert(wellFormed: DeclStmt(decl: AnyDeclID(decl)))
-        state.ast.ranges[id] = state.ast.ranges[decl]
+        let id = try state.ast.insert(wellFormed: DeclStmt(
+          decl: AnyDeclID(decl),
+          origin: state.ast[decl].origin))
         return AnyStmtID(id)
       } else {
         return nil
@@ -2477,7 +2466,7 @@ public enum Parser {
   static let conditionalBindingStmt = (
     bindingDecl.and(take(.else)).and(conditionalBindingFallback)
       .map({ (state, tree) -> NodeID<CondBindingStmt> in
-        let bindingRange = state.ast.ranges[tree.0.0]!
+        let bindingRange = state.ast[tree.0.0].origin!
 
         if state.ast[tree.0.0].initializer == nil {
           throw DiagnosedError(.error(
@@ -2485,11 +2474,10 @@ public enum Parser {
             range: bindingRange.upperBounded(by: bindingRange.lowerBound)))
         }
 
-        let id = try state.ast.insert(wellFormed: CondBindingStmt(
+        return try state.ast.insert(wellFormed: CondBindingStmt(
           binding: tree.0.0,
-          fallback: tree.1))
-        state.ast.ranges[id] = bindingRange.upperBounded(by: state.currentIndex)
-        return id
+          fallback: tree.1,
+          origin: bindingRange.upperBounded(by: state.currentIndex)))
       })
   )
 
@@ -2514,18 +2502,14 @@ public enum Parser {
   static let declStmt = (
     Apply(parseDecl)
       .map({ (state, decl) -> NodeID<DeclStmt> in
-        let id = try state.ast.insert(wellFormed: DeclStmt(decl: decl))
-        state.ast.ranges[id] = state.ast.ranges[decl]
-        return id
+        try state.ast.insert(wellFormed: DeclStmt(decl: decl, origin: state.ast[decl].origin))
       })
   )
 
   static let exprStmt = (
     expr
       .map({ (state, expr) -> NodeID<ExprStmt> in
-        let id = try state.ast.insert(wellFormed: ExprStmt(expr: expr))
-        state.ast.ranges[id] = state.ast.ranges[expr]
-        return id
+        try state.ast.insert(wellFormed: ExprStmt(expr: expr, origin: state.ast[expr].origin))
       })
   )
 
@@ -2564,9 +2548,9 @@ public enum Parser {
 
         let id = try state.ast.insert(wellFormed: ExistentialTypeExpr(
           traits: traits,
-          whereClause: clause))
-        state.ast.ranges[id] = head.range.upperBounded(
-          by: clause?.range?.upperBound ?? state.ast.ranges[traits.last!]!.upperBound)
+          whereClause: clause,
+          origin: head.range.upperBounded(
+            by: clause?.range?.upperBound ?? state.ast[traits.last!].origin!.upperBound)))
         return AnyTypeExprID(id)
 
       default:
@@ -2581,7 +2565,7 @@ public enum Parser {
         if let converted = NodeID<NameExpr>(id) {
           return converted
         } else {
-          throw DiagnosedError(expected("type name", at: state.ast.ranges[id]!.first()))
+          throw DiagnosedError(expected("type name", at: state.ast[id].origin!.first()))
         }
       })
   )
@@ -2589,7 +2573,7 @@ public enum Parser {
   static let compoundTypeExpr = (
     Apply<ParserState, AnyTypeExprID>({ (state) -> AnyTypeExprID? in
       guard var head = try primaryTypeExpr.parse(&state) else { return nil }
-      let headRange = state.ast.ranges[head]!
+      let headRange = state.ast[head].origin!
 
       while true {
         if state.take(.dot) != nil {
@@ -2606,7 +2590,6 @@ public enum Parser {
               origin: origin)
           })
 
-          state.ast.ranges[member] = headRange.upperBounded(by: state.currentIndex)
           head = AnyTypeExprID(member)
           continue
         }
@@ -2618,8 +2601,8 @@ public enum Parser {
 
           let id = try state.ast.insert(wellFormed: ConformanceLensTypeExpr(
             subject: head,
-            lens: lens))
-          state.ast.ranges[id] = headRange.upperBounded(by: state.currentIndex)
+            lens: lens,
+            origin: headRange.upperBounded(by: state.currentIndex)))
           head = AnyTypeExprID(id)
           continue
         }
@@ -2643,20 +2626,19 @@ public enum Parser {
   static let primaryTypeDeclRef = (
     typeIdentifier.and(maybe(staticArgumentList))
       .map({ (state, tree) -> NodeID<NameExpr> in
-        let id = try state.ast.insert(wellFormed: NameExpr(
+        try state.ast.insert(wellFormed: NameExpr(
           name: tree.0,
-          arguments: tree.1 ?? []))
-        state.ast.ranges[id] = tree.0.range!.upperBounded(by: state.currentIndex)
-        return id
+          arguments: tree.1 ?? [],
+          origin: tree.0.range!.upperBounded(by: state.currentIndex)))
       })
   )
 
   static let tupleTypeExpr = (
     take(.lBrace).and(maybe(tupleTypeExprElementList)).and(take(.rBrace))
       .map({ (state, tree) -> NodeID<TupleTypeExpr> in
-        let id = try state.ast.insert(wellFormed: TupleTypeExpr(elements: tree.0.1 ?? []))
-        state.ast.ranges[id] = tree.0.0.range.upperBounded(by: tree.1.range.upperBound)
-        return id
+        try state.ast.insert(wellFormed: TupleTypeExpr(
+          elements: tree.0.1 ?? [],
+          origin: tree.0.0.range.upperBounded(by: tree.1.range.upperBound)))
       })
   )
 
@@ -2724,7 +2706,6 @@ public enum Parser {
     or: lambdaEnvironment.and(typeErasedLambdaTypeExpr)
       .map({ (state, tree) in
         state.ast[tree.1].incorporate(environment: tree.0)
-        state.ast.ranges[tree.1]!.lowerBound = tree.0.range!.lowerBound
         return tree.1
       })
   )
@@ -2735,12 +2716,11 @@ public enum Parser {
       .and(take(.arrow))
       .and(typeExpr)
       .map({ (state, tree) -> NodeID<LambdaTypeExpr> in
-        let id = try state.ast.insert(wellFormed: LambdaTypeExpr(
+        try state.ast.insert(wellFormed: LambdaTypeExpr(
           receiverEffect: tree.0.0.1,
           parameters: tree.0.0.0.0.1 ?? [],
-          output: tree.1))
-        state.ast.ranges[id] = tree.0.0.0.0.0.range.upperBounded(by: state.currentIndex)
-        return id
+          output: tree.1,
+          origin: tree.0.0.0.0.0.range.upperBounded(by: state.currentIndex)))
       })
   )
 
@@ -2781,11 +2761,12 @@ public enum Parser {
         if let expr = tree.0.1 {
           return SourceRepresentable(value: expr, range: range)
         } else {
-          let expr = try state.ast.insert(wellFormed: TupleTypeExpr())
-          state.ast.ranges[expr] = SourceRange(
-            in: state.lexer.source,
-            from: tree.0.0.range.upperBound,
-            to: tree.1.range.lowerBound)
+          let expr = try state.ast.insert(wellFormed: TupleTypeExpr(
+            elements: [],
+            origin: SourceRange(
+              in: state.lexer.source,
+              from: tree.0.0.range.upperBound,
+              to: tree.1.range.lowerBound)))
           return SourceRepresentable(value: AnyTypeExprID(expr), range: range)
         }
       })
@@ -2794,9 +2775,7 @@ public enum Parser {
   static let wildcardTypeExpr = (
     take(.under)
       .map({ (state, token) -> NodeID<WildcardTypeExpr> in
-        let id = try state.ast.insert(wellFormed: WildcardTypeExpr())
-        state.ast.ranges[id] = token.range
-        return id
+        try state.ast.insert(wellFormed: WildcardTypeExpr(origin: token.range))
       })
   )
 
@@ -2809,15 +2788,12 @@ public enum Parser {
     maybe(passingConvention)
       .andCollapsingSoftFailures(typeExpr)
       .map({ (state, tree) -> NodeID<ParameterTypeExpr> in
-        let id = try state.ast.insert(wellFormed: ParameterTypeExpr(
+        try state.ast.insert(wellFormed: ParameterTypeExpr(
           convention: tree.0 ?? SourceRepresentable(value: .let),
-          bareType: tree.1))
-
-        state.ast.ranges[id] = (
-          tree.0?.range.map({ $0.upperBounded(by: state.currentIndex) })
-          ?? state.ast.ranges[tree.1])
-
-        return id
+          bareType: tree.1,
+          origin: (
+            tree.0?.range.map({ $0.upperBounded(by: state.currentIndex) })
+            ?? state.ast[tree.1].origin)))
       })
   )
 
@@ -2910,7 +2886,7 @@ public enum Parser {
         }
         return SourceRepresentable(
           value: .equality(l: lhs, r: rhs),
-          range: state.ast.ranges[lhs]!.upperBounded(by: state.currentIndex))
+          range: state.ast[lhs].origin!.upperBounded(by: state.currentIndex))
       }
 
       // conformance-constraint
@@ -2920,7 +2896,7 @@ public enum Parser {
         }
         return SourceRepresentable(
           value: .conformance(l: lhs, traits: traits),
-          range: state.ast.ranges[lhs]!.upperBounded(by: state.currentIndex))
+          range: state.ast[lhs].origin!.upperBounded(by: state.currentIndex))
       }
 
       throw DiagnosedError(expected("constraint operator", at: state.currentLocation))

--- a/Sources/Compiler/Parse/Parser.swift
+++ b/Sources/Compiler/Parse/Parser.swift
@@ -946,7 +946,7 @@ public enum Parser {
     }
 
     let origin: SourceRange
-    if let startIndex = introducer.range?.lowerBound {
+    if let startIndex = introducer.origin?.lowerBound {
       origin = state.range(from: startIndex)
     } else {
       switch body! {
@@ -1215,7 +1215,7 @@ public enum Parser {
           introducer: tree.0,
           receiver: receiver,
           body: tree.1,
-          origin: tree.0.range!.extended(upTo: state.currentIndex)))
+          origin: tree.0.origin!.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -1342,7 +1342,7 @@ public enum Parser {
           annotation: tree.0.1?.1,
           defaultValue: tree.1?.1,
           origin: state.range(
-            from: tree.0.0.label?.range!.lowerBound ?? tree.0.0.name.range!.lowerBound)))
+            from: tree.0.0.label?.origin!.lowerBound ?? tree.0.0.name.origin!.lowerBound)))
       })
   )
 
@@ -1572,7 +1572,7 @@ public enum Parser {
       if !state.hasLeadingWhitespace {
         // If there isn't any leading whitespace before the next expression but the operator is on
         // a different line, we may be looking at the start of a prefix expression.
-        let rangeBefore = state.ast[lhs].origin!.upperBound ..< operatorStem.range!.lowerBound
+        let rangeBefore = state.ast[lhs].origin!.upperBound ..< operatorStem.origin!.lowerBound
         if state.lexer.source.contents[rangeBefore].contains(where: { $0.isNewline }) {
           state.restore(from: backup)
           break
@@ -1580,7 +1580,7 @@ public enum Parser {
 
         // Otherwise, complain about missing whitespaces.
         state.diagnostics.append(.diagnose(
-          infixOperatorRequiresWhitespacesAt: operatorStem.range))
+          infixOperatorRequiresWhitespacesAt: operatorStem.origin))
       }
 
       // If we can't parse an operand, the tail is empty.
@@ -1591,7 +1591,7 @@ public enum Parser {
 
       let `operator` = try state.ast.insert(wellFormed: NameExpr(
         name: SourceRepresentable(value: Name(stem: operatorStem.value, notation: .infix)),
-        origin: operatorStem.range))
+        origin: operatorStem.origin))
       tail.append(SequenceExpr.TailElement(operator: `operator`, operand: operand))
     }
 
@@ -1671,8 +1671,8 @@ public enum Parser {
           domain: .expr(tree.1),
           name: SourceRepresentable(
             value: Name(stem: tree.0.value, notation: .prefix),
-            range: tree.0.range),
-          origin: tree.0.range!.extended(upTo: state.ast[tree.1].origin!.upperBound)))
+            range: tree.0.origin),
+          origin: tree.0.origin!.extended(upTo: state.ast[tree.1].origin!.upperBound)))
 
         let call = try state.ast.insert(wellFormed: FunCallExpr(
           callee: AnyExprID(callee),
@@ -1699,8 +1699,8 @@ public enum Parser {
           let callee = try state.ast.insert(wellFormed: NameExpr(
             domain: .expr(tree.0),
             name: SourceRepresentable(
-              value: Name(stem: oper.value, notation: .postfix), range: oper.range),
-            origin: state.ast[tree.0].origin!.extended(upTo: oper.range!.upperBound)))
+              value: Name(stem: oper.value, notation: .postfix), range: oper.origin),
+            origin: state.ast[tree.0].origin!.extended(upTo: oper.origin!.upperBound)))
 
           let call = try state.ast.insert(wellFormed: FunCallExpr(
             callee: AnyExprID(callee),
@@ -1973,7 +1973,7 @@ public enum Parser {
         try state.ast.insert(wellFormed: NameExpr(
           name: tree.0,
           arguments: tree.1 ?? [],
-          origin: tree.0.range!.extended(upTo: state.currentIndex)))
+          origin: tree.0.origin!.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2189,7 +2189,7 @@ public enum Parser {
           introducer: tree.0.0,
           subpattern: tree.0.1,
           annotation: tree.1?.1,
-          origin: tree.0.0.range!.extended(upTo: state.currentIndex)))
+          origin: tree.0.0.origin!.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2544,7 +2544,7 @@ public enum Parser {
           traits: traits,
           whereClause: clause,
           origin: head.origin.extended(
-            upTo: clause?.range?.upperBound ?? state.ast[traits.last!].origin!.upperBound)))
+            upTo: clause?.origin?.upperBound ?? state.ast[traits.last!].origin!.upperBound)))
         return AnyTypeExprID(id)
 
       default:
@@ -2623,7 +2623,7 @@ public enum Parser {
         try state.ast.insert(wellFormed: NameExpr(
           name: tree.0,
           arguments: tree.1 ?? [],
-          origin: tree.0.range!.extended(upTo: state.currentIndex)))
+          origin: tree.0.origin!.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2786,7 +2786,7 @@ public enum Parser {
           convention: tree.0 ?? SourceRepresentable(value: .let),
           bareType: tree.1,
           origin: state.range(
-            from: tree.0?.range!.lowerBound ?? state.ast[tree.1].origin!.lowerBound)))
+            from: tree.0?.origin!.lowerBound ?? state.ast[tree.1].origin!.lowerBound)))
       })
   )
 
@@ -2980,8 +2980,8 @@ public enum Parser {
           throw DiagnosedError(expected("operator", at: state.currentLocation))
         }
 
-        let stem = String(state.lexer.source[oper.range!])
-        let range = head.origin.extended(upTo: oper.range!.upperBound)
+        let stem = String(state.lexer.source[oper.origin!])
+        let range = head.origin.extended(upTo: oper.origin!.upperBound)
 
         switch head.kind {
         case .infix:

--- a/Sources/Compiler/Parse/Parser.swift
+++ b/Sources/Compiler/Parse/Parser.swift
@@ -1215,7 +1215,7 @@ public enum Parser {
           introducer: tree.0,
           receiver: receiver,
           body: tree.1,
-          origin: tree.0.range!.upperBounded(by: state.currentIndex)))
+          origin: tree.0.range!.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -1341,10 +1341,8 @@ public enum Parser {
           identifier: tree.0.0.name,
           annotation: tree.0.1?.1,
           defaultValue: tree.1?.1,
-          origin: SourceRange(
-            in: state.lexer.source,
-            from: tree.0.0.label?.range!.lowerBound ?? tree.0.0.name.range!.lowerBound,
-            to: state.currentIndex)))
+          origin: state.range(
+            from: tree.0.0.label?.range!.lowerBound ?? tree.0.0.name.range!.lowerBound)))
       })
   )
 
@@ -1412,7 +1410,7 @@ public enum Parser {
       .map({ (state, tree) -> SourceRepresentable<GenericClause> in
         return SourceRepresentable(
           value: GenericClause(parameters: tree.0.0.1, whereClause: tree.0.1),
-          range: tree.0.0.0.range.upperBounded(by: state.currentIndex))
+          range: tree.0.0.0.range.extended(upTo: state.currentIndex))
       })
   )
 
@@ -1434,10 +1432,7 @@ public enum Parser {
           identifier: SourceRepresentable(token: tree.0.0.1, in: state.lexer.source),
           conformances: tree.0.1?.1 ?? [],
           defaultValue: tree.1?.1,
-          origin: SourceRange(
-            in: state.lexer.source,
-            from: tree.0.0.0?.range.lowerBound ?? tree.0.0.1.range.lowerBound,
-            to: state.currentIndex)))
+          origin: state.range(from: tree.0.0.0?.range.lowerBound ?? tree.0.0.1.range.lowerBound)))
         return .type(id)
       })
   )
@@ -1451,7 +1446,7 @@ public enum Parser {
           identifier: SourceRepresentable(token: tree.0.0.1, in: state.lexer.source),
           annotation: tree.0.1.1,
           defaultValue: tree.1?.1,
-          origin: tree.0.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.0.range.extended(upTo: state.currentIndex)))
         return .value(id)
       })
   )
@@ -1533,7 +1528,7 @@ public enum Parser {
       left: lhs,
       right: rhs,
       kind: castKind,
-      origin: state.ast[lhs].origin!.upperBounded(by: state.currentIndex)))
+      origin: state.ast[lhs].origin!.extended(upTo: state.currentIndex)))
     lhs = AnyExprID(expr)
   }
 
@@ -1554,7 +1549,7 @@ public enum Parser {
     let expr = try state.ast.insert(wellFormed: AssignExpr(
       left: lhs,
       right: rhs,
-      origin: state.ast[lhs].origin!.upperBounded(by: state.currentIndex)))
+      origin: state.ast[lhs].origin!.extended(upTo: state.currentIndex)))
     lhs = AnyExprID(expr)
   }
 
@@ -1605,7 +1600,7 @@ public enum Parser {
     let expr = try state.ast.insert(wellFormed: SequenceExpr(
       head: lhs,
       tail: tail,
-      origin: state.ast[lhs].origin!.upperBounded(by: state.currentIndex)))
+      origin: state.ast[lhs].origin!.extended(upTo: state.currentIndex)))
     lhs = AnyExprID(expr)
     return true
   }
@@ -1628,7 +1623,7 @@ public enum Parser {
           output: tree.0.1,
           body: .block(tree.1),
           isInExprContext: true,
-          origin: tree.0.0.0.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.0.0.0.range.extended(upTo: state.currentIndex)))
 
         return try state.ast.insert(wellFormed: AsyncExpr(
           decl: decl,
@@ -1647,8 +1642,7 @@ public enum Parser {
           explicitCaptures: tree.0.0.1 ?? [],
           body: .expr(tree.1),
           isInExprContext: true,
-          origin: tree.0.0.0.range.upperBounded(by: state.currentIndex)))
-
+          origin: tree.0.0.0.range.extended(upTo: state.currentIndex)))
         return try state.ast.insert(wellFormed: AsyncExpr(
           decl: decl,
           origin: state.ast[decl].origin))
@@ -1664,7 +1658,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<AwaitExpr> in
         try state.ast.insert(wellFormed: AwaitExpr(
           operand: tree.1,
-          origin: tree.0.range.upperBounded(by: state.ast[tree.1].origin!.upperBound)))
+          origin: tree.0.range.extended(upTo: state.ast[tree.1].origin!.upperBound)))
       })
   )
 
@@ -1677,7 +1671,7 @@ public enum Parser {
           name: SourceRepresentable(
             value: Name(stem: tree.0.value, notation: .prefix),
             range: tree.0.range),
-          origin: tree.0.range!.upperBounded(by: state.ast[tree.1].origin!.upperBound)))
+          origin: tree.0.range!.extended(upTo: state.ast[tree.1].origin!.upperBound)))
 
         let call = try state.ast.insert(wellFormed: FunCallExpr(
           callee: AnyExprID(callee),
@@ -1705,7 +1699,7 @@ public enum Parser {
             domain: .expr(tree.0),
             name: SourceRepresentable(
               value: Name(stem: oper.value, notation: .postfix), range: oper.range),
-            origin: state.ast[tree.0].origin!.upperBounded(by: oper.range!.upperBound)))
+            origin: state.ast[tree.0].origin!.extended(upTo: oper.range!.upperBound)))
 
           let call = try state.ast.insert(wellFormed: FunCallExpr(
             callee: AnyExprID(callee),
@@ -1763,7 +1757,7 @@ public enum Parser {
         if state.take(.dot) != nil {
           // labeled-member-expr
           if let member = try primaryDeclRef.parse(&state) {
-            let origin = headRange.upperBounded(by: state.currentIndex)
+            let origin = headRange.extended(upTo: state.currentIndex)
             try state.ast.modify(at: member, { (node: NameExpr) -> NameExpr in
               NameExpr(
                 domain: .expr(head),
@@ -1781,7 +1775,7 @@ public enum Parser {
             head = try AnyExprID(state.ast.insert(wellFormed: TupleMemberExpr(
               tuple: head,
               index: index,
-              origin: headRange.upperBounded(by: state.currentIndex))))
+              origin: headRange.extended(upTo: state.currentIndex))))
             continue
           }
 
@@ -1801,7 +1795,7 @@ public enum Parser {
           head = try AnyExprID(state.ast.insert(wellFormed: FunCallExpr(
             callee: head,
             arguments: arguments,
-            origin: headRange.upperBounded(by: state.currentIndex))))
+            origin: headRange.extended(upTo: state.currentIndex))))
           continue
         }
 
@@ -1815,7 +1809,7 @@ public enum Parser {
           head = try AnyExprID(state.ast.insert(wellFormed: SubscriptCallExpr(
             callee: head,
             arguments: arguments,
-            origin: headRange.upperBounded(by: state.currentIndex))))
+            origin: headRange.extended(upTo: state.currentIndex))))
           continue
         }
 
@@ -1859,8 +1853,8 @@ public enum Parser {
   static let staticValueMemberExpr = (
     primaryTypeExpr.and(take(.dot)).and(primaryDeclRef)
       .map({ (state, tree) -> NodeID<NameExpr> in
-        let origin = state.ast[tree.0.0].origin!.upperBounded(
-          by: state.ast[tree.1].origin!.upperBound)
+        let origin = state.ast[tree.0.0].origin!.extended(
+          upTo: state.ast[tree.1].origin!.upperBound)
         try state.ast.modify(at: tree.1, { (node: NameExpr) -> NameExpr in
           NameExpr(
             domain: .type(tree.0.0),
@@ -1937,7 +1931,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<BufferLiteralExpr> in
         try state.ast.insert(wellFormed: BufferLiteralExpr(
           elements: tree.0.1 ?? [],
-          origin: tree.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -1951,7 +1945,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<MapLiteralExpr> in
         try state.ast.insert(wellFormed: MapLiteralExpr(
           elements: tree.0.1,
-          origin: tree.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -1978,7 +1972,7 @@ public enum Parser {
         try state.ast.insert(wellFormed: NameExpr(
           name: tree.0,
           arguments: tree.1 ?? [],
-          origin: tree.0.range!.upperBounded(by: state.currentIndex)))
+          origin: tree.0.range!.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -1990,7 +1984,7 @@ public enum Parser {
             domain: .implicit,
             name: node.name,
             arguments: node.arguments,
-            origin: tree.0.range.upperBounded(by: node.origin!.upperBound))
+            origin: tree.0.range.extended(upTo: node.origin!.upperBound))
         })
         return tree.1
       })
@@ -2009,8 +2003,7 @@ public enum Parser {
           output: signature.output,
           body: tree.1,
           isInExprContext: true,
-          origin: tree.0.0.0.range.upperBounded(by: state.currentIndex)))
-
+          origin: tree.0.0.0.range.extended(upTo: state.currentIndex)))
         return try state.ast.insert(wellFormed: LambdaExpr(
           decl: decl,
           origin: state.ast[decl].origin))
@@ -2030,7 +2023,7 @@ public enum Parser {
         try state.ast.insert(wellFormed: MatchExpr(
           subject: tree.0.0.0.1,
           cases: tree.0.1,
-          origin: tree.0.0.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.0.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2041,7 +2034,7 @@ public enum Parser {
           pattern: tree.0.0,
           condition: tree.0.1?.1,
           body: tree.1,
-          origin: state.ast[tree.0.0].origin!.upperBounded(by: state.currentIndex)))
+          origin: state.ast[tree.0.0].origin!.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2063,7 +2056,7 @@ public enum Parser {
           condition: tree.0.0.1,
           success: tree.0.1,
           failure: tree.1,
-          origin: tree.0.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2078,7 +2071,7 @@ public enum Parser {
         let id = try state.ast.insert(wellFormed: BindingDecl(
           pattern: tree.0.0,
           initializer: tree.1,
-          origin: state.ast[tree.0.0].origin!.upperBounded(by: state.currentIndex)))
+          origin: state.ast[tree.0.0].origin!.extended(upTo: state.currentIndex)))
         return .decl(id)
       }),
     or: expr
@@ -2107,7 +2100,7 @@ public enum Parser {
         try state.ast.insert(wellFormed: InoutExpr(
           operatorRange: tree.0.range,
           subject: tree.1,
-          origin: tree.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2116,7 +2109,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<TupleExpr> in
         try state.ast.insert(wellFormed: TupleExpr(
           elements: tree.0.1 ?? [],
-          origin: tree.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2195,7 +2188,7 @@ public enum Parser {
           introducer: tree.0.0,
           subpattern: tree.0.1,
           annotation: tree.1?.1,
-          origin: tree.0.0.range!.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.range!.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2230,7 +2223,7 @@ public enum Parser {
 
       return SourceRepresentable(
         value: introducer,
-        range: head.range.upperBounded(by: state.currentIndex))
+        range: head.range.extended(upTo: state.currentIndex))
     })
   )
 
@@ -2271,7 +2264,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<TuplePattern> in
         try state.ast.insert(wellFormed: TuplePattern(
           elements: tree.0.1 ?? [],
-          origin: tree.0.0.range.upperBounded(by: tree.1.range.upperBound)))
+          origin: tree.0.0.range.extended(upTo: tree.1.range.upperBound)))
       })
   )
 
@@ -2353,7 +2346,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<BraceStmt> in
         try state.ast.insert(wellFormed: BraceStmt(
           stmts: tree.0.1,
-          origin: tree.0.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2362,7 +2355,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<DiscardStmt> in
         try state.ast.insert(wellFormed: DiscardStmt(
           expr: tree.1,
-          origin: tree.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2372,7 +2365,7 @@ public enum Parser {
         try state.ast.insert(wellFormed: DoWhileStmt(
           body: tree.0.0.1,
           condition: tree.1,
-          origin: tree.0.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2382,7 +2375,7 @@ public enum Parser {
         try state.ast.insert(wellFormed: WhileStmt(
           condition: tree.0.1,
           body: tree.1,
-          origin: tree.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2398,7 +2391,7 @@ public enum Parser {
           domain: tree.0.0.1,
           filter: tree.0.1,
           body: tree.1,
-          origin: tree.0.0.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.0.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2417,7 +2410,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<ReturnStmt> in
         try state.ast.insert(wellFormed: ReturnStmt(
           value: tree.1,
-          origin: tree.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2426,7 +2419,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<YieldStmt> in
         try state.ast.insert(wellFormed: YieldStmt(
           value: tree.1,
-          origin: tree.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2471,13 +2464,13 @@ public enum Parser {
         if state.ast[tree.0.0].initializer == nil {
           throw DiagnosedError(.error(
             "conditional binding requires an initializer",
-            range: bindingRange.upperBounded(by: bindingRange.lowerBound)))
+            range: bindingRange.extended(upTo: bindingRange.lowerBound)))
         }
 
         return try state.ast.insert(wellFormed: CondBindingStmt(
           binding: tree.0.0,
           fallback: tree.1,
-          origin: bindingRange.upperBounded(by: state.currentIndex)))
+          origin: bindingRange.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2549,8 +2542,8 @@ public enum Parser {
         let id = try state.ast.insert(wellFormed: ExistentialTypeExpr(
           traits: traits,
           whereClause: clause,
-          origin: head.range.upperBounded(
-            by: clause?.range?.upperBound ?? state.ast[traits.last!].origin!.upperBound)))
+          origin: head.range.extended(
+            upTo: clause?.range?.upperBound ?? state.ast[traits.last!].origin!.upperBound)))
         return AnyTypeExprID(id)
 
       default:
@@ -2581,7 +2574,7 @@ public enum Parser {
             throw DiagnosedError(expected("type member name", at: state.currentLocation))
           }
 
-          let origin = headRange.upperBounded(by: state.currentIndex)
+          let origin = headRange.extended(upTo: state.currentIndex)
           try state.ast.modify(at: member, { (node: NameExpr) -> NameExpr in
             NameExpr(
               domain: .type(head),
@@ -2602,7 +2595,7 @@ public enum Parser {
           let id = try state.ast.insert(wellFormed: ConformanceLensTypeExpr(
             subject: head,
             lens: lens,
-            origin: headRange.upperBounded(by: state.currentIndex)))
+            origin: headRange.extended(upTo: state.currentIndex)))
           head = AnyTypeExprID(id)
           continue
         }
@@ -2629,7 +2622,7 @@ public enum Parser {
         try state.ast.insert(wellFormed: NameExpr(
           name: tree.0,
           arguments: tree.1 ?? [],
-          origin: tree.0.range!.upperBounded(by: state.currentIndex)))
+          origin: tree.0.range!.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2638,7 +2631,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<TupleTypeExpr> in
         try state.ast.insert(wellFormed: TupleTypeExpr(
           elements: tree.0.1 ?? [],
-          origin: tree.0.0.range.upperBounded(by: tree.1.range.upperBound)))
+          origin: tree.0.0.range.extended(upTo: tree.1.range.upperBound)))
       })
   )
 
@@ -2720,7 +2713,7 @@ public enum Parser {
           receiverEffect: tree.0.0.1,
           parameters: tree.0.0.0.0.1 ?? [],
           output: tree.1,
-          origin: tree.0.0.0.0.0.range.upperBounded(by: state.currentIndex)))
+          origin: tree.0.0.0.0.0.range.extended(upTo: state.currentIndex)))
       })
   )
 
@@ -2757,7 +2750,7 @@ public enum Parser {
   static let lambdaEnvironment = (
     take(.lBrack).and(maybe(typeExpr)).and(take(.rBrack))
       .map({ (state, tree) -> SourceRepresentable<AnyTypeExprID> in
-        let range = tree.0.0.range.upperBounded(by: tree.1.range.upperBound)
+        let range = tree.0.0.range.extended(upTo: tree.1.range.upperBound)
         if let expr = tree.0.1 {
           return SourceRepresentable(value: expr, range: range)
         } else {
@@ -2791,9 +2784,8 @@ public enum Parser {
         try state.ast.insert(wellFormed: ParameterTypeExpr(
           convention: tree.0 ?? SourceRepresentable(value: .let),
           bareType: tree.1,
-          origin: (
-            tree.0?.range.map({ $0.upperBounded(by: state.currentIndex) })
-            ?? state.ast[tree.1].origin)))
+          origin: state.range(
+            from: tree.0?.range!.lowerBound ?? state.ast[tree.1].origin!.lowerBound)))
       })
   )
 
@@ -2860,7 +2852,7 @@ public enum Parser {
       .map({ (state, tree) -> SourceRepresentable<WhereClause> in
         SourceRepresentable(
           value: WhereClause(constraints: tree.1),
-          range: tree.0.range.upperBounded(by: state.currentIndex))
+          range: tree.0.range.extended(upTo: state.currentIndex))
       })
   )
 
@@ -2886,7 +2878,7 @@ public enum Parser {
         }
         return SourceRepresentable(
           value: .equality(l: lhs, r: rhs),
-          range: state.ast[lhs].origin!.upperBounded(by: state.currentIndex))
+          range: state.ast[lhs].origin!.extended(upTo: state.currentIndex))
       }
 
       // conformance-constraint
@@ -2896,7 +2888,7 @@ public enum Parser {
         }
         return SourceRepresentable(
           value: .conformance(l: lhs, traits: traits),
-          range: state.ast[lhs].origin!.upperBounded(by: state.currentIndex))
+          range: state.ast[lhs].origin!.extended(upTo: state.currentIndex))
       }
 
       throw DiagnosedError(expected("constraint operator", at: state.currentLocation))
@@ -2908,7 +2900,7 @@ public enum Parser {
       .map({ (state, tree) -> SourceRepresentable<WhereClause.ConstraintExpr> in
         SourceRepresentable(
           value: .value(tree.1),
-          range: tree.0.range.upperBounded(by: state.currentIndex))
+          range: tree.0.range.extended(upTo: state.currentIndex))
       })
   )
 
@@ -2988,7 +2980,7 @@ public enum Parser {
         }
 
         let stem = String(state.lexer.source[oper.range!])
-        let range = head.range.upperBounded(by: oper.range!.upperBound)
+        let range = head.range.extended(upTo: oper.range!.upperBound)
 
         switch head.kind {
         case .infix:
@@ -3025,7 +3017,7 @@ public enum Parser {
           value: Attribute(
             name: SourceRepresentable(token: tree.0, in: state.lexer.source),
             arguments: tree.1 ?? []),
-          range: tree.0.range.upperBounded(by: state.currentIndex))
+          range: tree.0.range.extended(upTo: state.currentIndex))
       })
   )
 

--- a/Sources/Compiler/Parse/SourceRange.swift
+++ b/Sources/Compiler/Parse/SourceRange.swift
@@ -37,8 +37,17 @@ public struct SourceRange: Hashable {
   }
 
   /// Returns a copy of `self` with the upper bound set to `newUpperBound`.
-  public func upperBounded(by newUpperBound: String.Index) -> SourceRange {
+  public func extended(upTo newUpperBound: String.Index) -> SourceRange {
     SourceRange(in: source, from: lowerBound, to: newUpperBound)
+  }
+
+  /// Returns a copy of `self` extended to cover `other`.
+  public func extended(toCover other: SourceRange) -> SourceRange {
+    precondition(source == other.source, "incompatible ranges")
+    return SourceRange(
+      in: source,
+      from: Swift.min(lowerBound, other.lowerBound),
+      to  : Swift.max(upperBound, other.upperBound))
   }
 
   public static func ..< (l: SourceRange, r: SourceRange) -> SourceRange {

--- a/Sources/Compiler/Parse/Token.swift
+++ b/Sources/Compiler/Parse/Token.swift
@@ -98,8 +98,8 @@ public struct Token {
   /// The kind of the token.
   public internal(set) var kind: Kind
 
-  /// The range of the token in the source file from which it has been parsed.
-  public internal(set) var range: SourceRange
+  /// The source range from which `self` was extracted.
+  public internal(set) var origin: SourceRange
 
   /// Indicates whether `self` is a keyword.
   public var isKeyword: Bool {

--- a/Sources/Compiler/TypeChecking/ConstraintGenerator.swift
+++ b/Sources/Compiler/TypeChecking/ConstraintGenerator.swift
@@ -331,7 +331,8 @@ struct ConstraintGenerator {
         switch candidates.count {
         case 0:
           let name = Name(stem: "init", labels: labels)
-          diagnostics.append(.diagnose(undefinedName: "\(name)", at: checker.program.ast[c].name.range))
+          diagnostics.append(
+            .diagnose(undefinedName: "\(name)", at: checker.program.ast[c].name.origin))
           assignToError(id)
           return
 
@@ -356,9 +357,8 @@ struct ConstraintGenerator {
 
       case TraitDecl.self:
         let trait = TraitType(NodeID(rawValue: d.rawValue), ast: checker.program.ast)
-        diagnostics.append(.diagnose(
-          cannotConstructTrait: trait,
-          at: checker.program.ast[callee].origin))
+        diagnostics.append(
+          .diagnose(cannotConstructTrait: trait, at: checker.program.ast[callee].origin))
         assignToError(id)
 
       case TypeAliasDecl.self:
@@ -561,7 +561,8 @@ struct ConstraintGenerator {
 
       let candidates = checker.resolve(expr.name.value, inScope: scope)
       if candidates.isEmpty {
-        diagnostics.append(.diagnose(undefinedName: expr.name.value.description, at: expr.name.range))
+        diagnostics.append(
+          .diagnose(undefinedName: expr.name.value.description, at: expr.name.origin))
         assignToError(id)
         return
       }
@@ -615,7 +616,7 @@ struct ConstraintGenerator {
           checker.referredDecls[id] = .direct(AnyDeclID(checker.program.ast.builtinDecl))
         } else {
           diagnostics.append(
-            .diagnose(undefinedName: symbolName, at: checker.program.ast[id].name.range))
+            .diagnose(undefinedName: symbolName, at: checker.program.ast[id].name.origin))
           assignToError(id)
         }
 

--- a/Sources/Compiler/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/Compiler/TypeChecking/TypeChecker+Diagnostics.swift
@@ -10,7 +10,7 @@ extension Diagnostic {
     ambiguousUse expr: NodeID<NameExpr>,
     in ast: AST
   ) -> Diagnostic {
-    .error("ambiguous use of '\(ast[expr].name)'", range: ast.ranges[expr])
+    .error("ambiguous use of '\(ast[expr].name)'", range: ast[expr].origin)
   }
 
   static func diagnose(
@@ -80,7 +80,7 @@ extension Diagnostic {
     doesNotEvaluateToType expr: AnyExprID,
     in ast: AST
   ) -> Diagnostic {
-    .error("expression does not evaluate to a type", range: ast.ranges[expr])
+    .error("expression does not evaluate to a type", range: ast[expr].origin)
   }
 
   static func diagnose(

--- a/Sources/Compiler/TypeChecking/TypeChecker.swift
+++ b/Sources/Compiler/TypeChecking/TypeChecker.swift
@@ -328,7 +328,7 @@ public struct TypeChecker {
     case nil:
       declRequests[id] = .typeCheckingStarted
     case .typeCheckingStarted:
-      diagnostics.insert(.diagnose(circularDependencyAt: program.ast.ranges[id]))
+      diagnostics.insert(.diagnose(circularDependencyAt: program.ast[id].origin))
       return false
     case .success:
       return true
@@ -355,7 +355,7 @@ public struct TypeChecker {
         equalityOrSubtypingConstraint(
           initializerType,
           shape.type,
-          because: ConstraintCause(.initialization, at: program.ast.ranges[id])))
+          because: ConstraintCause(.initialization, at: program.ast[id].origin)))
 
       // Infer the type of the initializer
       let names = program.ast.names(in: program.ast[id].pattern).map({ (name) in
@@ -591,7 +591,7 @@ public struct TypeChecker {
     // Check for duplicate parameter names.
     if !siblingNames.insert(program.ast[id].name).inserted {
       diagnostics.insert(.diganose(
-        duplicateParameterNamed: program.ast[id].name, at: program.ast.ranges[id]))
+        duplicateParameterNamed: program.ast[id].name, at: program.ast[id].origin))
       declRequests[id] = .failure
       return false
     }
@@ -605,7 +605,7 @@ public struct TypeChecker {
         ParameterConstraint(
           defaultValueType,
           ^parameterType,
-          because: ConstraintCause(.argument, at: program.ast.ranges[id]))
+          because: ConstraintCause(.argument, at: program.ast[id].origin))
       ]
 
       let solution = infer(
@@ -637,7 +637,7 @@ public struct TypeChecker {
       {
         diagnostics.insert(.diagnose(
           duplicateOperatorNamed: program.ast[id].name.value,
-          at: program.ast.ranges[id]))
+          at: program.ast[id].origin))
         return false
       }
     }
@@ -834,7 +834,7 @@ public struct TypeChecker {
       case .typeRealizationStarted, .typeCheckingStarted:
         // Note: The request status will be updated when the request that caused the circular
         // dependency handles the failure.
-        diagnostics.insert(.diagnose(circularDependencyAt: program.ast.ranges[id]))
+        diagnostics.insert(.diagnose(circularDependencyAt: program.ast[id].origin))
         return false
 
       case .success:
@@ -986,7 +986,9 @@ public struct TypeChecker {
       if let type = infer(expr: stmt.expr, inScope: lexicalContext) {
         // Issue a warning if the type of the expression isn't void.
         if type != .void {
-          diagnostics.insert(.diagnose(unusedResultOfType: type, at: program.ast.ranges[stmt.expr]))
+          diagnostics.insert(.diagnose(
+            unusedResultOfType: type,
+            at: program.ast[stmt.expr].origin))
         }
         return true
       } else {
@@ -1034,7 +1036,7 @@ public struct TypeChecker {
       let c = equalityOrSubtypingConstraint(
         inferredReturnType,
         expectedType,
-        because: ConstraintCause(.return, at: program.ast.ranges[returnValue]))
+        because: ConstraintCause(.return, at: program.ast[returnValue].origin))
       let solution = infer(
         expr: returnValue,
         inferredType: inferredReturnType,
@@ -1043,7 +1045,7 @@ public struct TypeChecker {
         constraints: [c])
       return solution.diagnostics.isEmpty
     } else if expectedType != .void {
-      diagnostics.insert(.diagnose(missingReturnValueAt: program.ast.ranges[id]))
+      diagnostics.insert(.diagnose(missingReturnValueAt: program.ast[id].origin))
       return false
     } else {
       return true
@@ -1062,7 +1064,7 @@ public struct TypeChecker {
     let c = equalityOrSubtypingConstraint(
       inferredReturnType,
       expectedType,
-      because: ConstraintCause(.yield, at: program.ast.ranges[program.ast[id].value]))
+      because: ConstraintCause(.yield, at: program.ast[program.ast[id].value].origin))
     let solution = infer(
       expr: program.ast[id].value,
       inferredType: inferredReturnType,
@@ -1165,7 +1167,7 @@ public struct TypeChecker {
       else { return nil }
 
       if !traits.isEmpty {
-        let cause = ConstraintCause(.annotation, at: program.ast.ranges[list[0]])
+        let cause = ConstraintCause(.annotation, at: program.ast[list[0]].origin)
         constraints.append(ConformanceConstraint(lhs, traits: traits, because: cause))
       }
     }
@@ -1304,7 +1306,7 @@ public struct TypeChecker {
     else { return false }
 
     if !traits.isEmpty {
-      let cause = ConstraintCause(.annotation, at: program.ast.ranges[list[0]])
+      let cause = ConstraintCause(.annotation, at: program.ast[list[0]].origin)
       constraints.append(ConformanceConstraint(lhs, traits: traits, because: cause))
     }
 
@@ -1499,7 +1501,7 @@ public struct TypeChecker {
               SubtypingConstraint(
                 type,
                 r,
-                because: ConstraintCause(.annotation, at: program.ast.ranges[pattern])))
+                because: ConstraintCause(.annotation, at: program.ast[pattern].origin)))
           }
           subpatternType = type
         } else {
@@ -1555,14 +1557,14 @@ public struct TypeChecker {
             diagnostics.insert(.diagnose(
               labels: lLabels,
               incompatibleWith: rLabels,
-              at: program.ast.ranges[pattern]))
+              at: program.ast[pattern].origin))
             return nil
           }
         } else {
           // Invalid destructuring.
           diagnostics.insert(.diagnose(
             invalidDestructuringOfType: expectedType!,
-            at: program.ast.ranges[pattern]))
+            at: program.ast[pattern].origin))
           return nil
         }
 
@@ -1570,7 +1572,7 @@ public struct TypeChecker {
         // The pattern has a tuple shape, the expected type hasn't.
         diagnostics.insert(.diagnose(
           invalidDestructuringOfType: expectedType!,
-          at: program.ast.ranges[pattern]))
+          at: program.ast[pattern].origin))
         return nil
 
       case nil:
@@ -2195,7 +2197,7 @@ public struct TypeChecker {
     /// The lens must be a trait.
     guard let lens = realize(node.lens, inScope: scope)?.instance else { return nil }
     guard let lensTrait = lens.base as? TraitType else {
-      diagnostics.insert(.diagnose(notATrait: lens, at: program.ast.ranges[node.lens]))
+      diagnostics.insert(.diagnose(notATrait: lens, at: program.ast[node.lens].origin))
       return nil
     }
 
@@ -2205,7 +2207,7 @@ public struct TypeChecker {
           traits.contains(lensTrait)
     else {
       diagnostics.insert(
-        .diagnose(subject, doesNotConformTo: lensTrait, at: program.ast.ranges[node.lens]))
+        .diagnose(subject, doesNotConformTo: lensTrait, at: program.ast[node.lens].origin))
       return nil
     }
 
@@ -2409,7 +2411,7 @@ public struct TypeChecker {
       if let trait = rhs.base as? TraitType {
         traits.insert(trait)
       } else {
-        diagnostics.insert(.diagnose(conformanceToNonTraitType: rhs, at: program.ast.ranges[expr]))
+        diagnostics.insert(.diagnose(conformanceToNonTraitType: rhs, at: program.ast[expr].origin))
         return nil
       }
     }
@@ -2532,7 +2534,7 @@ public struct TypeChecker {
           // The annotation may not omit generic arguments.
           if type[.hasVariable] {
             diagnostics.insert(.diagnose(
-              notEnoughContextToInferArgumentsAt: program.ast.ranges[annotation]))
+              notEnoughContextToInferArgumentsAt: program.ast[annotation].origin))
             success = false
           }
 
@@ -2675,7 +2677,8 @@ public struct TypeChecker {
       if let type = realize(parameter: annotation, inScope: AnyScopeID(id))?.instance {
         // The annotation may not omit generic arguments.
         if type[.hasVariable] {
-          diagnostics.insert(.diagnose(notEnoughContextToInferArgumentsAt: program.ast.ranges[annotation]))
+          diagnostics.insert(
+            .diagnose(notEnoughContextToInferArgumentsAt: program.ast[annotation].origin))
           success = false
         }
 
@@ -2721,7 +2724,8 @@ public struct TypeChecker {
       if let type = realize(parameter: annotation, inScope: AnyScopeID(id))?.instance {
         // The annotation may not omit generic arguments.
         if type[.hasVariable] {
-          diagnostics.insert(.diagnose(notEnoughContextToInferArgumentsAt: program.ast.ranges[annotation]))
+          diagnostics.insert(
+            .diagnose(notEnoughContextToInferArgumentsAt: program.ast[annotation].origin))
           success = false
         }
 
@@ -2756,7 +2760,7 @@ public struct TypeChecker {
     let capabilities = Set(program.ast[id].impls.map({ program.ast[$0].introducer.value }))
     if capabilities.contains(.inout) && (outputType != receiver) {
       let range = program.ast[id].output.map({ (output) in
-        program.ast.ranges[output]
+        program.ast[output].origin
       }) ?? program.ast[id].introducerRange
       diagnostics.insert(.diagnose(inoutCapableMethodBundleMustReturn: receiver, at: range))
       return .error
@@ -2778,7 +2782,7 @@ public struct TypeChecker {
       preconditionFailure()
 
     case .typeRealizationStarted:
-      diagnostics.insert(.diagnose(circularDependencyAt: program.ast.ranges[id]))
+      diagnostics.insert(.diagnose(circularDependencyAt: program.ast[id].origin))
       return .error
 
     case .typeRealizationCompleted, .typeCheckingStarted, .success, .failure:
@@ -2806,7 +2810,8 @@ public struct TypeChecker {
       if let type = realize(parameter: annotation, inScope: AnyScopeID(id))?.instance {
         // The annotation may not omit generic arguments.
         if type[.hasVariable] {
-          diagnostics.insert(.diagnose(notEnoughContextToInferArgumentsAt: program.ast.ranges[annotation]))
+          diagnostics.insert(
+            .diagnose(notEnoughContextToInferArgumentsAt: program.ast[annotation].origin))
           success = false
         }
 
@@ -2883,7 +2888,7 @@ public struct TypeChecker {
         if !explictNames.insert(Name(stem: program.ast[varDecl].name)).inserted {
           diagnostics.insert(.diagnose(
             duplicateCaptureNamed: program.ast[varDecl].name,
-            at: program.ast.ranges[varDecl]))
+            at: program.ast[varDecl].origin))
           success = false
         }
       }
@@ -3016,7 +3021,7 @@ public struct TypeChecker {
       declRequests[id] = .typeRealizationStarted
 
     case .typeRealizationStarted:
-      diagnostics.insert(.diagnose(circularDependencyAt: program.ast.ranges[id]))
+      diagnostics.insert(.diagnose(circularDependencyAt: program.ast[id].origin))
       declRequests[id] = .failure
       declTypes[id] = .error
       return declTypes[id]!

--- a/Sources/Compiler/TypeChecking/TypeChecker.swift
+++ b/Sources/Compiler/TypeChecking/TypeChecker.swift
@@ -137,7 +137,8 @@ public struct TypeChecker {
 
       while let base = work.popFirst() {
         if base == t {
-          diagnostics.insert(.diagnose(circularRefinementAt: program.ast[t.decl].identifier.range))
+          diagnostics.insert(
+            .diagnose(circularRefinementAt: program.ast[t.decl].identifier.origin))
           return nil
         } else if result.insert(base).inserted {
           guard let traits = realize(
@@ -519,7 +520,7 @@ public struct TypeChecker {
     } else if program.isRequirement(id) {
       return success
     } else {
-      diagnostics.insert(.diagnose(declarationRequiresBodyAt: program.ast[id].introducer.range))
+      diagnostics.insert(.diagnose(declarationRequiresBodyAt: program.ast[id].introducer.origin))
       return false
     }
   }
@@ -732,7 +733,7 @@ public struct TypeChecker {
         if program.isRequirement(id) { continue }
 
         // Declaration requires a body.
-        diagnostics.insert(.diagnose(declarationRequiresBodyAt: program.ast[id].introducer.range))
+        diagnostics.insert(.diagnose(declarationRequiresBodyAt: program.ast[id].introducer.origin))
         success = false
       }
     }
@@ -952,7 +953,7 @@ public struct TypeChecker {
             .diagnose(
               conformingType,
               doesNotConformTo: trait,
-              at: program.ast[decl].identifier.range,
+              at: program.ast[decl].identifier.origin,
               because: [
                 .diagnose(
                   traitRequiresMethod: Name(of: requirement, in: program.ast)!,
@@ -1280,7 +1281,7 @@ public struct TypeChecker {
       ConformanceConstraint(
         ^selfType,
         traits: [trait],
-        because: ConstraintCause(.structural, at: program.ast[id].identifier.range)))
+        because: ConstraintCause(.structural, at: program.ast[id].identifier.origin)))
 
     let e = GenericEnvironment(decl: id, constraints: constraints, into: &self)
     environments[id] = .done(e)
@@ -1363,16 +1364,16 @@ public struct TypeChecker {
       guard let b = realize(r, inScope: scope)?.instance else { return nil }
 
       if !a.isTypeParam && !b.isTypeParam {
-        diagnostics.insert(.diagnose(invalidEqualityConstraintBetween: a, and: b, at: expr.range))
+        diagnostics.insert(.diagnose(invalidEqualityConstraintBetween: a, and: b, at: expr.origin))
         return nil
       }
 
-      return EqualityConstraint(a, b, because: ConstraintCause(.structural, at: expr.range))
+      return EqualityConstraint(a, b, because: ConstraintCause(.structural, at: expr.origin))
 
     case .conformance(let l, let traits):
       guard let a = realize(name: l, inScope: scope)?.instance else { return nil }
       if !a.isTypeParam {
-        diagnostics.insert(.diagnose(invalidConformanceConstraintTo: a, at: expr.range))
+        diagnostics.insert(.diagnose(invalidConformanceConstraintTo: a, at: expr.origin))
         return nil
       }
 
@@ -1382,7 +1383,7 @@ public struct TypeChecker {
         if let trait = type.base as? TraitType {
           b.insert(trait)
         } else {
-          diagnostics.insert(.diagnose(conformanceToNonTraitType: a, at: expr.range))
+          diagnostics.insert(.diagnose(conformanceToNonTraitType: a, at: expr.origin))
           return nil
         }
       }
@@ -1390,11 +1391,11 @@ public struct TypeChecker {
       return ConformanceConstraint(
         a,
         traits: b,
-        because: ConstraintCause(.structural, at: expr.range))
+        because: ConstraintCause(.structural, at: expr.origin))
 
     case .value(let e):
       // TODO: Symbolic execution
-      return PredicateConstraint(e, because: ConstraintCause(.structural, at: expr.range))
+      return PredicateConstraint(e, because: ConstraintCause(.structural, at: expr.origin))
     }
   }
 
@@ -2046,7 +2047,7 @@ public struct TypeChecker {
       diagnostics.insert(
         .diagnose(
           illegalParameterConvention: program.ast[id].convention.value,
-          at: program.ast[id].convention.range))
+          at: program.ast[id].convention.origin))
       return nil
 
     case TupleTypeExpr.self:
@@ -2092,7 +2093,7 @@ public struct TypeChecker {
     case "Any":
       let type = MetatypeType(.any)
       if arguments.count > 0 {
-        diagnostics.insert(.diagnose(argumentToNonGenericType: type.instance, at: name.range))
+        diagnostics.insert(.diagnose(argumentToNonGenericType: type.instance, at: name.origin))
         return nil
       }
       return type
@@ -2100,25 +2101,25 @@ public struct TypeChecker {
     case "Never":
       let type = MetatypeType(.never)
       if arguments.count > 0 {
-        diagnostics.insert(.diagnose(argumentToNonGenericType: type.instance, at: name.range))
+        diagnostics.insert(.diagnose(argumentToNonGenericType: type.instance, at: name.origin))
         return nil
       }
       return type
 
     case "Self":
       guard let type = realizeSelfTypeExpr(inScope: scope) else {
-        diagnostics.insert(.diagnose(invalidReferenceToSelfTypeAt: name.range))
+        diagnostics.insert(.diagnose(invalidReferenceToSelfTypeAt: name.origin))
         return nil
       }
       if arguments.count > 0 {
-        diagnostics.insert(.diagnose(argumentToNonGenericType: type.instance, at: name.range))
+        diagnostics.insert(.diagnose(argumentToNonGenericType: type.instance, at: name.origin))
         return nil
       }
       return type
 
     case "Metatype":
       if arguments.count != 1 {
-        diagnostics.insert(.diagnose(metatypeRequiresOneArgumentAt: name.range))
+        diagnostics.insert(.diagnose(metatypeRequiresOneArgumentAt: name.origin))
       }
       if case .type(let a) = arguments.first! {
         return MetatypeType(MetatypeType(a))
@@ -2129,7 +2130,7 @@ public struct TypeChecker {
     case "Builtin" where isBuiltinModuleVisible:
       let type = MetatypeType(.builtin(.module))
       if arguments.count > 0 {
-        diagnostics.insert(.diagnose(argumentToNonGenericType: type.instance, at: name.range))
+        diagnostics.insert(.diagnose(argumentToNonGenericType: type.instance, at: name.origin))
         return nil
       }
       return type
@@ -2281,7 +2282,7 @@ public struct TypeChecker {
         if let type = BuiltinType(name.value.stem) {
           return MetatypeType(.builtin(type))
         } else {
-          diagnostics.insert(.diagnose(noType: name.value, in: domain, at: name.range))
+          diagnostics.insert(.diagnose(noType: name.value, in: domain, at: name.origin))
           return nil
         }
       }
@@ -2291,7 +2292,7 @@ public struct TypeChecker {
 
     case .implicit:
       diagnostics.insert(
-        .diagnose(notEnoughContextToResolveMember: name.value, at: name.range))
+        .diagnose(notEnoughContextToResolveMember: name.value, at: name.origin))
       return nil
 
     case .expr:
@@ -2300,7 +2301,7 @@ public struct TypeChecker {
 
     // Diagnose unresolved names.
     if matches.isEmpty {
-      diagnostics.insert(.diagnose(noType: name.value, in: domain, at: name.range))
+      diagnostics.insert(.diagnose(noType: name.value, in: domain, at: name.origin))
       return nil
     }
 
@@ -2343,7 +2344,7 @@ public struct TypeChecker {
       case .some:
         diagnostics.insert(.diagnose(
           invalidUseOfAssociatedType: program.ast[decl].name,
-          at: name.range))
+          at: name.origin))
         return nil
       }
     } else {

--- a/Tests/ValTests/ASTTests.swift
+++ b/Tests/ValTests/ASTTests.swift
@@ -20,7 +20,8 @@ final class ASTTests: XCTestCase {
       accessModifier: nil,
       identifier: SourceRepresentable(value: "T"),
       refinements: [],
-      members: []))
+      members: [],
+      origin: nil))
 
     // Create a source declaration set.
     let source = try ast.insert(wellFormed: TopLevelDeclSet(decls: [AnyDeclID(trait)]))
@@ -39,7 +40,8 @@ final class ASTTests: XCTestCase {
       decls: [
         AnyDeclID(ast.insert(wellFormed: FunctionDecl(
           introducerRange: nil,
-          identifier: SourceRepresentable(value: "foo")))),
+          identifier: SourceRepresentable(value: "foo"),
+          origin: nil))),
       ]))
     ast[module].addSourceFile(source)
 

--- a/Tests/ValTests/LexerTests.swift
+++ b/Tests/ValTests/LexerTests.swift
@@ -336,7 +336,7 @@ final class LexerTests: XCTestCase {
         file: spec.file,
         line: spec.line)
 
-      let value = source[token.range]
+      let value = source[token.origin]
       XCTAssert(
         value == spec.value,
         "token has value '\(value)', not '\(spec.value)'",


### PR DESCRIPTION
Encapsulate the origin (formerly "range") of an AST node in its representation and rename properties denoting source origins (from `range` to `origin`).