### PR TITLE
SubstitutionMap cleanup

### DIFF
--- a/Sources/Compiler/TypeChecking/ConstraintSolver.swift
+++ b/Sources/Compiler/TypeChecking/ConstraintSolver.swift
@@ -561,7 +561,7 @@ struct ConstraintSolver {
   private func finalize(using checker: inout TypeChecker) -> Solution {
     assert(fresh.isEmpty)
     var s = Solution(
-      typeAssumptions: typeAssumptions.flattened(),
+      typeAssumptions: typeAssumptions.asDictionary(),
       bindingAssumptions: bindingAssumptions,
       penalties: penalties,
       diagnostics: diagnostics)

--- a/Sources/Compiler/TypeChecking/SubstitutionMap.swift
+++ b/Sources/Compiler/TypeChecking/SubstitutionMap.swift
@@ -34,28 +34,9 @@ struct SubstitutionMap {
     storage[walked] = substitution
   }
 
-  /// Returns the contents of the map flattened into a dictionary.
-  func flattened() -> [TypeVariable: AnyType] {
-    storage.reduce(into: [:], { (d, e) in d[e.key] = self[e.value] })
-  }
-
-}
-
-extension SubstitutionMap: Collection {
-
-  typealias Index = Dictionary<TypeVariable, AnyType>.Index
-
-  typealias Element = (key: TypeVariable, value: AnyType)
-
-  var startIndex: Index { storage.startIndex }
-
-  var endIndex: Index { storage.endIndex }
-
-  func index(after i: Index) -> Index { storage.index(after: i) }
-
-  subscript(position: Index) -> Element {
-    let key = storage[position].key
-    return (key: key, value: self[^key])
+  /// Returns a dictionary representing the same mapping as `self`.
+  func asDictionary() -> [TypeVariable: AnyType] {
+    Dictionary(uniqueKeysWithValues: storage.lazy.map { (k, v) in (k, self[v]) })
   }
 
 }
@@ -63,7 +44,7 @@ extension SubstitutionMap: Collection {
 extension SubstitutionMap: CustomStringConvertible {
 
   var description: String {
-    let elements = self.map({ (key, value) in "\(key): \(value)" }).joined(separator: ", ")
+    let elements = storage.map({ (key, value) in "\(key): \(value)" }).joined(separator: ", ")
     return "[\(elements)]"
   }
 
@@ -74,7 +55,7 @@ extension SubstitutionMap: CustomReflectable {
   var customMirror: Mirror {
     Mirror(
       self,
-      children: self.map({ (key, value) in (label: "\(key)", value: value) }),
+      children: storage.map({ (key, value) in (label: "\(key)", value: value) }),
       displayStyle: .collection)
   }
 


### PR DESCRIPTION
- Shouldn't be a collection; things whose order is not salient should _have_, rather than _be_ collections.  Let's not compound Swift's error.  Plus nobody's using the functionality.
- flattened() was badly named and documented; the flattening is below the level of the client's abstraction.