### PR TITLE
Remove probably-wrong conformances

### DIFF
--- a/Sources/Utils/Cache.swift
+++ b/Sources/Utils/Cache.swift
@@ -102,7 +102,3 @@ extension Cache: Collection {
   }
 
 }
-
-extension Cache: Equatable where Value: Equatable {}
-
-extension Cache: Hashable where Value: Hashable {}


### PR DESCRIPTION
An empty cache should be equivalent to a full one, if anything, right?