### PR TITLE
Unwrap lines

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,31 +2,15 @@
 import PackageDescription
 
 /// Settings to be passed to swiftc for all targets.
-let allTargetsSwiftSettings: [SwiftSetting] = [
-  .unsafeFlags(["-warnings-as-errors"])
-]
+let allTargetsSwiftSettings: [SwiftSetting] = [.unsafeFlags(["-warnings-as-errors"])]
 
 let package = Package(
-  name: "Val",
-  platforms: [
-    .macOS(.v12)
-  ],
-  products: [
-    .executable(name: "valc", targets: ["CLI"])
-  ],
+  name: "Val", platforms: [.macOS(.v12)], products: [.executable(name: "valc", targets: ["CLI"])],
   dependencies: [
-    .package(
-      url: "https://github.com/apple/swift-argument-parser.git",
-      from: "0.4.0"),
-    .package(
-      url: "https://github.com/apple/swift-collections.git",
-      from: "1.0.0"),
-    .package(
-      url: "https://github.com/val-lang/Durian.git",
-      from: "1.2.0"),
-    .package(
-      url: "https://github.com/attaswift/BigInt.git",
-      from: "5.3.0"),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.4.0"),
+    .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
+    .package(url: "https://github.com/val-lang/Durian.git", from: "1.2.0"),
+    .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
   ],
   targets: [
     // The compiler's executable target.
@@ -47,8 +31,7 @@ let package = Package(
       swiftSettings: allTargetsSwiftSettings),
     .target(
       name: "Utils", dependencies: [.product(name: "BigInt", package: "BigInt")],
-      swiftSettings: allTargetsSwiftSettings
-    ),
+      swiftSettings: allTargetsSwiftSettings),
     // Test targets.
     .testTarget(
       name: "ValTests", dependencies: ["Compiler"], resources: [.copy("TestCases")],

--- a/Package.swift
+++ b/Package.swift
@@ -8,15 +8,12 @@ let allTargetsSwiftSettings: [SwiftSetting] = [
 
 let package = Package(
   name: "Val",
-
   platforms: [
     .macOS(.v12)
   ],
-
   products: [
     .executable(name: "valc", targets: ["CLI"])
   ],
-
   dependencies: [
     .package(
       url: "https://github.com/apple/swift-argument-parser.git",
@@ -31,46 +28,29 @@ let package = Package(
       url: "https://github.com/attaswift/BigInt.git",
       from: "5.3.0"),
   ],
-
   targets: [
     // The compiler's executable target.
     .executableTarget(
       name: "CLI",
       dependencies: [
-        "Compiler",
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-      ],
-      swiftSettings: allTargetsSwiftSettings),
-
+        "Compiler", .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      ], swiftSettings: allTargetsSwiftSettings),
     // Targets related to the compiler's internal library.
     .target(
       name: "Compiler",
       dependencies: [
-        "Utils",
-        "ValModule",
-        .product(name: "Collections", package: "swift-collections"),
-        .product(name: "Durian", package: "Durian"),
-        .product(name: "BigInt", package: "BigInt"),
-      ],
-      exclude: ["CXX/README.md"],
-      swiftSettings: allTargetsSwiftSettings),
-
+        "Utils", "ValModule", .product(name: "Collections", package: "swift-collections"),
+        .product(name: "Durian", package: "Durian"), .product(name: "BigInt", package: "BigInt"),
+      ], exclude: ["CXX/README.md"], swiftSettings: allTargetsSwiftSettings),
     .target(
-      name: "ValModule",
-      path: "Library",
-      resources: [.copy("Core")],
+      name: "ValModule", path: "Library", resources: [.copy("Core")],
       swiftSettings: allTargetsSwiftSettings),
-
     .target(
-      name: "Utils",
-      dependencies: [.product(name: "BigInt", package: "BigInt")],
+      name: "Utils", dependencies: [.product(name: "BigInt", package: "BigInt")],
       swiftSettings: allTargetsSwiftSettings
     ),
-
     // Test targets.
     .testTarget(
-      name: "ValTests",
-      dependencies: ["Compiler"],
-      resources: [.copy("TestCases")],
+      name: "ValTests", dependencies: ["Compiler"], resources: [.copy("TestCases")],
       swiftSettings: allTargetsSwiftSettings),
   ])

--- a/Sources/CLI/main.swift
+++ b/Sources/CLI/main.swift
@@ -39,44 +39,29 @@ struct CLI: ParsableCommand {
 
   static let configuration = CommandConfiguration(commandName: "valc")
 
-  @Flag(
-    name: [.customLong("modules")],
-    help: "Compile inputs as separate modules.")
+  @Flag(name: [.customLong("modules")], help: "Compile inputs as separate modules.")
   var compileInputAsModules: Bool = false
 
-  @Flag(
-    name: [.customLong("import-builtin")],
-    help: "Import the built-in module.")
+  @Flag(name: [.customLong("import-builtin")], help: "Import the built-in module.")
   var importBuiltinModule: Bool = false
 
-  @Flag(
-    name: [.customLong("no-std")],
-    help: "Do not include the standard library.")
+  @Flag(name: [.customLong("no-std")], help: "Do not include the standard library.")
   var noStandardLibrary: Bool = false
 
-  @Flag(
-    name: [.customLong("typecheck")],
-    help: "Type-check the input file(s).")
+  @Flag(name: [.customLong("typecheck")], help: "Type-check the input file(s).")
   var typeCheckOnly: Bool = false
 
-  @Option(
-    name: [.customLong("emit")],
-    help: "Emit the specified type output files.")
+  @Option(name: [.customLong("emit")], help: "Emit the specified type output files.")
   var outputType: OutputType = .binary
 
   @Option(
-    name: [.customShort("o")],
-    help: "Write output to <o>.",
-    transform: URL.init(fileURLWithPath:))
+    name: [.customShort("o")], help: "Write output to <o>.", transform: URL.init(fileURLWithPath:))
   var outputURL: URL?
 
-  @Flag(
-    name: [.short, .long],
-    help: "Use verbose output.")
+  @Flag(name: [.short, .long], help: "Use verbose output.")
   var verbose: Bool = false
 
-  @Argument(
-    transform: URL.init(fileURLWithPath:))
+  @Argument(transform: URL.init(fileURLWithPath:))
   var inputs: [URL]
 
   private var noteLabel: String { "note: ".styled([.bold, .cyan]) }
@@ -154,11 +139,8 @@ struct CLI: ParsableCommand {
     if typeCheckOnly { CLI.exit() }
 
     let typedProgram = TypedProgram(
-      annotating: checker.program,
-      declTypes: checker.declTypes,
-      exprTypes: checker.exprTypes,
-      implicitCaptures: checker.implicitCaptures,
-      referredDecls: checker.referredDecls,
+      annotating: checker.program, declTypes: checker.declTypes, exprTypes: checker.exprTypes,
+      implicitCaptures: checker.implicitCaptures, referredDecls: checker.referredDecls,
       foldedSequenceExprs: checker.foldedSequenceExprs)
 
     // *** IR Lowering ***
@@ -178,10 +160,8 @@ struct CLI: ParsableCommand {
 
     // Run mandatory IR analysis and transformation passes.
     var pipeline: [TransformPass] = [
-      ImplicitReturnInsertionPass(),
-      DefiniteInitializationPass(program: typedProgram),
-      LifetimePass(program: typedProgram),
-      // OwnershipPass(program: typedProgram),
+      ImplicitReturnInsertionPass(), DefiniteInitializationPass(program: typedProgram),
+      LifetimePass(program: typedProgram),  // OwnershipPass(program: typedProgram),
     ]
 
     log(verbose: "Analyzing '\(productName)'".styled([.bold]))
@@ -229,9 +209,7 @@ struct CLI: ParsableCommand {
     assert(outputType == .binary)
 
     let buildDirectoryURL = try FileManager.default.url(
-      for: .itemReplacementDirectory,
-      in: .userDomainMask,
-      appropriateFor: currentDirectory,
+      for: .itemReplacementDirectory, in: .userDomainMask, appropriateFor: currentDirectory,
       create: true)
 
     // Compile the transpiled module.
@@ -244,20 +222,11 @@ struct CLI: ParsableCommand {
     let clang = find("clang++")
     let binaryURL = outputURL ?? URL(fileURLWithPath: productName)
     try runCommandLine(
-      clang,
-      [
-        "-o", binaryURL.path,
-        "-I", buildDirectoryURL.path,
-        cxxSourceURL.path,
-      ])
+      clang, ["-o", binaryURL.path, "-I", buildDirectoryURL.path, cxxSourceURL.path])
   }
 
   /// Parses the contents of the file at `fileURL` and insert them into `ast[module]`.
-  func insert(
-    contentsOf fileURL: URL,
-    into module: NodeID<ModuleDecl>,
-    in ast: inout AST
-  ) -> Bool {
+  func insert(contentsOf fileURL: URL, into module: NodeID<ModuleDecl>, in ast: inout AST) -> Bool {
     switch fileURL.pathExtension {
     case "val":
       log(verbose: fileURL.relativePath)

--- a/Sources/CLI/main.swift
+++ b/Sources/CLI/main.swift
@@ -48,8 +48,8 @@ struct CLI: ParsableCommand {
   @Flag(name: [.customLong("no-std")], help: "Do not include the standard library.")
   var noStandardLibrary: Bool = false
 
-  @Flag(name: [.customLong("typecheck")], help: "Type-check the input file(s).")
-  var typeCheckOnly: Bool = false
+  @Flag(name: [.customLong("typecheck")], help: "Type-check the input file(s).") var typeCheckOnly:
+    Bool = false
 
   @Option(name: [.customLong("emit")], help: "Emit the specified type output files.")
   var outputType: OutputType = .binary
@@ -58,11 +58,9 @@ struct CLI: ParsableCommand {
     name: [.customShort("o")], help: "Write output to <o>.", transform: URL.init(fileURLWithPath:))
   var outputURL: URL?
 
-  @Flag(name: [.short, .long], help: "Use verbose output.")
-  var verbose: Bool = false
+  @Flag(name: [.short, .long], help: "Use verbose output.") var verbose: Bool = false
 
-  @Argument(transform: URL.init(fileURLWithPath:))
-  var inputs: [URL]
+  @Argument(transform: URL.init(fileURLWithPath:)) var inputs: [URL]
 
   private var noteLabel: String { "note: ".styled([.bold, .cyan]) }
 
@@ -81,9 +79,7 @@ struct CLI: ParsableCommand {
     /// The AST of the program being compiled.
     var ast = AST()
 
-    if compileInputAsModules {
-      fatalError("not implemented")
-    }
+    if compileInputAsModules { fatalError("not implemented") }
 
     // *** Parsing ***
 
@@ -131,9 +127,7 @@ struct CLI: ParsableCommand {
 
     // Report type-checking errors.
     log(diagnostics: checker.diagnostics)
-    if !typeCheckingSucceeded {
-      CLI.exit(withError: ExitCode(-1))
-    }
+    if !typeCheckingSucceeded { CLI.exit(withError: ExitCode(-1)) }
 
     // Exit if `--typecheck` is set.
     if typeCheckOnly { CLI.exit() }
@@ -233,9 +227,7 @@ struct CLI: ParsableCommand {
 
       // Read the contents of the file.
       let sourceFile: SourceFile
-      do {
-        sourceFile = try SourceFile(contentsOf: fileURL)
-      } catch let error {
+      do { sourceFile = try SourceFile(contentsOf: fileURL) } catch let error {
         log(errorLabel + error.localizedDescription)
         return false
       }
@@ -262,15 +254,11 @@ struct CLI: ParsableCommand {
   /// Creates a module from the contents at `url` and adds it to the AST.
   ///
   /// - Requires: `url` must denote a directly.
-  func addModule(url: URL) {
-    fatalError("not implemented")
-  }
+  func addModule(url: URL) { fatalError("not implemented") }
 
   /// Logs the contents of `diagnostics` tot he standard error.
   func log<S: Sequence>(diagnostics: S) where S.Element == Diagnostic {
-    for d in diagnostics.sorted(by: Diagnostic.isLoggedBefore) {
-      log(diagnostic: d)
-    }
+    for d in diagnostics.sorted(by: Diagnostic.isLoggedBefore) { log(diagnostic: d) }
   }
 
   /// Logs `diagnostic` to the standard error.
@@ -287,10 +275,8 @@ struct CLI: ParsableCommand {
       write(noteLabel)
     } else {
       switch diagnostic.level {
-      case .warning:
-        write(warningLabel)
-      case .error:
-        write(errorLabel)
+      case .warning: write(warningLabel)
+      case .error: write(errorLabel)
       }
     }
 
@@ -309,18 +295,12 @@ struct CLI: ParsableCommand {
 
       let count = line.distance(
         from: window.range.lowerBound, to: min(window.range.upperBound, line.endIndex))
-      if count > 1 {
-        write(String(repeating: "~", count: count))
-      } else {
-        write("^")
-      }
+      if count > 1 { write(String(repeating: "~", count: count)) } else { write("^") }
       write("\n")
     }
 
     // Log the children.
-    for child in diagnostic.children {
-      log(diagnostic: child, asChild: true)
-    }
+    for child in diagnostic.children { log(diagnostic: child, asChild: true) }
   }
 
   /// Logs `message` to the standard error file if `--verbose` is set.
@@ -337,21 +317,15 @@ struct CLI: ParsableCommand {
   }
 
   /// Writes `text` to the standard error file.
-  func write<S: StringProtocol>(_ text: S) {
-    FileHandle.standardError.write(Data(text.utf8))
-  }
+  func write<S: StringProtocol>(_ text: S) { FileHandle.standardError.write(Data(text.utf8)) }
 
   /// Returns the path of the specified executable.
   mutating func find(_ executable: String) -> String {
     // Nothing to do if `executable` is a path
-    if executable.contains("/") {
-      return executable
-    }
+    if executable.contains("/") { return executable }
 
     // Check the cache.
-    if let path = CLI.executableLocationCache[executable] {
-      return path
-    }
+    if let path = CLI.executableLocationCache[executable] { return path }
 
     // Search in the current working directory.
     var candidateURL = currentDirectory.appendingPathComponent(executable)
@@ -375,8 +349,9 @@ struct CLI: ParsableCommand {
   }
 
   /// Executes the program at `path` with the specified arguments in a subprocess.
-  @discardableResult
-  func runCommandLine(_ programPath: String, _ arguments: [String] = []) throws -> String? {
+  @discardableResult func runCommandLine(_ programPath: String, _ arguments: [String] = []) throws
+    -> String?
+  {
     log(verbose: ([programPath] + arguments).joined(separator: " "))
 
     let pipe = Pipe()

--- a/Sources/Compiler/AST/AST+Diagnostics.swift
+++ b/Sources/Compiler/AST/AST+Diagnostics.swift
@@ -2,67 +2,49 @@ import Utils
 
 extension Diagnostic {
 
-  static func diagnose(
-    duplicateAccessModifier m: SourceRepresentable<AccessModifier>
-  ) -> Diagnostic {
-    .error(
-      "duplicate access modifier '\(m.value)'",
-      range: m.origin)
+  static func diagnose(duplicateAccessModifier m: SourceRepresentable<AccessModifier>) -> Diagnostic
+  {
+    .error("duplicate access modifier '\(m.value)'", range: m.origin)
   }
 
-  static func diagnose(
-    duplicateImplementationIntroducer i: SourceRepresentable<ImplIntroducer>
-  ) -> Diagnostic {
-    .error(
-      "duplicate implementation introducer '\(i.value)'",
-      range: i.origin)
+  static func diagnose(duplicateImplementationIntroducer i: SourceRepresentable<ImplIntroducer>)
+    -> Diagnostic
+  {
+    .error("duplicate implementation introducer '\(i.value)'", range: i.origin)
   }
 
-  static func diagnose(
-    duplicateMemberModifier m: SourceRepresentable<MemberModifier>
-  ) -> Diagnostic {
-    .error(
-      "duplicate member modifier '\(m.value)'",
-      range: m.origin)
+  static func diagnose(duplicateMemberModifier m: SourceRepresentable<MemberModifier>) -> Diagnostic
+  {
+    .error("duplicate member modifier '\(m.value)'", range: m.origin)
   }
 
   static func diagnose(
     illegalGlobalBindingIntroducer i: SourceRepresentable<BindingPattern.Introducer>
   ) -> Diagnostic {
-    .error(
-      "global binding must be introduced by 'let'",
-      range: i.origin)
+    .error("global binding must be introduced by 'let'", range: i.origin)
   }
 
   static func diagnose(
     illegalMemberBindingIntroducer i: SourceRepresentable<BindingPattern.Introducer>
   ) -> Diagnostic {
-    .error(
-      "member binding must be introduced by 'let' or 'var'",
-      range: i.origin)
+    .error("member binding must be introduced by 'let' or 'var'", range: i.origin)
   }
 
   static func diagnose(
-    invalidOperatorLabels found: [String?],
-    expected: [String?],
-    at range: SourceRange?
+    invalidOperatorLabels found: [String?], expected: [String?], at range: SourceRange?
   ) -> Diagnostic {
     .error(
       """
       invalid operator labels '\(Name.describe(labels: found))', \
       expected '\(Name.describe(labels: found))'
-      """,
-      range: range)
+      """, range: range)
   }
 
   static func diagnose(
-    invalidOperatorNotation found: OperatorNotation,
-    expected: OperatorNotation,
+    invalidOperatorNotation found: OperatorNotation, expected: OperatorNotation,
     at range: SourceRange?
   ) -> Diagnostic {
-    .error(
-      "invalid operator notation '\(found)', expected '\(expected)'",
-      range: range)
+    .error("invalid operator notation '\(found)', expected '\(expected)'", range: range)
   }
 
   static func diagnose(
@@ -74,204 +56,108 @@ extension Diagnostic {
       range: member.origin)
   }
 
-  static func diagnose(
-    missingFunctionIdentifier d: FunctionDecl
-  ) -> Diagnostic {
-    .error(
-      "missing identifier in function declaration",
-      range: d.introducerRange)
+  static func diagnose(missingFunctionIdentifier d: FunctionDecl) -> Diagnostic {
+    .error("missing identifier in function declaration", range: d.introducerRange)
   }
 
-  static func diagnose(
-    missingMethodIdentifier d: MethodDecl
-  ) -> Diagnostic {
+  static func diagnose(missingMethodIdentifier d: MethodDecl) -> Diagnostic {
     diagnose(missingMethodIdentifierAt: d.introducerRange)
   }
 
-  static func diagnose(
-    missingMethodIdentifierAt range: SourceRange?
-  ) -> Diagnostic {
-    .error(
-      "missing identifier in method bundle declaration",
-      range: range)
+  static func diagnose(missingMethodIdentifierAt range: SourceRange?) -> Diagnostic {
+    .error("missing identifier in method bundle declaration", range: range)
   }
 
-  static func diagnose(
-    missingSubscriptIdentifier d: SubscriptDecl
-  ) -> Diagnostic {
-    .error(
-      "missing identifier in subscript declaration",
-      range: d.introducer.origin)
+  static func diagnose(missingSubscriptIdentifier d: SubscriptDecl) -> Diagnostic {
+    .error("missing identifier in subscript declaration", range: d.introducer.origin)
   }
 
-  static func diagnose(
-    missingTypeAnnotation p: BindingPattern,
-    in ast: AST
-  ) -> Diagnostic {
-    .error(
-      "missing type annotation",
-      range: ast[p.subpattern].origin)
+  static func diagnose(missingTypeAnnotation p: BindingPattern, in ast: AST) -> Diagnostic {
+    .error("missing type annotation", range: ast[p.subpattern].origin)
   }
 
-  static func diagnose(
-    missingTypeAnnotation p: ParameterDecl,
-    in ast: AST
-  ) -> Diagnostic {
-    .error(
-      "missing type annotation",
-      range: p.identifier.origin)
+  static func diagnose(missingTypeAnnotation p: ParameterDecl, in ast: AST) -> Diagnostic {
+    .error("missing type annotation", range: p.identifier.origin)
   }
 
-  static func diagnose(
-    unexpectedAccessModifier m: SourceRepresentable<AccessModifier>
-  ) -> Diagnostic {
-    .error(
-      "unexpected access modifier '\(m.value)'",
-      range: m.origin)
+  static func diagnose(unexpectedAccessModifier m: SourceRepresentable<AccessModifier>)
+    -> Diagnostic
+  {
+    .error("unexpected access modifier '\(m.value)'", range: m.origin)
   }
 
-  static func diagnose(
-    unexpectedAssociatedTypeDecl d: AssociatedTypeDecl
-  ) -> Diagnostic {
-    .error(
-      "associated type declaration is not allowed here",
-      range: d.introducerRange)
+  static func diagnose(unexpectedAssociatedTypeDecl d: AssociatedTypeDecl) -> Diagnostic {
+    .error("associated type declaration is not allowed here", range: d.introducerRange)
   }
 
-  static func diagnose(
-    unexpectedAssociatedValueDecl d: AssociatedValueDecl
-  ) -> Diagnostic {
-    .error(
-      "associated value declaration is not allowed here",
-      range: d.introducerRange)
+  static func diagnose(unexpectedAssociatedValueDecl d: AssociatedValueDecl) -> Diagnostic {
+    .error("associated value declaration is not allowed here", range: d.introducerRange)
   }
 
-  static func diagnose(
-    unexpectedAttribute a: SourceRepresentable<Attribute>
-  ) -> Diagnostic {
-    .error(
-      "unexpected attribute modifier '\(a.value.name.value)'",
-      range: a.value.name.origin)
+  static func diagnose(unexpectedAttribute a: SourceRepresentable<Attribute>) -> Diagnostic {
+    .error("unexpected attribute modifier '\(a.value.name.value)'", range: a.value.name.origin)
   }
 
-  static func diagnose(
-    unexpectedCapture p: BindingPattern
-  ) -> Diagnostic {
-    .error(
-      "explicit capture is not allowed here",
-      range: p.introducer.origin)
+  static func diagnose(unexpectedCapture p: BindingPattern) -> Diagnostic {
+    .error("explicit capture is not allowed here", range: p.introducer.origin)
   }
 
-  static func diagnose(
-    unexpectedImportDecl d: ImportDecl
-  ) -> Diagnostic {
-    .error(
-      "import declaration is not allowed here",
-      range: d.introducerRange)
+  static func diagnose(unexpectedImportDecl d: ImportDecl) -> Diagnostic {
+    .error("import declaration is not allowed here", range: d.introducerRange)
   }
 
-  static func diagnose(
-    unexpectedGenericParameterDecl d: GenericParameterDecl
-  ) -> Diagnostic {
-    .error(
-      "generic parameter declaration is not allowed here",
-      range: d.identifier.origin)
+  static func diagnose(unexpectedGenericParameterDecl d: GenericParameterDecl) -> Diagnostic {
+    .error("generic parameter declaration is not allowed here", range: d.identifier.origin)
   }
 
-  static func diagnose(
-    unexpectedInitializerDecl d: InitializerDecl
-  ) -> Diagnostic {
-    .error(
-      "initializer declaration is not allowed here",
-      range: d.introducer.origin)
+  static func diagnose(unexpectedInitializerDecl d: InitializerDecl) -> Diagnostic {
+    .error("initializer declaration is not allowed here", range: d.introducer.origin)
   }
 
-  static func diagnose(
-    unexpectedMemberModifier m: SourceRepresentable<MemberModifier>
-  ) -> Diagnostic {
-    .error(
-      "unexpected member modifier '\(m.value)'",
-      range: m.origin)
+  static func diagnose(unexpectedMemberModifier m: SourceRepresentable<MemberModifier>)
+    -> Diagnostic
+  {
+    .error("unexpected member modifier '\(m.value)'", range: m.origin)
   }
 
-  static func diagnose(
-    unexpectedMethodDecl d: MethodDecl
-  ) -> Diagnostic {
-    .error(
-      "method bundle declaration is not allowed here",
-      range: d.introducerRange)
+  static func diagnose(unexpectedMethodDecl d: MethodDecl) -> Diagnostic {
+    .error("method bundle declaration is not allowed here", range: d.introducerRange)
   }
 
-  static func diagnose(
-    unexpectedMethodImplDecl d: MethodImplDecl
-  ) -> Diagnostic {
-    .error(
-      "method implementation declaration is not allowed here",
-      range: d.introducer.origin)
+  static func diagnose(unexpectedMethodImplDecl d: MethodImplDecl) -> Diagnostic {
+    .error("method implementation declaration is not allowed here", range: d.introducer.origin)
   }
 
-  static func diagnose(
-    unexpectedNamespaceDecl d: NamespaceDecl
-  ) -> Diagnostic {
-    .error(
-      "namespace declaration is not allowed here",
-      range: d.introducerRange)
+  static func diagnose(unexpectedNamespaceDecl d: NamespaceDecl) -> Diagnostic {
+    .error("namespace declaration is not allowed here", range: d.introducerRange)
   }
 
-  static func diagnose(
-    unexpectedOperatorDecl d: OperatorDecl
-  ) -> Diagnostic {
-    .error(
-      "operator declaration is not allowed here",
-      range: d.introducerRange)
+  static func diagnose(unexpectedOperatorDecl d: OperatorDecl) -> Diagnostic {
+    .error("operator declaration is not allowed here", range: d.introducerRange)
   }
 
-  static func diagnose(
-    unexpectedParameterDecl d: ParameterDecl
-  ) -> Diagnostic {
-    .error(
-      "parameter declaration is not allowed here",
-      range: d.identifier.origin)
+  static func diagnose(unexpectedParameterDecl d: ParameterDecl) -> Diagnostic {
+    .error("parameter declaration is not allowed here", range: d.identifier.origin)
   }
 
-  static func diagnose(
-    unexpectedPropertyDecl d: SubscriptDecl
-  ) -> Diagnostic {
-    .error(
-      "property declaration is not allowed here",
-      range: d.introducer.origin)
+  static func diagnose(unexpectedPropertyDecl d: SubscriptDecl) -> Diagnostic {
+    .error("property declaration is not allowed here", range: d.introducer.origin)
   }
 
-  static func diagnose(
-    unexpectedEffect e: SourceRepresentable<ReceiverEffect>
-  ) -> Diagnostic {
-    .error(
-      "unexpected effect '\(e.value)'",
-      range: e.origin)
+  static func diagnose(unexpectedEffect e: SourceRepresentable<ReceiverEffect>) -> Diagnostic {
+    .error("unexpected effect '\(e.value)'", range: e.origin)
   }
 
-  static func diagnose(
-    unexpectedSubscriptImplDecl d: SubscriptImplDecl
-  ) -> Diagnostic {
-    .error(
-      "subscript implementation declaration is not allowed here",
-      range: d.introducer.origin)
+  static func diagnose(unexpectedSubscriptImplDecl d: SubscriptImplDecl) -> Diagnostic {
+    .error("subscript implementation declaration is not allowed here", range: d.introducer.origin)
   }
 
-  static func diagnose(
-    unexpectedTraitDecl d: TraitDecl
-  ) -> Diagnostic {
-    .error(
-      "trait declaration is not allowed here",
-      range: d.identifier.origin)
+  static func diagnose(unexpectedTraitDecl d: TraitDecl) -> Diagnostic {
+    .error("trait declaration is not allowed here", range: d.identifier.origin)
   }
 
-  static func diagnose(
-    unexpectedVarDecl d: VarDecl
-  ) -> Diagnostic {
-    .error(
-      "variable declaration is not allowed here",
-      range: d.identifier.origin)
+  static func diagnose(unexpectedVarDecl d: VarDecl) -> Diagnostic {
+    .error("variable declaration is not allowed here", range: d.identifier.origin)
   }
 
 }

--- a/Sources/Compiler/AST/AST+Diagnostics.swift
+++ b/Sources/Compiler/AST/AST+Diagnostics.swift
@@ -3,32 +3,22 @@ import Utils
 extension Diagnostic {
 
   static func diagnose(duplicateAccessModifier m: SourceRepresentable<AccessModifier>) -> Diagnostic
-  {
-    .error("duplicate access modifier '\(m.value)'", range: m.origin)
-  }
+  { .error("duplicate access modifier '\(m.value)'", range: m.origin) }
 
   static func diagnose(duplicateImplementationIntroducer i: SourceRepresentable<ImplIntroducer>)
     -> Diagnostic
-  {
-    .error("duplicate implementation introducer '\(i.value)'", range: i.origin)
-  }
+  { .error("duplicate implementation introducer '\(i.value)'", range: i.origin) }
 
   static func diagnose(duplicateMemberModifier m: SourceRepresentable<MemberModifier>) -> Diagnostic
-  {
-    .error("duplicate member modifier '\(m.value)'", range: m.origin)
-  }
+  { .error("duplicate member modifier '\(m.value)'", range: m.origin) }
 
   static func diagnose(
     illegalGlobalBindingIntroducer i: SourceRepresentable<BindingPattern.Introducer>
-  ) -> Diagnostic {
-    .error("global binding must be introduced by 'let'", range: i.origin)
-  }
+  ) -> Diagnostic { .error("global binding must be introduced by 'let'", range: i.origin) }
 
   static func diagnose(
     illegalMemberBindingIntroducer i: SourceRepresentable<BindingPattern.Introducer>
-  ) -> Diagnostic {
-    .error("member binding must be introduced by 'let' or 'var'", range: i.origin)
-  }
+  ) -> Diagnostic { .error("member binding must be introduced by 'let' or 'var'", range: i.origin) }
 
   static func diagnose(
     invalidOperatorLabels found: [String?], expected: [String?], at range: SourceRange?
@@ -82,9 +72,7 @@ extension Diagnostic {
 
   static func diagnose(unexpectedAccessModifier m: SourceRepresentable<AccessModifier>)
     -> Diagnostic
-  {
-    .error("unexpected access modifier '\(m.value)'", range: m.origin)
-  }
+  { .error("unexpected access modifier '\(m.value)'", range: m.origin) }
 
   static func diagnose(unexpectedAssociatedTypeDecl d: AssociatedTypeDecl) -> Diagnostic {
     .error("associated type declaration is not allowed here", range: d.introducerRange)
@@ -116,9 +104,7 @@ extension Diagnostic {
 
   static func diagnose(unexpectedMemberModifier m: SourceRepresentable<MemberModifier>)
     -> Diagnostic
-  {
-    .error("unexpected member modifier '\(m.value)'", range: m.origin)
-  }
+  { .error("unexpected member modifier '\(m.value)'", range: m.origin) }
 
   static func diagnose(unexpectedMethodDecl d: MethodDecl) -> Diagnostic {
     .error("method bundle declaration is not allowed here", range: d.introducerRange)

--- a/Sources/Compiler/AST/AST+WellFormedness.swift
+++ b/Sources/Compiler/AST/AST+WellFormedness.swift
@@ -16,9 +16,7 @@ extension AST {
 
     case BindingDecl.self:
       let d = self[NodeID<BindingDecl>(rawValue: decl.rawValue)]
-      if let m = d.memberModifier {
-        report.append(.diagnose(unexpectedMemberModifier: m))
-      }
+      if let m = d.memberModifier { report.append(.diagnose(unexpectedMemberModifier: m)) }
       if self[d.pattern].introducer.value != .let {
         report.append(.diagnose(illegalGlobalBindingIntroducer: self[d.pattern].introducer))
       }
@@ -26,20 +24,14 @@ extension AST {
         report.append(.diagnose(missingTypeAnnotation: self[d.pattern], in: self))
       }
 
-    case ConformanceDecl.self:
-      break
+    case ConformanceDecl.self: break
 
-    case ExtensionDecl.self:
-      break
+    case ExtensionDecl.self: break
 
     case FunctionDecl.self:
       let d = self[NodeID<FunctionDecl>(rawValue: decl.rawValue)]
-      if let m = d.memberModifier {
-        report.append(.diagnose(unexpectedMemberModifier: m))
-      }
-      if d.identifier == nil {
-        report.append(.diagnose(missingFunctionIdentifier: d))
-      }
+      if let m = d.memberModifier { report.append(.diagnose(unexpectedMemberModifier: m)) }
+      if d.identifier == nil { report.append(.diagnose(missingFunctionIdentifier: d)) }
 
     case GenericParameterDecl.self:
       report.append(
@@ -59,8 +51,7 @@ extension AST {
     case MethodImplDecl.self:
       report.append(.diagnose(unexpectedMethodImplDecl: self[NodeID(rawValue: decl.rawValue)]))
 
-    case NamespaceDecl.self:
-      break
+    case NamespaceDecl.self: break
 
     case OperatorDecl.self:
       if !atTopLevel {
@@ -70,35 +61,25 @@ extension AST {
     case ParameterDecl.self:
       report.append(.diagnose(unexpectedParameterDecl: self[NodeID(rawValue: decl.rawValue)]))
 
-    case ProductTypeDecl.self:
-      break
+    case ProductTypeDecl.self: break
 
     case SubscriptDecl.self:
       let d = self[NodeID<SubscriptDecl>(rawValue: decl.rawValue)]
-      if d.introducer.value != .subscript {
-        report.append(.diagnose(unexpectedPropertyDecl: d))
-      }
-      if let m = d.memberModifier {
-        report.append(.diagnose(unexpectedMemberModifier: m))
-      }
-      if d.identifier == nil {
-        report.append(.diagnose(missingSubscriptIdentifier: d))
-      }
+      if d.introducer.value != .subscript { report.append(.diagnose(unexpectedPropertyDecl: d)) }
+      if let m = d.memberModifier { report.append(.diagnose(unexpectedMemberModifier: m)) }
+      if d.identifier == nil { report.append(.diagnose(missingSubscriptIdentifier: d)) }
 
     case SubscriptImplDecl.self:
       report.append(.diagnose(unexpectedSubscriptImplDecl: self[NodeID(rawValue: decl.rawValue)]))
 
-    case TraitDecl.self:
-      break
+    case TraitDecl.self: break
 
-    case TypeAliasDecl.self:
-      break
+    case TypeAliasDecl.self: break
 
     case VarDecl.self:
       report.append(.diagnose(unexpectedVarDecl: self[NodeID(rawValue: decl.rawValue)]))
 
-    default:
-      unreachable("unexpected declaration")
+    default: unreachable("unexpected declaration")
     }
 
     return report.isEmpty ? .success : .failure(report)
@@ -131,20 +112,14 @@ extension AST {
         report.append(.diagnose(missingTypeAnnotation: self[d.pattern], in: self))
       }
 
-    case ConformanceDecl.self:
-      break
+    case ConformanceDecl.self: break
 
-    case ExtensionDecl.self:
-      break
+    case ExtensionDecl.self: break
 
     case FunctionDecl.self:
       let d = self[NodeID<FunctionDecl>(rawValue: decl.rawValue)]
-      if let m = d.memberModifier {
-        report.append(.diagnose(unexpectedMemberModifier: m))
-      }
-      if d.identifier == nil {
-        report.append(.diagnose(missingFunctionIdentifier: d))
-      }
+      if let m = d.memberModifier { report.append(.diagnose(unexpectedMemberModifier: m)) }
+      if d.identifier == nil { report.append(.diagnose(missingFunctionIdentifier: d)) }
       if let c = d.explicitCaptures.first {
         report.append(.diagnose(unexpectedCapture: self[self[c].pattern]))
       }
@@ -156,11 +131,9 @@ extension AST {
     case ImportDecl.self:
       report.append(.diagnose(unexpectedImportDecl: self[NodeID(rawValue: decl.rawValue)]))
 
-    case InitializerDecl.self:
-      break
+    case InitializerDecl.self: break
 
-    case MethodDecl.self:
-      break
+    case MethodDecl.self: break
 
     case MethodImplDecl.self:
       report.append(.diagnose(unexpectedMethodImplDecl: self[NodeID(rawValue: decl.rawValue)]))
@@ -174,11 +147,9 @@ extension AST {
     case ParameterDecl.self:
       report.append(.diagnose(unexpectedParameterDecl: self[NodeID(rawValue: decl.rawValue)]))
 
-    case ProductTypeDecl.self:
-      break
+    case ProductTypeDecl.self: break
 
-    case SubscriptDecl.self:
-      break
+    case SubscriptDecl.self: break
 
     case SubscriptImplDecl.self:
       report.append(.diagnose(unexpectedSubscriptImplDecl: self[NodeID(rawValue: decl.rawValue)]))
@@ -186,14 +157,12 @@ extension AST {
     case TraitDecl.self:
       report.append(.diagnose(unexpectedTraitDecl: self[NodeID(rawValue: decl.rawValue)]))
 
-    case TypeAliasDecl.self:
-      break
+    case TypeAliasDecl.self: break
 
     case VarDecl.self:
       report.append(.diagnose(unexpectedVarDecl: self[NodeID(rawValue: decl.rawValue)]))
 
-    default:
-      unreachable("unexpected declaration")
+    default: unreachable("unexpected declaration")
     }
 
     return report.isEmpty ? .success : .failure(report)

--- a/Sources/Compiler/AST/AST+WellFormedness.swift
+++ b/Sources/Compiler/AST/AST+WellFormedness.swift
@@ -4,10 +4,7 @@ extension AST {
 
   /// Returns `.success` if `decl` is a well-formed top-level or namespace member declaration.
   /// Otherwise, returns `.failure` with the diagnostics of the broken invariants.
-  func validateGlobalScopeMember(
-    _ decl: AnyDeclID,
-    atTopLevel: Bool
-  ) -> SuccessOrDiagnostics {
+  func validateGlobalScopeMember(_ decl: AnyDeclID, atTopLevel: Bool) -> SuccessOrDiagnostics {
     var report: [Diagnostic] = []
 
     switch decl.kind {

--- a/Sources/Compiler/AST/AST.swift
+++ b/Sources/Compiler/AST/AST.swift
@@ -151,8 +151,7 @@ public struct AST: Codable {
   public typealias TopLevelDecls = LazySequence<
     FlattenSequence<
       LazyMapSequence<
-        LazySequence<[NodeID<TopLevelDeclSet>]>.Elements,
-        [AnyDeclID]
+        LazySequence<[NodeID<TopLevelDeclSet>]>.Elements, [AnyDeclID]
       >.Elements
     >
   >
@@ -168,8 +167,7 @@ public struct AST: Codable {
   /// Returns the IDs of the named patterns contained in `pattern`.
   public func names<T: PatternID>(in pattern: T) -> [(path: [Int], pattern: NodeID<NamePattern>)] {
     func visit(
-      pattern: AnyPatternID,
-      path: [Int],
+      pattern: AnyPatternID, path: [Int],
       result: inout [(path: [Int], pattern: NodeID<NamePattern>)]
     ) {
       switch pattern.kind {
@@ -187,10 +185,7 @@ public struct AST: Codable {
       case TuplePattern.self:
         let p = NodeID<TuplePattern>(rawValue: pattern.rawValue)
         for i in 0..<self[p].elements.count {
-          visit(
-            pattern: self[p].elements[i].pattern,
-            path: path + [i],
-            result: &result)
+          visit(pattern: self[p].elements[i].pattern, path: path + [i], result: &result)
         }
 
       case WildcardPattern.self:

--- a/Sources/Compiler/AST/AST.swift
+++ b/Sources/Compiler/AST/AST.swift
@@ -23,9 +23,7 @@ public struct AST: Codable {
 
   /// Inserts `n` into `self`.
   public mutating func insert<T: Node>(wellFormed n: T) throws -> NodeID<T> {
-    if case .failure(let error) = n.validateForm(in: self) {
-      throw DiagnosedError(error)
-    }
+    if case .failure(let error) = n.validateForm(in: self) { throw DiagnosedError(error) }
 
     let i = NodeID<T>(rawValue: nodes.count)
     if let n = n as? ModuleDecl {
@@ -54,9 +52,7 @@ public struct AST: Codable {
   }
 
   /// Accesses the node at `position`.
-  public subscript<T: NodeIDProtocol>(position: T) -> Node {
-    nodes[position.rawValue].node
-  }
+  public subscript<T: NodeIDProtocol>(position: T) -> Node { nodes[position.rawValue].node }
 
   /// Accesses the node at `position`.
   public subscript<T: NodeIDProtocol>(position: T?) -> Node? {
@@ -64,16 +60,12 @@ public struct AST: Codable {
   }
 
   /// Accesses the node at `position`.
-  subscript(raw position: NodeID.RawValue) -> Node {
-    nodes[position].node
-  }
+  subscript(raw position: NodeID.RawValue) -> Node { nodes[position].node }
 
   /// Modifies the node at `position`.
   mutating func modify<T: Node>(at position: NodeID<T>, _ transform: (T) -> T) throws {
     let newNode = transform(self[position])
-    if case .failure(let error) = newNode.validateForm(in: self) {
-      throw DiagnosedError(error)
-    }
+    if case .failure(let error) = newNode.validateForm(in: self) { throw DiagnosedError(error) }
     nodes[position.rawValue] = AnyNode(newNode)
   }
 
@@ -91,8 +83,7 @@ public struct AST: Codable {
 
     withFiles(
       in: ValModule.core!,
-      { (sourceURL) in
-        if sourceURL.pathExtension != "val" { return true }
+      { (sourceURL) in if sourceURL.pathExtension != "val" { return true }
 
         // Parse the file.
         do {
@@ -100,16 +91,10 @@ public struct AST: Codable {
           let diagnostics = try Parser.parse(sourceFile, into: corelib!, in: &self).diagnostics
 
           // Note: the core module shouldn't produce any diagnostic.
-          if !diagnostics.isEmpty {
-            throw DiagnosedError(diagnostics)
-          } else {
-            return true
-          }
+          if !diagnostics.isEmpty { throw DiagnosedError(diagnostics) } else { return true }
         } catch let error as DiagnosedError {
           fatalError(error.diagnostics.first!.description)
-        } catch let error {
-          fatalError(error.localizedDescription)
-        }
+        } catch let error { fatalError(error.localizedDescription) }
       })
   }
 
@@ -121,9 +106,7 @@ public struct AST: Codable {
 
     for id in topLevelDecls(corelib!) where id.kind == ProductTypeDecl.self {
       let id = NodeID<ProductTypeDecl>(id)!
-      if self[id].name == name {
-        return ProductType(id, ast: self)
-      }
+      if self[id].name == name { return ProductType(id, ast: self) }
     }
 
     return nil
@@ -137,9 +120,7 @@ public struct AST: Codable {
 
     for id in topLevelDecls(corelib!) where id.kind == TraitDecl.self {
       let id = NodeID<TraitDecl>(rawValue: id.rawValue)
-      if self[id].name == name {
-        return TraitType(id, ast: self)
-      }
+      if self[id].name == name { return TraitType(id, ast: self) }
     }
 
     return nil
@@ -150,17 +131,13 @@ public struct AST: Codable {
   /// A collection that presents the top-level declarations of a module.
   public typealias TopLevelDecls = LazySequence<
     FlattenSequence<
-      LazyMapSequence<
-        LazySequence<[NodeID<TopLevelDeclSet>]>.Elements, [AnyDeclID]
-      >.Elements
+      LazyMapSequence<LazySequence<[NodeID<TopLevelDeclSet>]>.Elements, [AnyDeclID]>.Elements
     >
   >
 
   /// Returns the IDs of the top-level declarations in the lexical scope of `module`.
   public func topLevelDecls(_ module: NodeID<ModuleDecl>) -> TopLevelDecls {
-    let a = self[module].sources.lazy
-      .map({ self[$0].decls })
-      .joined()
+    let a = self[module].sources.lazy.map({ self[$0].decls }).joined()
     return a
   }
 
@@ -175,8 +152,7 @@ public struct AST: Codable {
         let p = NodeID<BindingPattern>(rawValue: pattern.rawValue)
         visit(pattern: self[p].subpattern, path: path, result: &result)
 
-      case ExprPattern.self:
-        break
+      case ExprPattern.self: break
 
       case NamePattern.self:
         let p = NodeID<NamePattern>(rawValue: pattern.rawValue)
@@ -188,11 +164,9 @@ public struct AST: Codable {
           visit(pattern: self[p].elements[i].pattern, path: path + [i], result: &result)
         }
 
-      case WildcardPattern.self:
-        break
+      case WildcardPattern.self: break
 
-      default:
-        unreachable("unexpected pattern")
+      default: unreachable("unexpected pattern")
       }
     }
 
@@ -204,8 +178,7 @@ public struct AST: Codable {
   /// Returns the source origin of `expr`, if any.
   public func origin(of expr: FoldedSequenceExpr) -> SourceRange? {
     switch expr {
-    case .leaf(let i):
-      return self[i].origin
+    case .leaf(let i): return self[i].origin
 
     case .infix(_, let lhs, let rhs):
       if let lhsRange = origin(of: lhs), let rhsRange = origin(of: rhs) {

--- a/Sources/Compiler/AST/AnyNode.swift
+++ b/Sources/Compiler/AST/AnyNode.swift
@@ -13,9 +13,7 @@ struct AnyNode: Codable {
   let node: Node
 
   /// Creates a type-erased container that wraps `node`.
-  init(_ node: Node) {
-    self.node = node
-  }
+  init(_ node: Node) { self.node = node }
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -35,16 +33,12 @@ struct AnyNode: Codable {
 
 extension KeyedDecodingContainer where K == AnyNode.CodingKeys {
 
-  fileprivate func decode<T: Node>(_ type: T.Type) throws -> T {
-    try decode(type, forKey: .data)
-  }
+  fileprivate func decode<T: Node>(_ type: T.Type) throws -> T { try decode(type, forKey: .data) }
 
 }
 
 extension KeyedEncodingContainer where K == AnyNode.CodingKeys {
 
-  fileprivate mutating func encode<T: Node>(_ node: T) throws {
-    try encode(node, forKey: .data)
-  }
+  fileprivate mutating func encode<T: Node>(_ node: T) throws { try encode(node, forKey: .data) }
 
 }

--- a/Sources/Compiler/AST/Decl/AssociatedTypeDecl.swift
+++ b/Sources/Compiler/AST/Decl/AssociatedTypeDecl.swift
@@ -20,12 +20,9 @@ public struct AssociatedTypeDecl: SingleEntityDecl {
 
   /// Creates an instance with the given properties.
   public init(
-    introducerRange: SourceRange?,
-    identifier: SourceRepresentable<Identifier>,
-    conformances: [NodeID<NameExpr>],
-    whereClause: SourceRepresentable<WhereClause>?,
-    defaultValue: AnyTypeExprID?,
-    origin: SourceRange?
+    introducerRange: SourceRange?, identifier: SourceRepresentable<Identifier>,
+    conformances: [NodeID<NameExpr>], whereClause: SourceRepresentable<WhereClause>?,
+    defaultValue: AnyTypeExprID?, origin: SourceRange?
   ) {
     self.origin = origin
     self.introducerRange = introducerRange

--- a/Sources/Compiler/AST/Decl/AssociatedValueDecl.swift
+++ b/Sources/Compiler/AST/Decl/AssociatedValueDecl.swift
@@ -17,11 +17,8 @@ public struct AssociatedValueDecl: SingleEntityDecl {
 
   /// Creates an instance with the given properties.
   public init(
-    introducerRange: SourceRange?,
-    identifier: SourceRepresentable<Identifier>,
-    whereClause: SourceRepresentable<WhereClause>?,
-    defaultValue: AnyExprID?,
-    origin: SourceRange?
+    introducerRange: SourceRange?, identifier: SourceRepresentable<Identifier>,
+    whereClause: SourceRepresentable<WhereClause>?, defaultValue: AnyExprID?, origin: SourceRange?
   ) {
     self.origin = origin
     self.introducerRange = introducerRange

--- a/Sources/Compiler/AST/Decl/BindingDecl.swift
+++ b/Sources/Compiler/AST/Decl/BindingDecl.swift
@@ -22,10 +22,8 @@ public struct BindingDecl: Decl {
   public init(
     attributes: [SourceRepresentable<Attribute>] = [],
     accessModifier: SourceRepresentable<AccessModifier>? = nil,
-    memberModifier: SourceRepresentable<MemberModifier>? = nil,
-    pattern: NodeID<BindingPattern>,
-    initializer: AnyExprID?,
-    origin: SourceRange?
+    memberModifier: SourceRepresentable<MemberModifier>? = nil, pattern: NodeID<BindingPattern>,
+    initializer: AnyExprID?, origin: SourceRange?
   ) {
     self.origin = origin
     self.attributes = attributes

--- a/Sources/Compiler/AST/Decl/ConformanceDecl.swift
+++ b/Sources/Compiler/AST/Decl/ConformanceDecl.swift
@@ -20,12 +20,9 @@ public struct ConformanceDecl: TypeExtendingDecl {
 
   /// Creates an instance with the given properties.
   public init(
-    accessModifier: SourceRepresentable<AccessModifier>?,
-    subject: AnyTypeExprID,
-    conformances: [NodeID<NameExpr>],
-    whereClause: SourceRepresentable<WhereClause>?,
-    members: [AnyDeclID],
-    origin: SourceRange?
+    accessModifier: SourceRepresentable<AccessModifier>?, subject: AnyTypeExprID,
+    conformances: [NodeID<NameExpr>], whereClause: SourceRepresentable<WhereClause>?,
+    members: [AnyDeclID], origin: SourceRange?
   ) {
     self.origin = origin
     self.accessModifier = accessModifier

--- a/Sources/Compiler/AST/Decl/ExtensionDecl.swift
+++ b/Sources/Compiler/AST/Decl/ExtensionDecl.swift
@@ -17,11 +17,8 @@ public struct ExtensionDecl: TypeExtendingDecl {
 
   /// Creates an instance with the given properties.
   public init(
-    accessModifier: SourceRepresentable<AccessModifier>?,
-    subject: AnyTypeExprID,
-    whereClause: SourceRepresentable<WhereClause>?,
-    members: [AnyDeclID],
-    origin: SourceRange?
+    accessModifier: SourceRepresentable<AccessModifier>?, subject: AnyTypeExprID,
+    whereClause: SourceRepresentable<WhereClause>?, members: [AnyDeclID], origin: SourceRange?
   ) {
     self.origin = origin
     self.accessModifier = accessModifier

--- a/Sources/Compiler/AST/Decl/FunctionDecl.swift
+++ b/Sources/Compiler/AST/Decl/FunctionDecl.swift
@@ -100,9 +100,7 @@ public struct FunctionDecl: GenericDecl, GenericScope {
   public var isSink: Bool { receiverEffect?.value == .sink }
 
   /// Returns whether `self` is a foreign function interface.
-  public var isFFI: Bool {
-    attributes.contains(where: { $0.value.name.value == "@_lowered_name" })
-  }
+  public var isFFI: Bool { attributes.contains(where: { $0.value.name.value == "@_lowered_name" }) }
 
   public func validateForm(in ast: AST) -> SuccessOrDiagnostics {
     var report: [Diagnostic] = []

--- a/Sources/Compiler/AST/Decl/FunctionDecl.swift
+++ b/Sources/Compiler/AST/Decl/FunctionDecl.swift
@@ -59,21 +59,16 @@ public struct FunctionDecl: GenericDecl, GenericScope {
 
   /// Creates an instance with the given properties.
   public init(
-    introducerRange: SourceRange?,
-    attributes: [SourceRepresentable<Attribute>] = [],
+    introducerRange: SourceRange?, attributes: [SourceRepresentable<Attribute>] = [],
     accessModifier: SourceRepresentable<AccessModifier>? = nil,
     memberModifier: SourceRepresentable<MemberModifier>? = nil,
     receiverEffect: SourceRepresentable<ReceiverEffect>? = nil,
     notation: SourceRepresentable<OperatorNotation>? = nil,
     identifier: SourceRepresentable<Identifier>? = nil,
     genericClause: SourceRepresentable<GenericClause>? = nil,
-    explicitCaptures: [NodeID<BindingDecl>] = [],
-    parameters: [NodeID<ParameterDecl>] = [],
-    receiver: NodeID<ParameterDecl>? = nil,
-    output: AnyTypeExprID? = nil,
-    body: Body? = nil,
-    isInExprContext: Bool = false,
-    origin: SourceRange?
+    explicitCaptures: [NodeID<BindingDecl>] = [], parameters: [NodeID<ParameterDecl>] = [],
+    receiver: NodeID<ParameterDecl>? = nil, output: AnyTypeExprID? = nil, body: Body? = nil,
+    isInExprContext: Bool = false, origin: SourceRange?
   ) {
     self.origin = origin
     self.introducerRange = introducerRange

--- a/Sources/Compiler/AST/Decl/GenericClause.swift
+++ b/Sources/Compiler/AST/Decl/GenericClause.swift
@@ -8,8 +8,7 @@ public struct GenericClause: Codable {
   public let whereClause: SourceRepresentable<WhereClause>?
 
   public init(
-    parameters: [NodeID<GenericParameterDecl>],
-    whereClause: SourceRepresentable<WhereClause>? = nil
+    parameters: [NodeID<GenericParameterDecl>], whereClause: SourceRepresentable<WhereClause>? = nil
   ) {
     self.parameters = parameters
     self.whereClause = whereClause

--- a/Sources/Compiler/AST/Decl/GenericParameterDecl.swift
+++ b/Sources/Compiler/AST/Decl/GenericParameterDecl.swift
@@ -17,10 +17,8 @@ public struct GenericParameterDecl: SingleEntityDecl {
   public let defaultValue: AnyExprID?
 
   public init(
-    identifier: SourceRepresentable<Identifier>,
-    conformances: [NodeID<NameExpr>] = [],
-    defaultValue: AnyExprID? = nil,
-    origin: SourceRange?
+    identifier: SourceRepresentable<Identifier>, conformances: [NodeID<NameExpr>] = [],
+    defaultValue: AnyExprID? = nil, origin: SourceRange?
   ) {
     self.origin = origin
     self.identifier = identifier

--- a/Sources/Compiler/AST/Decl/ImportDecl.swift
+++ b/Sources/Compiler/AST/Decl/ImportDecl.swift
@@ -11,9 +11,7 @@ public struct ImportDecl: SingleEntityDecl {
 
   /// Creates an instance with the given properties.
   public init(
-    introducerRange: SourceRange?,
-    identifier: SourceRepresentable<Identifier>,
-    origin: SourceRange?
+    introducerRange: SourceRange?, identifier: SourceRepresentable<Identifier>, origin: SourceRange?
   ) {
     self.origin = origin
     self.introducerRange = introducerRange

--- a/Sources/Compiler/AST/Decl/InitializerDecl.swift
+++ b/Sources/Compiler/AST/Decl/InitializerDecl.swift
@@ -39,14 +39,10 @@ public struct InitializerDecl: GenericDecl, GenericScope {
 
   /// Creates an instance with the given properties.
   public init(
-    introducer: SourceRepresentable<Introducer>,
-    attributes: [SourceRepresentable<Attribute>],
+    introducer: SourceRepresentable<Introducer>, attributes: [SourceRepresentable<Attribute>],
     accessModifier: SourceRepresentable<AccessModifier>?,
-    genericClause: SourceRepresentable<GenericClause>?,
-    parameters: [NodeID<ParameterDecl>],
-    receiver: NodeID<ParameterDecl>,
-    body: NodeID<BraceStmt>?,
-    origin: SourceRange?
+    genericClause: SourceRepresentable<GenericClause>?, parameters: [NodeID<ParameterDecl>],
+    receiver: NodeID<ParameterDecl>, body: NodeID<BraceStmt>?, origin: SourceRange?
   ) {
     precondition((introducer.value == .`init`) || (body == nil))
 

--- a/Sources/Compiler/AST/Decl/MethodDecl.swift
+++ b/Sources/Compiler/AST/Decl/MethodDecl.swift
@@ -34,16 +34,11 @@ public struct MethodDecl: GenericDecl, GenericScope {
 
   /// Creates an instance with the given properties.
   public init(
-    introducerRange: SourceRange?,
-    attributes: [SourceRepresentable<Attribute>],
+    introducerRange: SourceRange?, attributes: [SourceRepresentable<Attribute>],
     accessModifier: SourceRepresentable<AccessModifier>?,
-    notation: SourceRepresentable<OperatorNotation>?,
-    identifier: SourceRepresentable<Identifier>,
-    genericClause: SourceRepresentable<GenericClause>?,
-    parameters: [NodeID<ParameterDecl>],
-    output: AnyTypeExprID?,
-    impls: [NodeID<MethodImplDecl>],
-    origin: SourceRange?
+    notation: SourceRepresentable<OperatorNotation>?, identifier: SourceRepresentable<Identifier>,
+    genericClause: SourceRepresentable<GenericClause>?, parameters: [NodeID<ParameterDecl>],
+    output: AnyTypeExprID?, impls: [NodeID<MethodImplDecl>], origin: SourceRange?
   ) {
     self.origin = origin
     self.introducerRange = introducerRange

--- a/Sources/Compiler/AST/Decl/MethodImplDecl.swift
+++ b/Sources/Compiler/AST/Decl/MethodImplDecl.swift
@@ -24,10 +24,8 @@ public struct MethodImplDecl: Decl, LexicalScope {
 
   /// Creates an instance with the given properties and no `receiver`.
   public init(
-    introducer: SourceRepresentable<ImplIntroducer>,
-    receiver: NodeID<ParameterDecl>,
-    body: Body? = nil,
-    origin: SourceRange?
+    introducer: SourceRepresentable<ImplIntroducer>, receiver: NodeID<ParameterDecl>,
+    body: Body? = nil, origin: SourceRange?
   ) {
     self.origin = origin
     self.introducer = introducer

--- a/Sources/Compiler/AST/Decl/ModuleDecl.swift
+++ b/Sources/Compiler/AST/Decl/ModuleDecl.swift
@@ -7,15 +7,11 @@ public struct ModuleDecl: SingleEntityDecl, LexicalScope {
   /// The source files in the module.
   public private(set) var sources: [NodeID<TopLevelDeclSet>] = []
 
-  public init(name: String) {
-    self.name = name
-  }
+  public init(name: String) { self.name = name }
 
   public var origin: SourceRange? { nil }
 
   /// Adds the given source file to our list of sources.
-  public mutating func addSourceFile(_ s: NodeID<TopLevelDeclSet>) {
-    sources.append(s)
-  }
+  public mutating func addSourceFile(_ s: NodeID<TopLevelDeclSet>) { sources.append(s) }
 
 }

--- a/Sources/Compiler/AST/Decl/NamespaceDecl.swift
+++ b/Sources/Compiler/AST/Decl/NamespaceDecl.swift
@@ -17,11 +17,8 @@ public struct NamespaceDecl: SingleEntityDecl, LexicalScope {
 
   /// Creates an instance with the given properties.
   public init(
-    introducerRange: SourceRange?,
-    accessModifier: SourceRepresentable<AccessModifier>?,
-    identifier: SourceRepresentable<Identifier>,
-    members: [AnyDeclID],
-    origin: SourceRange?
+    introducerRange: SourceRange?, accessModifier: SourceRepresentable<AccessModifier>?,
+    identifier: SourceRepresentable<Identifier>, members: [AnyDeclID], origin: SourceRange?
   ) {
     self.origin = origin
     self.introducerRange = introducerRange

--- a/Sources/Compiler/AST/Decl/OperatorDecl.swift
+++ b/Sources/Compiler/AST/Decl/OperatorDecl.swift
@@ -20,12 +20,9 @@ public struct OperatorDecl: Decl {
 
   /// Creates an instance with the given properties.
   public init(
-    introducerRange: SourceRange?,
-    accessModifier: SourceRepresentable<AccessModifier>?,
-    notation: SourceRepresentable<OperatorNotation>,
-    name: SourceRepresentable<Identifier>,
-    precedenceGroup: SourceRepresentable<PrecedenceGroup>?,
-    origin: SourceRange?
+    introducerRange: SourceRange?, accessModifier: SourceRepresentable<AccessModifier>?,
+    notation: SourceRepresentable<OperatorNotation>, name: SourceRepresentable<Identifier>,
+    precedenceGroup: SourceRepresentable<PrecedenceGroup>?, origin: SourceRange?
   ) {
     self.origin = origin
     self.introducerRange = introducerRange

--- a/Sources/Compiler/AST/Decl/ParameterDecl.swift
+++ b/Sources/Compiler/AST/Decl/ParameterDecl.swift
@@ -16,10 +16,8 @@ public struct ParameterDecl: SingleEntityDecl {
   public let defaultValue: AnyExprID?
 
   public init(
-    label: SourceRepresentable<Identifier>? = nil,
-    identifier: SourceRepresentable<Identifier>,
-    annotation: NodeID<ParameterTypeExpr>? = nil,
-    defaultValue: AnyExprID? = nil,
+    label: SourceRepresentable<Identifier>? = nil, identifier: SourceRepresentable<Identifier>,
+    annotation: NodeID<ParameterTypeExpr>? = nil, defaultValue: AnyExprID? = nil,
     origin: SourceRange?
   ) {
     self.origin = origin

--- a/Sources/Compiler/AST/Decl/ProductTypeDecl.swift
+++ b/Sources/Compiler/AST/Decl/ProductTypeDecl.swift
@@ -47,9 +47,7 @@ public struct ProductTypeDecl: SingleEntityDecl, GenericDecl, TypeScope, Generic
   public func validateForm(in ast: AST) -> SuccessOrDiagnostics {
     let ds: [Diagnostic] = members.reduce(
       into: [],
-      { (ds, member) in
-        ds.append(contentsOf: ast.validateTypeMember(member).diagnostics)
-      })
+      { (ds, member) in ds.append(contentsOf: ast.validateTypeMember(member).diagnostics) })
     return ds.isEmpty ? .success : .failure(ds)
   }
 

--- a/Sources/Compiler/AST/Decl/ProductTypeDecl.swift
+++ b/Sources/Compiler/AST/Decl/ProductTypeDecl.swift
@@ -24,11 +24,8 @@ public struct ProductTypeDecl: SingleEntityDecl, GenericDecl, TypeScope, Generic
   /// Creates an instance with the given properties.
   public init(
     accessModifier: SourceRepresentable<AccessModifier>?,
-    identifier: SourceRepresentable<Identifier>,
-    genericClause: SourceRepresentable<GenericClause>?,
-    conformances: [NodeID<NameExpr>],
-    members: [AnyDeclID],
-    memberwiseInit: NodeID<InitializerDecl>,
+    identifier: SourceRepresentable<Identifier>, genericClause: SourceRepresentable<GenericClause>?,
+    conformances: [NodeID<NameExpr>], members: [AnyDeclID], memberwiseInit: NodeID<InitializerDecl>,
     origin: SourceRange?
   ) {
     precondition(members.contains(AnyDeclID(memberwiseInit)))

--- a/Sources/Compiler/AST/Decl/SubscriptDecl.swift
+++ b/Sources/Compiler/AST/Decl/SubscriptDecl.swift
@@ -47,16 +47,12 @@ public struct SubscriptDecl: GenericDecl, GenericScope {
 
   /// Creates an instance with the given properties.
   public init(
-    introducer: SourceRepresentable<Introducer>,
-    attributes: [SourceRepresentable<Attribute>],
+    introducer: SourceRepresentable<Introducer>, attributes: [SourceRepresentable<Attribute>],
     accessModifier: SourceRepresentable<AccessModifier>?,
     memberModifier: SourceRepresentable<MemberModifier>?,
     identifier: SourceRepresentable<Identifier>?,
-    genericClause: SourceRepresentable<GenericClause>?,
-    explicitCaptures: [NodeID<BindingDecl>],
-    parameters: [NodeID<ParameterDecl>]?,
-    output: AnyTypeExprID,
-    impls: [NodeID<SubscriptImplDecl>],
+    genericClause: SourceRepresentable<GenericClause>?, explicitCaptures: [NodeID<BindingDecl>],
+    parameters: [NodeID<ParameterDecl>]?, output: AnyTypeExprID, impls: [NodeID<SubscriptImplDecl>],
     origin: SourceRange?
   ) {
     self.origin = origin

--- a/Sources/Compiler/AST/Decl/SubscriptImplDecl.swift
+++ b/Sources/Compiler/AST/Decl/SubscriptImplDecl.swift
@@ -24,9 +24,7 @@ public struct SubscriptImplDecl: Decl, LexicalScope {
   public let body: Body?
 
   public init(
-    introducer: SourceRepresentable<ImplIntroducer>,
-    receiver: NodeID<ParameterDecl>?,
-    body: Body?,
+    introducer: SourceRepresentable<ImplIntroducer>, receiver: NodeID<ParameterDecl>?, body: Body?,
     origin: SourceRange?
   ) {
     self.origin = origin

--- a/Sources/Compiler/AST/Decl/TopLevelDeclSet.swift
+++ b/Sources/Compiler/AST/Decl/TopLevelDeclSet.swift
@@ -5,9 +5,7 @@ public struct TopLevelDeclSet: Node, LexicalScope {
   public private(set) var decls: [AnyDeclID]
 
   /// Creates an instance with the given properties.
-  public init(decls: [AnyDeclID] = []) {
-    self.decls = decls
-  }
+  public init(decls: [AnyDeclID] = []) { self.decls = decls }
 
   public var origin: SourceRange? { nil }
 

--- a/Sources/Compiler/AST/Decl/TraitDecl.swift
+++ b/Sources/Compiler/AST/Decl/TraitDecl.swift
@@ -20,10 +20,8 @@ public struct TraitDecl: SingleEntityDecl, TypeScope, GenericScope {
   /// Creates an instance with the given properties.
   public init(
     accessModifier: SourceRepresentable<AccessModifier>?,
-    identifier: SourceRepresentable<Identifier>,
-    refinements: [NodeID<NameExpr>],
-    members: [AnyDeclID],
-    origin: SourceRange?
+    identifier: SourceRepresentable<Identifier>, refinements: [NodeID<NameExpr>],
+    members: [AnyDeclID], origin: SourceRange?
   ) {
     self.origin = origin
     self.accessModifier = accessModifier

--- a/Sources/Compiler/AST/Decl/TypeAliasDecl.swift
+++ b/Sources/Compiler/AST/Decl/TypeAliasDecl.swift
@@ -28,10 +28,8 @@ public struct TypeAliasDecl: SingleEntityDecl, GenericDecl, TypeScope, GenericSc
   /// Creates an instance with the given properties.
   public init(
     accessModifier: SourceRepresentable<AccessModifier>?,
-    identifier: SourceRepresentable<Identifier>,
-    genericClause: SourceRepresentable<GenericClause>?,
-    body: Body,
-    origin: SourceRange?
+    identifier: SourceRepresentable<Identifier>, genericClause: SourceRepresentable<GenericClause>?,
+    body: Body, origin: SourceRange?
   ) {
     self.origin = origin
     self.accessModifier = accessModifier

--- a/Sources/Compiler/AST/Decl/VarDecl.swift
+++ b/Sources/Compiler/AST/Decl/VarDecl.swift
@@ -4,9 +4,7 @@ public struct VarDecl: SingleEntityDecl {
   /// The identifier of the declared variable.
   public let identifier: SourceRepresentable<Identifier>
 
-  public init(identifier: SourceRepresentable<Identifier>) {
-    self.identifier = identifier
-  }
+  public init(identifier: SourceRepresentable<Identifier>) { self.identifier = identifier }
 
   public var origin: SourceRange? { identifier.origin }
 

--- a/Sources/Compiler/AST/Decl/WhereClause.swift
+++ b/Sources/Compiler/AST/Decl/WhereClause.swift
@@ -7,14 +7,10 @@ public struct WhereClause: Codable {
   public enum ConstraintExpr: Codable {
 
     /// An equality constraint involving one or two skolems.
-    case equality(
-      l: NodeID<NameExpr>,
-      r: AnyTypeExprID)
+    case equality(l: NodeID<NameExpr>, r: AnyTypeExprID)
 
     /// A conformance constraint on a skolem.
-    case conformance(
-      l: NodeID<NameExpr>,
-      traits: TraitComposition)
+    case conformance(l: NodeID<NameExpr>, traits: TraitComposition)
 
     /// A constraint on a value parameter.
     case value(AnyExprID)

--- a/Sources/Compiler/AST/DeclLocator.swift
+++ b/Sources/Compiler/AST/DeclLocator.swift
@@ -31,18 +31,15 @@ public struct DeclLocator: Hashable {
     /// Creates a component identifying `decl` in `program`.
     init?<T: NodeIDProtocol>(identifying decl: T, in program: TypedProgram) {
       switch decl.kind {
-      case ConformanceDecl.self, ExtensionDecl.self:
-        fatalError("not implemented")
+      case ConformanceDecl.self, ExtensionDecl.self: fatalError("not implemented")
 
       case FunctionDecl.self:
         let decl = NodeID<FunctionDecl>(rawValue: decl.rawValue)
 
         let labels: [String]
         switch program.declTypes[decl]!.base {
-        case let type as LambdaType:
-          labels = Array(type.inputs.map({ $0.label ?? "_" }))
-        default:
-          labels = []
+        case let type as LambdaType: labels = Array(type.inputs.map({ $0.label ?? "_" }))
+        default: labels = []
         }
 
         if let name = program.ast[decl].identifier?.value {
@@ -56,10 +53,8 @@ public struct DeclLocator: Hashable {
 
         let labels: [String]
         switch program.declTypes[decl]!.base {
-        case let type as LambdaType:
-          labels = Array(type.inputs.map({ $0.label ?? "_" }))
-        default:
-          labels = []
+        case let type as LambdaType: labels = Array(type.inputs.map({ $0.label ?? "_" }))
+        default: labels = []
         }
 
         self = .function(name: "init", labels: labels, notation: nil)
@@ -69,10 +64,8 @@ public struct DeclLocator: Hashable {
 
         let labels: [String]
         switch program.declTypes[decl]!.base {
-        case let type as MethodType:
-          labels = Array(type.inputs.map({ $0.label ?? "_" }))
-        default:
-          labels = []
+        case let type as MethodType: labels = Array(type.inputs.map({ $0.label ?? "_" }))
+        default: labels = []
         }
 
         let name = program.ast[decl].identifier.value
@@ -86,19 +79,16 @@ public struct DeclLocator: Hashable {
         let decl = NodeID<ProductTypeDecl>(rawValue: decl.rawValue)
         self = .product(program.ast[decl].name)
 
-      default:
-        return nil
+      default: return nil
       }
     }
 
     /// A mangled description of this component.
     public var mangled: String {
       switch self {
-      case .conformance(let target, let trait):
-        return "C\(target)\(trait.mangled)"
+      case .conformance(let target, let trait): return "C\(target)\(trait.mangled)"
 
-      case .extension(let target):
-        return "E\(target)"
+      case .extension(let target): return "E\(target)"
 
       case .function(let name, let labels, let notation):
         let labels = labels.map({ $0.mangled }).joined()
@@ -116,17 +106,13 @@ public struct DeclLocator: Hashable {
         case .sink: return "Is"
         }
 
-      case .module(let name):
-        return "M\(name.mangled)"
+      case .module(let name): return "M\(name.mangled)"
 
-      case .namespace(let name):
-        return "N\(name.mangled)"
+      case .namespace(let name): return "N\(name.mangled)"
 
-      case .lambda(let discriminator):
-        return "L\(discriminator.rawValue)"
+      case .lambda(let discriminator): return "L\(discriminator.rawValue)"
 
-      case .product(let name):
-        return "P\(name.mangled)"
+      case .product(let name): return "P\(name.mangled)"
 
       case .subscript(let name, let labels):
         let ls = labels.map({ $0.mangled }).joined()
@@ -140,8 +126,7 @@ public struct DeclLocator: Hashable {
         case .sink: return "Is"
         }
 
-      case .trait(let name):
-        return "N\(name.mangled)"
+      case .trait(let name): return "N\(name.mangled)"
       }
     }
 
@@ -167,17 +152,13 @@ public struct DeclLocator: Hashable {
   }
 
   /// The locator's value encoded as a string.
-  public var mangled: String {
-    components.lazy.map({ $0.mangled }).joined()
-  }
+  public var mangled: String { components.lazy.map({ $0.mangled }).joined() }
 
 }
 
 extension DeclLocator: CustomStringConvertible {
 
-  public var description: String {
-    components.descriptions(joinedBy: ".")
-  }
+  public var description: String { components.descriptions(joinedBy: ".") }
 
 }
 
@@ -185,11 +166,9 @@ extension DeclLocator.Component: CustomStringConvertible {
 
   public var description: String {
     switch self {
-    case .conformance(let target, let trait):
-      return "(\(target)::\(trait)"
+    case .conformance(let target, let trait): return "(\(target)::\(trait)"
 
-    case .extension(let target):
-      return target.description
+    case .extension(let target): return target.description
 
     case .function(let name, let labels, let notation):
       let n = notation.map(String.init(describing:)) ?? ""
@@ -199,20 +178,15 @@ extension DeclLocator.Component: CustomStringConvertible {
         return n + name + "(" + labels.lazy.map({ "\($0):" }).joined() + ")"
       }
 
-    case .methodImpl(let introducer):
-      return String(describing: introducer)
+    case .methodImpl(let introducer): return String(describing: introducer)
 
-    case .module(let name):
-      return name
+    case .module(let name): return name
 
-    case .namespace(let name):
-      return name
+    case .namespace(let name): return name
 
-    case .lambda(let discriminator):
-      return String(describing: discriminator.rawValue)
+    case .lambda(let discriminator): return String(describing: discriminator.rawValue)
 
-    case .product(let name):
-      return name.description
+    case .product(let name): return name.description
 
     case .subscript(let name, let labels):
       if labels.isEmpty {
@@ -221,11 +195,9 @@ extension DeclLocator.Component: CustomStringConvertible {
         return name + "[" + labels.lazy.map({ "\($0):" }).joined() + "]"
       }
 
-    case .subscriptImpl(let introducer):
-      return String(describing: introducer)
+    case .subscriptImpl(let introducer): return String(describing: introducer)
 
-    case .trait(let name):
-      return name
+    case .trait(let name): return name
     }
   }
 
@@ -243,11 +215,7 @@ extension String {
         result.append(character)
       } else {
         result.append(
-          character.utf16.reduce(
-            into: "u",
-            { (u, point) in
-              u += String(point, radix: 16)
-            }))
+          character.utf16.reduce(into: "u", { (u, point) in u += String(point, radix: 16) }))
       }
     }
 

--- a/Sources/Compiler/AST/Expr/CondExpr.swift
+++ b/Sources/Compiler/AST/Expr/CondExpr.swift
@@ -25,9 +25,7 @@ public struct CondExpr: Expr, LexicalScope {
   public let failure: Body?
 
   public init(
-    condition: [ConditionItem],
-    success: CondExpr.Body,
-    failure: CondExpr.Body?,
+    condition: [ConditionItem], success: CondExpr.Body, failure: CondExpr.Body?,
     origin: SourceRange?
   ) {
     precondition(condition.count > 0)

--- a/Sources/Compiler/AST/Expr/ErrorExpr.swift
+++ b/Sources/Compiler/AST/Expr/ErrorExpr.swift
@@ -3,8 +3,6 @@ public struct ErrorExpr: Expr {
 
   public let origin: SourceRange?
 
-  public init(origin: SourceRange?) {
-    self.origin = origin
-  }
+  public init(origin: SourceRange?) { self.origin = origin }
 
 }

--- a/Sources/Compiler/AST/Expr/ExistentialTypeExpr.swift
+++ b/Sources/Compiler/AST/Expr/ExistentialTypeExpr.swift
@@ -10,9 +10,7 @@ public struct ExistentialTypeExpr: Expr {
   public let whereClause: SourceRepresentable<WhereClause>?
 
   public init(
-    traits: TraitComposition,
-    whereClause: SourceRepresentable<WhereClause>?,
-    origin: SourceRange?
+    traits: TraitComposition, whereClause: SourceRepresentable<WhereClause>?, origin: SourceRange?
   ) {
     self.origin = origin
     self.traits = traits

--- a/Sources/Compiler/AST/Expr/LambdaTypeExpr.swift
+++ b/Sources/Compiler/AST/Expr/LambdaTypeExpr.swift
@@ -32,11 +32,8 @@ public struct LambdaTypeExpr: Expr {
   public let output: AnyExprID
 
   public init(
-    receiverEffect: SourceRepresentable<ReceiverEffect>?,
-    environment: AnyExprID?,
-    parameters: [Parameter],
-    output: AnyTypeExprID,
-    origin: SourceRange?
+    receiverEffect: SourceRepresentable<ReceiverEffect>?, environment: AnyExprID?,
+    parameters: [Parameter], output: AnyTypeExprID, origin: SourceRange?
   ) {
     self.origin = origin
     self.receiverEffect = receiverEffect

--- a/Sources/Compiler/AST/Expr/MatchCase.swift
+++ b/Sources/Compiler/AST/Expr/MatchCase.swift
@@ -23,10 +23,7 @@ public struct MatchCase: Node, LexicalScope {
   public let body: Body
 
   public init(
-    pattern: AnyPatternID,
-    condition: AnyExprID?,
-    body: MatchCase.Body,
-    origin: SourceRange?
+    pattern: AnyPatternID, condition: AnyExprID?, body: MatchCase.Body, origin: SourceRange?
   ) {
     self.origin = origin
     self.pattern = pattern

--- a/Sources/Compiler/AST/Expr/NameExpr.swift
+++ b/Sources/Compiler/AST/Expr/NameExpr.swift
@@ -26,9 +26,7 @@ public struct NameExpr: Expr {
   public let arguments: [LabeledArgument]
 
   public init(
-    domain: Domain = .none,
-    name: SourceRepresentable<Name>,
-    arguments: [LabeledArgument] = [],
+    domain: Domain = .none, name: SourceRepresentable<Name>, arguments: [LabeledArgument] = [],
     origin: SourceRange?
   ) {
     self.origin = origin

--- a/Sources/Compiler/AST/Expr/NilLiteralExpr.swift
+++ b/Sources/Compiler/AST/Expr/NilLiteralExpr.swift
@@ -3,8 +3,6 @@ public struct NilLiteralExpr: Expr {
 
   public let origin: SourceRange?
 
-  public init(origin: SourceRange?) {
-    self.origin = origin
-  }
+  public init(origin: SourceRange?) { self.origin = origin }
 
 }

--- a/Sources/Compiler/AST/Expr/ParameterTypeExpr.swift
+++ b/Sources/Compiler/AST/Expr/ParameterTypeExpr.swift
@@ -10,8 +10,7 @@ public struct ParameterTypeExpr: Expr {
   public let bareType: AnyTypeExprID
 
   public init(
-    convention: SourceRepresentable<PassingConvention>,
-    bareType: AnyTypeExprID,
+    convention: SourceRepresentable<PassingConvention>, bareType: AnyTypeExprID,
     origin: SourceRange?
   ) {
     self.origin = origin

--- a/Sources/Compiler/AST/Expr/RemoteTypeExpr.swift
+++ b/Sources/Compiler/AST/Expr/RemoteTypeExpr.swift
@@ -13,10 +13,8 @@ public struct RemoteTypeExpr: Expr {
   public let operand: AnyTypeExprID
 
   public init(
-    introducerRange: SourceRange?,
-    convention: SourceRepresentable<PassingConvention>,
-    operand: AnyTypeExprID,
-    origin: SourceRange?
+    introducerRange: SourceRange?, convention: SourceRepresentable<PassingConvention>,
+    operand: AnyTypeExprID, origin: SourceRange?
   ) {
     self.origin = origin
     self.introducerRange = introducerRange

--- a/Sources/Compiler/AST/Expr/SequenceExpr.swift
+++ b/Sources/Compiler/AST/Expr/SequenceExpr.swift
@@ -40,8 +40,7 @@ public struct SequenceExpr: Expr {
       if let notation = ast[element.operator].name.value.notation, notation != .infix {
         report.append(
           .diagnose(
-            invalidOperatorNotation: notation,
-            expected: .infix,
+            invalidOperatorNotation: notation, expected: .infix,
             at: ast[element.operator].name.origin))
       }
     }

--- a/Sources/Compiler/AST/Expr/UnicodeScalarLiteralExpr.swift
+++ b/Sources/Compiler/AST/Expr/UnicodeScalarLiteralExpr.swift
@@ -27,8 +27,7 @@ extension UnicodeScalarLiteralExpr: Codable {
     } else {
       throw DecodingError.dataCorrupted(
         DecodingError.Context(
-          codingPath: decoder.codingPath,
-          debugDescription: "Invalid Unicode scalar value"))
+          codingPath: decoder.codingPath, debugDescription: "Invalid Unicode scalar value"))
     }
   }
 

--- a/Sources/Compiler/AST/Expr/WildcardExpr.swift
+++ b/Sources/Compiler/AST/Expr/WildcardExpr.swift
@@ -3,8 +3,6 @@ public struct WildcardExpr: Expr {
 
   public let origin: SourceRange?
 
-  public init(origin: SourceRange?) {
-    self.origin = origin
-  }
+  public init(origin: SourceRange?) { self.origin = origin }
 
 }

--- a/Sources/Compiler/AST/Name.swift
+++ b/Sources/Compiler/AST/Name.swift
@@ -53,9 +53,7 @@ public struct Name: Hashable, Codable {
   }
 
   /// Returns a textual description of `labels`.
-  static func describe(labels: [String?]) -> String {
-    labels.map({ "\($0 ?? "_"):" }).joined()
-  }
+  static func describe(labels: [String?]) -> String { labels.map({ "\($0 ?? "_"):" }).joined() }
 
 }
 
@@ -78,9 +76,7 @@ extension Name: CustomStringConvertible {
 
 extension Name: ExpressibleByStringLiteral {
 
-  public init(stringLiteral value: StringLiteralType) {
-    self.init(stem: value)
-  }
+  public init(stringLiteral value: StringLiteralType) { self.init(stem: value) }
 
 }
 

--- a/Sources/Compiler/AST/Name.swift
+++ b/Sources/Compiler/AST/Name.swift
@@ -16,10 +16,7 @@ public struct Name: Hashable, Codable {
   public let introducer: ImplIntroducer?
 
   /// Creates a new name.
-  public init(
-    stem: Identifier,
-    labels: [String?] = []
-  ) {
+  public init(stem: Identifier, labels: [String?] = []) {
     self.stem = stem
     self.labels = labels
     self.notation = nil
@@ -27,10 +24,7 @@ public struct Name: Hashable, Codable {
   }
 
   /// Creates a new operator name.
-  public init(
-    stem: Identifier,
-    notation: OperatorNotation
-  ) {
+  public init(stem: Identifier, notation: OperatorNotation) {
     self.stem = stem
     self.labels = []
     self.notation = notation
@@ -49,9 +43,7 @@ public struct Name: Hashable, Codable {
 
   /// Creates an instance with the given properties.
   init(
-    stem: Identifier,
-    labels: [String?],
-    notation: OperatorNotation? = nil,
+    stem: Identifier, labels: [String?], notation: OperatorNotation? = nil,
     introducer: ImplIntroducer? = nil
   ) {
     self.stem = stem

--- a/Sources/Compiler/AST/NodeIDs/AnyNodeID.swift
+++ b/Sources/Compiler/AST/NodeIDs/AnyNodeID.swift
@@ -15,12 +15,8 @@ public struct AnyNodeID: NodeIDProtocol {
 
 extension AnyNodeID: Hashable {
 
-  public func hash(into hasher: inout Hasher) {
-    rawValue.hash(into: &hasher)
-  }
+  public func hash(into hasher: inout Hasher) { rawValue.hash(into: &hasher) }
 
-  public static func == (l: Self, r: Self) -> Bool {
-    l.rawValue == r.rawValue
-  }
+  public static func == (l: Self, r: Self) -> Bool { l.rawValue == r.rawValue }
 
 }

--- a/Sources/Compiler/AST/NodeIDs/DeclID.swift
+++ b/Sources/Compiler/AST/NodeIDs/DeclID.swift
@@ -12,9 +12,7 @@ public struct AnyDeclID: DeclID {
   let base: AnyNodeID
 
   /// Creates a type-erased ID from a declaration ID.
-  public init<T: DeclID>(_ other: T) {
-    base = AnyNodeID(other)
-  }
+  public init<T: DeclID>(_ other: T) { base = AnyNodeID(other) }
 
   public var rawValue: Int { base.rawValue }
 

--- a/Sources/Compiler/AST/NodeIDs/ExprID.swift
+++ b/Sources/Compiler/AST/NodeIDs/ExprID.swift
@@ -12,9 +12,7 @@ public struct AnyExprID: ExprID {
   let base: AnyNodeID
 
   /// Creates a type-erased ID from a value expression ID.
-  public init<T: ExprID>(_ other: T) {
-    base = AnyNodeID(other)
-  }
+  public init<T: ExprID>(_ other: T) { base = AnyNodeID(other) }
 
   public var rawValue: Int { base.rawValue }
 

--- a/Sources/Compiler/AST/NodeIDs/NodeID.swift
+++ b/Sources/Compiler/AST/NodeIDs/NodeID.swift
@@ -29,19 +29,13 @@ public struct NodeID<Subject: Node>: ConcreteNodeID {
 
   /// Creates an instance with the same raw value as `x` failing iff `x.kind != Subject.kind`.
   public init?<Other: NodeIDProtocol>(_ x: Other) {
-    if x.kind == Subject.kind {
-      self.init(rawValue: x.rawValue)
-    } else {
-      return nil
-    }
+    if x.kind == Subject.kind { self.init(rawValue: x.rawValue) } else { return nil }
   }
 
   /// Creates an instance with the given raw value.
   ///
   /// The result can only be used correctly in an AST where the identified node has type `Subject`.
-  internal init(rawValue: RawValue) {
-    self.rawValue = rawValue
-  }
+  internal init(rawValue: RawValue) { self.rawValue = rawValue }
 
   public static func == <Other: NodeIDProtocol>(l: Self, r: Other) -> Bool {
     l.rawValue == r.rawValue

--- a/Sources/Compiler/AST/NodeIDs/NodeKind.swift
+++ b/Sources/Compiler/AST/NodeIDs/NodeKind.swift
@@ -8,9 +8,7 @@ public struct NodeKind: Codable, Equatable, Hashable {
   let value: Node.Type
 
   /// Creates an instance with the given underlying value.
-  public init(_ value: Node.Type) {
-    self.value = value
-  }
+  public init(_ value: Node.Type) { self.value = value }
 
   /// Serializes `self` into `destination`.
   public func encode(to destination: Encoder) throws {
@@ -24,39 +22,25 @@ public struct NodeKind: Codable, Equatable, Hashable {
   }
 
   /// Returns true iff `l` and `r` denote the same node type.
-  public static func == (l: Self, r: Self) -> Bool {
-    return l.value == r.value
-  }
+  public static func == (l: Self, r: Self) -> Bool { return l.value == r.value }
 
   /// Incorporates the value of `self` into `h`.
-  public func hash(into h: inout Hasher) {
-    ObjectIdentifier(value).hash(into: &h)
-  }
+  public func hash(into h: inout Hasher) { ObjectIdentifier(value).hash(into: &h) }
 
   /// Returns true iff `l` and `r` denote the same node type.
-  static func == (l: Self, r: Node.Type) -> Bool {
-    return l.value == r
-  }
+  static func == (l: Self, r: Node.Type) -> Bool { return l.value == r }
 
   /// Returns true iff `l` and `r` do not denote the same node type.
-  static func != (l: Self, r: Node.Type) -> Bool {
-    return l.value == r
-  }
+  static func != (l: Self, r: Node.Type) -> Bool { return l.value == r }
 
   /// Returns true iff `l` and `r` denote the same node type.
-  static func == (l: Node.Type, r: Self) -> Bool {
-    return l == r.value
-  }
+  static func == (l: Node.Type, r: Self) -> Bool { return l == r.value }
 
   /// Returns true iff `l` and `r` do not denote the same node type.
-  static func != (l: Node.Type, r: Self) -> Bool {
-    return l != r.value
-  }
+  static func != (l: Node.Type, r: Self) -> Bool { return l != r.value }
 
   /// Returns true iff `me` and `pattern` denote the same node type.
-  static func ~= (pattern: Node.Type, me: Self) -> Bool {
-    me == pattern
-  }
+  static func ~= (pattern: Node.Type, me: Self) -> Bool { me == pattern }
 
 }
 
@@ -64,24 +48,16 @@ public struct NodeKind: Codable, Equatable, Hashable {
 extension Optional where Wrapped == NodeKind {
 
   /// Returns true iff `l` and `r` denote the same node type.
-  static func == (l: Self, r: Node.Type) -> Bool {
-    return l?.value == r
-  }
+  static func == (l: Self, r: Node.Type) -> Bool { return l?.value == r }
 
   /// Returns true iff `l` and `r` do not denote the same node type.
-  static func != (l: Self, r: Node.Type) -> Bool {
-    return l?.value == r
-  }
+  static func != (l: Self, r: Node.Type) -> Bool { return l?.value == r }
 
   /// Returns true iff `l` and `r` denote the same node type.
-  static func == (l: Node.Type, r: Self) -> Bool {
-    return l == r?.value
-  }
+  static func == (l: Node.Type, r: Self) -> Bool { return l == r?.value }
 
   /// Returns true iff `l` and `r` do not denote the same node type.
-  static func != (l: Node.Type, r: Self) -> Bool {
-    return l != r?.value
-  }
+  static func != (l: Node.Type, r: Self) -> Bool { return l != r?.value }
 
 }
 

--- a/Sources/Compiler/AST/NodeIDs/PatternID.swift
+++ b/Sources/Compiler/AST/NodeIDs/PatternID.swift
@@ -12,9 +12,7 @@ public struct AnyPatternID: PatternID {
   let base: AnyNodeID
 
   /// Creates a type-erased ID from a pattern ID.
-  public init<T: PatternID>(_ other: T) {
-    base = AnyNodeID(other)
-  }
+  public init<T: PatternID>(_ other: T) { base = AnyNodeID(other) }
 
   public var rawValue: Int { base.rawValue }
 

--- a/Sources/Compiler/AST/NodeIDs/ScopeID.swift
+++ b/Sources/Compiler/AST/NodeIDs/ScopeID.swift
@@ -12,18 +12,12 @@ public struct AnyScopeID: ScopeID {
   let base: AnyNodeID
 
   /// Creates a type-erased ID from the ID of a node outlining a lexical scope.
-  public init<T: ScopeID>(_ other: T) {
-    base = AnyNodeID(other)
-  }
+  public init<T: ScopeID>(_ other: T) { base = AnyNodeID(other) }
 
   /// Creates an instance referring to the same node as `x`, failing if `x` does not identify a
   /// lexical scope.
   public init?<Other: NodeIDProtocol>(_ x: Other) {
-    if x.kind.value is LexicalScope.Type {
-      base = AnyNodeID(x)
-    } else {
-      return nil
-    }
+    if x.kind.value is LexicalScope.Type { base = AnyNodeID(x) } else { return nil }
   }
 
   public var rawValue: Int { base.rawValue }

--- a/Sources/Compiler/AST/NodeIDs/StmtID.swift
+++ b/Sources/Compiler/AST/NodeIDs/StmtID.swift
@@ -12,9 +12,7 @@ public struct AnyStmtID: StmtID {
   let base: AnyNodeID
 
   /// Creates a type-erased ID from a statement ID.
-  public init<T: StmtID>(_ other: T) {
-    base = AnyNodeID(other)
-  }
+  public init<T: StmtID>(_ other: T) { base = AnyNodeID(other) }
 
   public var rawValue: Int { base.rawValue }
 

--- a/Sources/Compiler/AST/Pattern/BindingPattern.swift
+++ b/Sources/Compiler/AST/Pattern/BindingPattern.swift
@@ -30,10 +30,8 @@ public struct BindingPattern: Pattern {
   public let annotation: AnyTypeExprID?
 
   public init(
-    introducer: SourceRepresentable<BindingPattern.Introducer>,
-    subpattern: AnyPatternID,
-    annotation: AnyTypeExprID?,
-    origin: SourceRange?
+    introducer: SourceRepresentable<BindingPattern.Introducer>, subpattern: AnyPatternID,
+    annotation: AnyTypeExprID?, origin: SourceRange?
   ) {
     self.origin = origin
     self.introducer = introducer

--- a/Sources/Compiler/AST/Pattern/WildcardPattern.swift
+++ b/Sources/Compiler/AST/Pattern/WildcardPattern.swift
@@ -3,8 +3,6 @@ public struct WildcardPattern: Pattern {
 
   public let origin: SourceRange?
 
-  public init(origin: SourceRange?) {
-    self.origin = origin
-  }
+  public init(origin: SourceRange?) { self.origin = origin }
 
 }

--- a/Sources/Compiler/AST/PrecedenceGroup.swift
+++ b/Sources/Compiler/AST/PrecedenceGroup.swift
@@ -49,8 +49,7 @@ public enum PrecedenceGroup: String, Codable {
   /// The associativity of the operators in the group.
   public var associativity: Associativity {
     switch self {
-    case .assignment, .fallback, .exponentiation:
-      return .right
+    case .assignment, .fallback, .exponentiation: return .right
     case .disjunction, .conjunction, .comparison, .addition, .multiplication, .range, .shift:
       return .left
     }
@@ -61,8 +60,6 @@ public enum PrecedenceGroup: String, Codable {
 
 extension PrecedenceGroup: Comparable {
 
-  public static func < (l: Self, r: Self) -> Bool {
-    l.power < r.power
-  }
+  public static func < (l: Self, r: Self) -> Bool { l.power < r.power }
 
 }

--- a/Sources/Compiler/AST/SourceRepresentable.swift
+++ b/Sources/Compiler/AST/SourceRepresentable.swift
@@ -19,17 +19,13 @@ public struct SourceRepresentable<Part> {
 
 extension SourceRepresentable: Equatable where Part: Equatable {
 
-  public static func == (l: Self, r: Self) -> Bool {
-    l.value == r.value
-  }
+  public static func == (l: Self, r: Self) -> Bool { l.value == r.value }
 
 }
 
 extension SourceRepresentable: Hashable where Part: Hashable {
 
-  public func hash(into hasher: inout Hasher) {
-    value.hash(into: &hasher)
-  }
+  public func hash(into hasher: inout Hasher) { value.hash(into: &hasher) }
 
 }
 
@@ -44,11 +40,7 @@ extension SourceRepresentable: Codable where Part: Codable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     value = try container.decode(Part.self, forKey: .value)
-    do {
-      origin = try container.decode(SourceRange?.self, forKey: .range)
-    } catch {
-      origin = nil
-    }
+    do { origin = try container.decode(SourceRange?.self, forKey: .range) } catch { origin = nil }
   }
 
   public func encode(to encoder: Encoder) throws {

--- a/Sources/Compiler/AST/Stmt/BreakStmt.swift
+++ b/Sources/Compiler/AST/Stmt/BreakStmt.swift
@@ -3,8 +3,6 @@ public struct BreakStmt: Stmt {
 
   public let origin: SourceRange?
 
-  public init(origin: SourceRange?) {
-    self.origin = origin
-  }
+  public init(origin: SourceRange?) { self.origin = origin }
 
 }

--- a/Sources/Compiler/AST/Stmt/ContinueStmt.swift
+++ b/Sources/Compiler/AST/Stmt/ContinueStmt.swift
@@ -3,8 +3,6 @@ public struct ContinueStmt: Stmt {
 
   public let origin: SourceRange?
 
-  public init(origin: SourceRange?) {
-    self.origin = origin
-  }
+  public init(origin: SourceRange?) { self.origin = origin }
 
 }

--- a/Sources/Compiler/AST/Stmt/ForStmt.swift
+++ b/Sources/Compiler/AST/Stmt/ForStmt.swift
@@ -16,10 +16,7 @@ public struct ForStmt: Stmt, LexicalScope {
   public let body: NodeID<BraceStmt>
 
   internal init(
-    binding: NodeID<BindingDecl>,
-    domain: AnyExprID,
-    filter: AnyExprID?,
-    body: NodeID<BraceStmt>,
+    binding: NodeID<BindingDecl>, domain: AnyExprID, filter: AnyExprID?, body: NodeID<BraceStmt>,
     origin: SourceRange?
   ) {
     self.origin = origin

--- a/Sources/Compiler/AST/Utils/ASTProperty.swift
+++ b/Sources/Compiler/AST/Utils/ASTProperty.swift
@@ -17,10 +17,9 @@ public struct ASTProperty<Property> {
 
   /// Accesses the property this map associates with `id`, or `defaultProperty` if this map makes
   /// no such association.
-  public subscript<T: NodeIDProtocol>(
-    id: T,
-    default defaultProperty: @autoclosure () -> Property
-  ) -> Property {
+  public subscript<T: NodeIDProtocol>(id: T, default defaultProperty: @autoclosure () -> Property)
+    -> Property
+  {
     _read {
       yield storage[AnyNodeID(id), default: defaultProperty()]
     }

--- a/Sources/Compiler/AST/Utils/ASTProperty.swift
+++ b/Sources/Compiler/AST/Utils/ASTProperty.swift
@@ -5,9 +5,7 @@ public struct ASTProperty<Property> {
   private var storage: [AnyNodeID: Property]
 
   /// Creates an empty instance.
-  public init() {
-    storage = [:]
-  }
+  public init() { storage = [:] }
 
   /// Accesses the `Property` this map associates with `id`.
   public subscript<T: NodeIDProtocol>(id: T) -> Property? {
@@ -20,9 +18,7 @@ public struct ASTProperty<Property> {
   public subscript<T: NodeIDProtocol>(id: T, default defaultProperty: @autoclosure () -> Property)
     -> Property
   {
-    _read {
-      yield storage[AnyNodeID(id), default: defaultProperty()]
-    }
+    _read { yield storage[AnyNodeID(id), default: defaultProperty()] }
     _modify {
       var value = storage[AnyNodeID(id)] ?? defaultProperty()
       defer { storage[AnyNodeID(id)] = value }

--- a/Sources/Compiler/AST/Utils/DeclProperty.swift
+++ b/Sources/Compiler/AST/Utils/DeclProperty.swift
@@ -5,9 +5,7 @@ public struct DeclProperty<Value> {
   public var storage: [AnyDeclID: Value]
 
   /// Creates an empty node map.
-  public init() {
-    storage = [:]
-  }
+  public init() { storage = [:] }
 
   /// Accesses the property associated with the specified ID.
   public subscript<T: DeclID>(id: T) -> Value? {
@@ -17,9 +15,7 @@ public struct DeclProperty<Value> {
 
   /// Accesses the property associated with the specified ID.
   public subscript<T: DeclID>(id: T, default defaultValue: @autoclosure () -> Value) -> Value {
-    _read {
-      yield storage[AnyDeclID(id), default: defaultValue()]
-    }
+    _read { yield storage[AnyDeclID(id), default: defaultValue()] }
     _modify {
       var value = storage[AnyDeclID(id)] ?? defaultValue()
       defer { storage[AnyDeclID(id)] = value }

--- a/Sources/Compiler/AST/Utils/DeclProperty.swift
+++ b/Sources/Compiler/AST/Utils/DeclProperty.swift
@@ -16,10 +16,7 @@ public struct DeclProperty<Value> {
   }
 
   /// Accesses the property associated with the specified ID.
-  public subscript<T: DeclID>(
-    id: T,
-    default defaultValue: @autoclosure () -> Value
-  ) -> Value {
+  public subscript<T: DeclID>(id: T, default defaultValue: @autoclosure () -> Value) -> Value {
     _read {
       yield storage[AnyDeclID(id), default: defaultValue()]
     }

--- a/Sources/Compiler/AST/Utils/ExprProperty.swift
+++ b/Sources/Compiler/AST/Utils/ExprProperty.swift
@@ -16,10 +16,7 @@ public struct ExprProperty<Value> {
   }
 
   /// Accesses the property associated with the specified ID.
-  public subscript<T: ExprID>(
-    id: T,
-    default defaultValue: @autoclosure () -> Value
-  ) -> Value {
+  public subscript<T: ExprID>(id: T, default defaultValue: @autoclosure () -> Value) -> Value {
     _read {
       yield storage[AnyExprID(id), default: defaultValue()]
     }

--- a/Sources/Compiler/AST/Utils/ExprProperty.swift
+++ b/Sources/Compiler/AST/Utils/ExprProperty.swift
@@ -5,9 +5,7 @@ public struct ExprProperty<Value> {
   public var storage: [AnyExprID: Value]
 
   /// Creates an empty node map.
-  public init() {
-    storage = [:]
-  }
+  public init() { storage = [:] }
 
   /// Accesses the property associated with the specified ID.
   public subscript<T: ExprID>(id: T) -> Value? {
@@ -17,9 +15,7 @@ public struct ExprProperty<Value> {
 
   /// Accesses the property associated with the specified ID.
   public subscript<T: ExprID>(id: T, default defaultValue: @autoclosure () -> Value) -> Value {
-    _read {
-      yield storage[AnyExprID(id), default: defaultValue()]
-    }
+    _read { yield storage[AnyExprID(id), default: defaultValue()] }
     _modify {
       var value = storage[AnyExprID(id)] ?? defaultValue()
       defer { storage[AnyExprID(id)] = value }

--- a/Sources/Compiler/CXX/CXXIdentifier.swift
+++ b/Sources/Compiler/CXX/CXXIdentifier.swift
@@ -18,16 +18,10 @@ public struct CXXIdentifier: CustomStringConvertible {
 
   /// The set of reserved keywords in C++.
   public static let reserved = Set([
-    "asm", "auto", "break", "case",
-    "catch", "char", "class", "const",
-    "continue", "default", "delete", "do",
-    "double", "else", "enum", "extern",
-    "float", "for", "friend", "goto",
-    "if", "inline", "int", "long",
-    "signed", "sizeof", "static", "struct",
-    "switch", "template", "this", "throw",
-    "try", "typedef", "union", "unsigned",
-    "virtual", "void", "volatile", "while",
+    "asm", "auto", "break", "case", "catch", "char", "class", "const", "continue", "default",
+    "delete", "do", "double", "else", "enum", "extern", "float", "for", "friend", "goto", "if",
+    "inline", "int", "long", "signed", "sizeof", "static", "struct", "switch", "template", "this",
+    "throw", "try", "typedef", "union", "unsigned", "virtual", "void", "volatile", "while",
   ])
 
 }

--- a/Sources/Compiler/CXX/CXXIdentifier.swift
+++ b/Sources/Compiler/CXX/CXXIdentifier.swift
@@ -4,16 +4,12 @@ public struct CXXIdentifier: CustomStringConvertible {
   /// The value of the identifier.
   public let description: String
 
-  public init(_ identifier: String) {
-    description = CXXIdentifier.sanitize(identifier)
-  }
+  public init(_ identifier: String) { description = CXXIdentifier.sanitize(identifier) }
 
   /// Sanitizes `identifier` and returns a valid C++ identifier.
   public static func sanitize(_ identifier: String) -> String {
     // Append an underscore to reserved identifiers.
-    reserved.contains(identifier)
-      ? identifier + "_"
-      : identifier
+    reserved.contains(identifier) ? identifier + "_" : identifier
   }
 
   /// The set of reserved keywords in C++.

--- a/Sources/Compiler/CXX/CXXModule.swift
+++ b/Sources/Compiler/CXX/CXXModule.swift
@@ -47,25 +47,20 @@ public struct CXXModule {
       case let valDeclType as LambdaType:
         output = CXXTypeExpr(valDeclType.output, ast: program.ast, asReturnType: true)!
 
-      case is MethodType:
-        fatalError("not implemented")
+      case is MethodType: fatalError("not implemented")
 
-      default:
-        unreachable()
+      default: unreachable()
       }
     }
 
     // Determine the parameter types of the function.
     let paramTypes: [CallableTypeParameter]
     switch valFunctionDecl.type.base {
-    case let valDeclType as LambdaType:
-      paramTypes = valDeclType.inputs
+    case let valDeclType as LambdaType: paramTypes = valDeclType.inputs
 
-    case is MethodType:
-      fatalError("not implemented")
+    case is MethodType: fatalError("not implemented")
 
-    default:
-      unreachable()
+    default: unreachable()
     }
 
     // Determine the parameters of the function.
@@ -92,9 +87,7 @@ public struct CXXModule {
   /// Set the body for the function with the given ID.
   public mutating func setFunctionBody(
     _ body: CXXRepresentable?, forID cxxFunID: CXXFunctionDecl.ID
-  ) {
-    cxxFunctionBodies[cxxFunID] = body
-  }
+  ) { cxxFunctionBodies[cxxFunID] = body }
 
   // MARK: Serialization
 

--- a/Sources/Compiler/CXX/CXXModule.swift
+++ b/Sources/Compiler/CXX/CXXModule.swift
@@ -27,9 +27,9 @@ public struct CXXModule {
   /// Returns the ID of the C++ function declaration corresponding to `valFunctionDecl`.
   ///
   /// - Requires: `valFunctionDecl` must be declared in `self.decl`.
-  public mutating func getOrCreateFunction(
-    correspondingTo valFunctionDecl: Typed<FunctionDecl>
-  ) -> CXXFunctionDecl.ID {
+  public mutating func getOrCreateFunction(correspondingTo valFunctionDecl: Typed<FunctionDecl>)
+    -> CXXFunctionDecl.ID
+  {
     if let cxxFunctionDecl = valToCXXFunction[valFunctionDecl] { return cxxFunctionDecl }
 
     assert(program.isGlobal(valFunctionDecl.id))
@@ -80,10 +80,7 @@ public struct CXXModule {
     // Create the C++ function.
     let cxxFunctionDecl = cxxFunctions.count
     cxxFunctions.append(
-      CXXFunctionDecl(
-        identifier: identifier,
-        output: output,
-        parameters: cxxParams))
+      CXXFunctionDecl(identifier: identifier, output: output, parameters: cxxParams))
     // Associate an empty body to it.
     cxxFunctionBodies.append(nil)
 
@@ -94,8 +91,7 @@ public struct CXXModule {
 
   /// Set the body for the function with the given ID.
   public mutating func setFunctionBody(
-    _ body: CXXRepresentable?,
-    forID cxxFunID: CXXFunctionDecl.ID
+    _ body: CXXRepresentable?, forID cxxFunID: CXXFunctionDecl.ID
   ) {
     cxxFunctionBodies[cxxFunID] = body
   }

--- a/Sources/Compiler/CXX/CXXScopedBlock.swift
+++ b/Sources/Compiler/CXX/CXXScopedBlock.swift
@@ -5,9 +5,7 @@ struct CXXScopedBlock: CXXRepresentable {
 
   func writeCode<Target: TextOutputStream>(into target: inout Target) {
     target.write("{\n")
-    for stmt in stmts {
-      stmt.writeCode(into: &target)
-    }
+    for stmt in stmts { stmt.writeCode(into: &target) }
     target.write("}\n")
   }
 

--- a/Sources/Compiler/CXX/CXXTranspiler.swift
+++ b/Sources/Compiler/CXX/CXXTranspiler.swift
@@ -76,8 +76,7 @@ public struct CXXTranspiler {
 
   /// Emits borrowed bindings.
   private mutating func emit(
-    borrowedLocalBinding decl: Typed<BindingDecl>,
-    withCapability capability: RemoteType.Capability
+    borrowedLocalBinding decl: Typed<BindingDecl>, withCapability capability: RemoteType.Capability
   ) -> CXXRepresentable {
     // There's nothing to do if there's no initializer.
     if let initializer = decl.initializer {
@@ -153,10 +152,7 @@ public struct CXXTranspiler {
 
   // MARK: Expressions
 
-  private mutating func emit(
-    expr: TypedNode<AnyExprID>,
-    asLValue: Bool
-  ) -> CXXRepresentable {
+  private mutating func emit(expr: TypedNode<AnyExprID>, asLValue: Bool) -> CXXRepresentable {
     if asLValue {
       return CXXComment(comment: "expr (lvalue)")
     } else {

--- a/Sources/Compiler/CXX/CXXTranspiler.swift
+++ b/Sources/Compiler/CXX/CXXTranspiler.swift
@@ -7,28 +7,22 @@ public struct CXXTranspiler {
   public let program: TypedProgram
 
   /// Creates a C++ transpiler with a well-typed AST.
-  public init(program: TypedProgram) {
-    self.program = program
-  }
+  public init(program: TypedProgram) { self.program = program }
 
   // MARK: API
 
   /// Emits the C++ module corresponding to the Val module identified by `decl`.
   public mutating func emit(module decl: Typed<ModuleDecl>) -> CXXModule {
     var module = CXXModule(decl, for: program)
-    for member in decl.topLevelDecls {
-      emit(topLevel: member, into: &module)
-    }
+    for member in decl.topLevelDecls { emit(topLevel: member, into: &module) }
     return module
   }
 
   /// Emits the given top-level declaration into `module`.
   mutating func emit(topLevel decl: TypedNode<AnyDeclID>, into module: inout CXXModule) {
     switch decl.kind {
-    case FunctionDecl.self:
-      emit(function: Typed<FunctionDecl>(decl)!, into: &module)
-    default:
-      unreachable("unexpected declaration")
+    case FunctionDecl.self: emit(function: Typed<FunctionDecl>(decl)!, into: &module)
+    default: unreachable("unexpected declaration")
     }
   }
 
@@ -38,16 +32,13 @@ public struct CXXTranspiler {
     let id = module.getOrCreateFunction(correspondingTo: decl)
 
     // If we have a body for our function, emit it.
-    if let body = decl.body {
-      module.setFunctionBody(emit(funBody: body), forID: id)
-    }
+    if let body = decl.body { module.setFunctionBody(emit(funBody: body), forID: id) }
   }
 
   /// Translate the function body into a CXX entity.
   private mutating func emit(funBody body: Typed<FunctionDecl>.Body) -> CXXRepresentable {
     switch body {
-    case .block(let stmt):
-      return emit(brace: stmt)
+    case .block(let stmt): return emit(brace: stmt)
 
     case .expr:
       let exprStmt = CXXComment(comment: "expr")
@@ -61,12 +52,9 @@ public struct CXXTranspiler {
     let pattern = decl.pattern
 
     switch pattern.introducer.value {
-    case .var, .sinklet:
-      return emit(storedLocalBinding: decl)
-    case .let:
-      return emit(borrowedLocalBinding: decl, withCapability: .let)
-    case .inout:
-      return emit(borrowedLocalBinding: decl, withCapability: .inout)
+    case .var, .sinklet: return emit(storedLocalBinding: decl)
+    case .let: return emit(borrowedLocalBinding: decl, withCapability: .let)
+    case .inout: return emit(borrowedLocalBinding: decl, withCapability: .inout)
     }
   }
 
@@ -112,33 +100,24 @@ public struct CXXTranspiler {
   /// Emits the given statement into `module` at the current insertion point.
   private mutating func emit<ID: StmtID>(stmt: TypedNode<ID>) -> CXXRepresentable {
     switch stmt.kind {
-    case BraceStmt.self:
-      return emit(brace: Typed<BraceStmt>(stmt)!)
-    case DeclStmt.self:
-      return emit(declStmt: Typed<DeclStmt>(stmt)!)
-    case ExprStmt.self:
-      return emit(exprStmt: Typed<ExprStmt>(stmt)!)
-    case ReturnStmt.self:
-      return emit(returnStmt: Typed<ReturnStmt>(stmt)!)
-    default:
-      unreachable("unexpected statement")
+    case BraceStmt.self: return emit(brace: Typed<BraceStmt>(stmt)!)
+    case DeclStmt.self: return emit(declStmt: Typed<DeclStmt>(stmt)!)
+    case ExprStmt.self: return emit(exprStmt: Typed<ExprStmt>(stmt)!)
+    case ReturnStmt.self: return emit(returnStmt: Typed<ReturnStmt>(stmt)!)
+    default: unreachable("unexpected statement")
     }
   }
 
   private mutating func emit(brace stmt: Typed<BraceStmt>) -> CXXRepresentable {
     var stmts: [CXXRepresentable] = []
-    for s in stmt.stmts {
-      stmts.append(emit(stmt: s))
-    }
+    for s in stmt.stmts { stmts.append(emit(stmt: s)) }
     return CXXScopedBlock(stmts: stmts)
   }
 
   private mutating func emit(declStmt stmt: Typed<DeclStmt>) -> CXXRepresentable {
     switch stmt.decl.kind {
-    case BindingDecl.self:
-      return emit(localBinding: Typed<BindingDecl>(stmt.decl)!)
-    default:
-      unreachable("unexpected declaration")
+    case BindingDecl.self: return emit(localBinding: Typed<BindingDecl>(stmt.decl)!)
+    default: unreachable("unexpected declaration")
     }
   }
 

--- a/Sources/Compiler/CXX/CXXTypeExpr.swift
+++ b/Sources/Compiler/CXX/CXXTypeExpr.swift
@@ -13,8 +13,7 @@ public struct CXXTypeExpr: CustomStringConvertible {
   ///     variable type annotation.
   public init?(_ type: AnyType, ast: AST, asReturnType isReturnType: Bool = false) {
     switch type.base {
-    case AnyType.void:
-      description = isReturnType ? "void" : "std::monostate"
+    case AnyType.void: description = isReturnType ? "void" : "std::monostate"
 
     case let type as ProductType:
       // TODO: we should translate this to an "int" struct
@@ -29,14 +28,11 @@ public struct CXXTypeExpr: CustomStringConvertible {
       let bareDescription = CXXTypeExpr(type.bareType, ast: ast)!.description
       description = bareDescription
 
-    default:
-      return nil
+    default: return nil
     }
   }
 
   /// Creates a C++ type expression from its textual representation.
-  public init(_ description: String) {
-    self.description = description
-  }
+  public init(_ description: String) { self.description = description }
 
 }

--- a/Sources/Compiler/DiagnosedError.swift
+++ b/Sources/Compiler/DiagnosedError.swift
@@ -5,9 +5,7 @@ public struct DiagnosedError: Error {
   public let diagnostics: [Diagnostic]
 
   /// Creates a new instance with the given diagnostic.
-  public init(_ d: Diagnostic) {
-    self.diagnostics = [d]
-  }
+  public init(_ d: Diagnostic) { self.diagnostics = [d] }
 
   /// Creates a new instance with the given diagnostics.
   ///

--- a/Sources/Compiler/Diagnostic.swift
+++ b/Sources/Compiler/Diagnostic.swift
@@ -48,10 +48,7 @@ public struct Diagnostic: Hashable {
 
   /// Creates a new diagnostic.
   public init(
-    level: Level,
-    message: String,
-    location: SourceLocation? = nil,
-    window: Window? = nil,
+    level: Level, message: String, location: SourceLocation? = nil, window: Window? = nil,
     children: [Diagnostic] = []
   ) {
     self.level = level
@@ -63,30 +60,20 @@ public struct Diagnostic: Hashable {
 
   /// Creates an error diagnostic with `message` highlighting `range`.
   public static func error(
-    _ message: String,
-    range: SourceRange? = nil,
-    children: [Diagnostic] = []
+    _ message: String, range: SourceRange? = nil, children: [Diagnostic] = []
   ) -> Diagnostic {
     Diagnostic(
-      level: .error,
-      message: message,
-      location: range?.first(),
-      window: range.map({ r in Diagnostic.Window(range: r) }),
-      children: children)
+      level: .error, message: message, location: range?.first(),
+      window: range.map({ r in Diagnostic.Window(range: r) }), children: children)
   }
 
   /// Creates a warning diagnostic with `message` highlighting `range`.
   public static func warning(
-    _ message: String,
-    range: SourceRange? = nil,
-    children: [Diagnostic] = []
+    _ message: String, range: SourceRange? = nil, children: [Diagnostic] = []
   ) -> Diagnostic {
     Diagnostic(
-      level: .warning,
-      message: message,
-      location: range?.first(),
-      window: range.map({ r in Diagnostic.Window(range: r) }),
-      children: children)
+      level: .warning, message: message, location: range?.first(),
+      window: range.map({ r in Diagnostic.Window(range: r) }), children: children)
   }
 
 }

--- a/Sources/Compiler/IR/AbstractTypeLayout.swift
+++ b/Sources/Compiler/IR/AbstractTypeLayout.swift
@@ -33,9 +33,7 @@ extension TypedProgram {
       type: type, storedPropertiesIndices: indicesAndTypes.indices,
       storedPropertiesTypes: indicesAndTypes.types)
 
-    for offset in path {
-      layout = abstractLayout(of: layout.storedPropertiesTypes[offset])
-    }
+    for offset in path { layout = abstractLayout(of: layout.storedPropertiesTypes[offset]) }
     return layout
   }
 
@@ -56,8 +54,7 @@ extension TypedProgram {
         }
       }
 
-    default:
-      break
+    default: break
     }
 
     return (indices, types)

--- a/Sources/Compiler/IR/AbstractTypeLayout.swift
+++ b/Sources/Compiler/IR/AbstractTypeLayout.swift
@@ -11,9 +11,7 @@ public struct AbstractTypeLayout {
   public let storedPropertiesTypes: [AnyType]
 
   fileprivate init(
-    type: AnyType,
-    storedPropertiesIndices: [String: Int],
-    storedPropertiesTypes: [AnyType]
+    type: AnyType, storedPropertiesIndices: [String: Int], storedPropertiesTypes: [AnyType]
   ) {
     self.type = type
     self.storedPropertiesIndices = storedPropertiesIndices
@@ -32,8 +30,7 @@ extension TypedProgram {
   public func abstractLayout(of type: AnyType, at path: [Int] = []) -> AbstractTypeLayout {
     let indicesAndTypes = storedPropertiesIndicesAndTypes(of: type)
     var layout = AbstractTypeLayout(
-      type: type,
-      storedPropertiesIndices: indicesAndTypes.indices,
+      type: type, storedPropertiesIndices: indicesAndTypes.indices,
       storedPropertiesTypes: indicesAndTypes.types)
 
     for offset in path {
@@ -42,9 +39,9 @@ extension TypedProgram {
     return layout
   }
 
-  private func storedPropertiesIndicesAndTypes(
-    of type: AnyType
-  ) -> (indices: [String: Int], types: [AnyType]) {
+  private func storedPropertiesIndicesAndTypes(of type: AnyType) -> (
+    indices: [String: Int], types: [AnyType]
+  ) {
     var indices: [String: Int] = [:]
     var types: [AnyType] = []
 

--- a/Sources/Compiler/IR/Analysis/ControlFlowGraph.swift
+++ b/Sources/Compiler/IR/Analysis/ControlFlowGraph.swift
@@ -28,9 +28,7 @@ struct ControlFlowGraph {
   fileprivate var relation: DirectedGraph<Vertex, Label>
 
   /// Creates an empty control flow graph.
-  init() {
-    relation = DirectedGraph()
-  }
+  init() { relation = DirectedGraph() }
 
   /// Defines `source` as a predecessor of `target`.
   mutating func define(_ source: Vertex, predecessorOf target: Vertex) {
@@ -52,23 +50,18 @@ struct ControlFlowGraph {
     case .bidirectional:
       relation[from: source, to: target] = .backward
       relation[from: target, to: source] = .forward
-    default:
-      break
+    default: break
     }
   }
 
   /// Returns the successors of `source`.
   func successors(of source: Vertex) -> [Vertex] {
-    relation[from: source].compactMap({ tip in
-      tip.value != .backward ? tip.key : nil
-    })
+    relation[from: source].compactMap({ tip in tip.value != .backward ? tip.key : nil })
   }
 
   /// Returns the predecessors of `target`.
   func predecessors(of target: Vertex) -> [Vertex] {
-    relation[from: target].compactMap({ tip in
-      tip.value != .forward ? tip.key : nil
-    })
+    relation[from: target].compactMap({ tip in tip.value != .forward ? tip.key : nil })
   }
 
 }

--- a/Sources/Compiler/IR/Analysis/DefiniteInitializationPass.swift
+++ b/Sources/Compiler/IR/Analysis/DefiniteInitializationPass.swift
@@ -149,8 +149,7 @@ public struct DefiniteInitializationPass: TransformPass {
                 for path in difference {
                   let objectType = program.abstractLayout(of: rootType, at: path).type
                   let object = module.insert(
-                    LoadInst(.object(objectType), from: operand, at: path),
-                    at: beforeTerminator)[0]
+                    LoadInst(.object(objectType), from: operand, at: path), at: beforeTerminator)[0]
                   module.insert(DeinitInst(object), at: beforeTerminator)
                 }
                 didChange = true
@@ -315,9 +314,9 @@ public struct DefiniteInitializationPass: TransformPass {
     return true
   }
 
-  private mutating func eval(
-    allocStack inst: AllocStackInst, id: InstID, module: inout Module
-  ) -> Bool {
+  private mutating func eval(allocStack inst: AllocStackInst, id: InstID, module: inout Module)
+    -> Bool
+  {
     // Create an abstract location denoting the newly allocated memory.
     let location = MemoryLocation.inst(block: id.block, address: id.address)
     if currentContext.memory[location] != nil {
@@ -332,9 +331,7 @@ public struct DefiniteInitializationPass: TransformPass {
     return true
   }
 
-  private mutating func eval(
-    borrow inst: BorrowInst, id: InstID, module: inout Module
-  ) -> Bool {
+  private mutating func eval(borrow inst: BorrowInst, id: InstID, module: inout Module) -> Bool {
     // Operand must a location.
     let locations: [MemoryLocation]
     if let key = FunctionLocal(operand: inst.location) {
@@ -415,9 +412,9 @@ public struct DefiniteInitializationPass: TransformPass {
     return true
   }
 
-  private mutating func eval(
-    condBranch inst: CondBranchInst, id: InstID, module: inout Module
-  ) -> Bool {
+  private mutating func eval(condBranch inst: CondBranchInst, id: InstID, module: inout Module)
+    -> Bool
+  {
     // Consume the condition operand.
     let key = FunctionLocal(operand: inst.condition)!
     return consume(
@@ -427,9 +424,7 @@ public struct DefiniteInitializationPass: TransformPass {
       })
   }
 
-  private mutating func eval(
-    call inst: CallInst, id: InstID, module: inout Module
-  ) -> Bool {
+  private mutating func eval(call inst: CallInst, id: InstID, module: inout Module) -> Bool {
     // Process the operands.
     for i in 0..<inst.operands.count {
       switch inst.conventions[i] {
@@ -460,9 +455,9 @@ public struct DefiniteInitializationPass: TransformPass {
     return true
   }
 
-  private mutating func eval(
-    deallocStack inst: DeallocStackInst, id: InstID, module: inout Module
-  ) -> Bool {
+  private mutating func eval(deallocStack inst: DeallocStackInst, id: InstID, module: inout Module)
+    -> Bool
+  {
     // The location operand is the result an `alloc_stack` instruction.
     let allocID = inst.location.inst!
     let alloc = module[allocID.function][allocID.block][allocID.address] as! AllocStackInst
@@ -492,16 +487,12 @@ public struct DefiniteInitializationPass: TransformPass {
       let object = module.insert(
         LoadInst(
           .object(program.abstractLayout(of: alloc.allocatedType, at: path).type),
-          from: inst.location,
-          at: path,
-          range: inst.range),
-        at: beforeDealloc)[0]
+          from: inst.location, at: path, range: inst.range), at: beforeDealloc)[0]
       module.insert(DeinitInst(object, range: inst.range), at: beforeDealloc)
 
       // Apply the effect of the inserted instructions on the context directly.
       let consumer = InstID(
-        function: id.function,
-        block: id.block,
+        function: id.function, block: id.block,
         address: module[id.function][id.block].instructions.address(before: id.address)!)
       currentContext.locals[FunctionLocal(id, 0)] = .object(.full(.consumed(by: [consumer])))
     }
@@ -511,9 +502,7 @@ public struct DefiniteInitializationPass: TransformPass {
     return true
   }
 
-  private mutating func eval(
-    deinit inst: DeinitInst, id: InstID, module: inout Module
-  ) -> Bool {
+  private mutating func eval(deinit inst: DeinitInst, id: InstID, module: inout Module) -> Bool {
     // Consume the object operand.
     let key = FunctionLocal(operand: inst.object)!
     return consume(
@@ -523,9 +512,9 @@ public struct DefiniteInitializationPass: TransformPass {
       })
   }
 
-  private mutating func eval(
-    destructure inst: DestructureInst, id: InstID, module: inout Module
-  ) -> Bool {
+  private mutating func eval(destructure inst: DestructureInst, id: InstID, module: inout Module)
+    -> Bool
+  {
     // Consume the object operand.
     if let key = FunctionLocal(operand: inst.object) {
       if !consume(
@@ -545,9 +534,7 @@ public struct DefiniteInitializationPass: TransformPass {
     return true
   }
 
-  private mutating func eval(
-    load inst: LoadInst, id: InstID, module: inout Module
-  ) -> Bool {
+  private mutating func eval(load inst: LoadInst, id: InstID, module: inout Module) -> Bool {
     // Operand must be a location.
     let locations: [MemoryLocation]
     if let key = FunctionLocal(operand: inst.source) {
@@ -587,9 +574,7 @@ public struct DefiniteInitializationPass: TransformPass {
     return true
   }
 
-  private mutating func eval(
-    record inst: RecordInst, id: InstID, module: inout Module
-  ) -> Bool {
+  private mutating func eval(record inst: RecordInst, id: InstID, module: inout Module) -> Bool {
     // Consumes the non-constant operand.
     for operand in inst.operands {
       if let key = FunctionLocal(operand: operand) {
@@ -609,9 +594,7 @@ public struct DefiniteInitializationPass: TransformPass {
     return true
   }
 
-  private mutating func eval(
-    return inst: ReturnInst, id: InstID, module: inout Module
-  ) -> Bool {
+  private mutating func eval(return inst: ReturnInst, id: InstID, module: inout Module) -> Bool {
     // Consume the object operand.
     if let key = FunctionLocal(operand: inst.value) {
       if !consume(
@@ -627,9 +610,7 @@ public struct DefiniteInitializationPass: TransformPass {
     return true
   }
 
-  private mutating func eval(
-    store inst: StoreInst, id: InstID, module: inout Module
-  ) -> Bool {
+  private mutating func eval(store inst: StoreInst, id: InstID, module: inout Module) -> Bool {
     // Consume the object operand.
     if let key = FunctionLocal(operand: inst.object) {
       if !consume(
@@ -659,9 +640,9 @@ public struct DefiniteInitializationPass: TransformPass {
   }
 
   /// Returns the result of a call to `action` with a projection of the object at `location`.
-  private mutating func withObject<T>(
-    at location: MemoryLocation, _ action: (inout Object) -> T
-  ) -> T {
+  private mutating func withObject<T>(at location: MemoryLocation, _ action: (inout Object) -> T)
+    -> T
+  {
     switch location {
     case .null:
       preconditionFailure("null location")
@@ -703,8 +684,7 @@ public struct DefiniteInitializationPass: TransformPass {
   /// The method returns `true` if it succeeded. Otherwise, it or calls `handleFailure` with a
   /// with a projection of `self` and the state summary of the object before returning `false`.
   private mutating func consume(
-    localForKey key: FunctionLocal,
-    with consumer: InstID,
+    localForKey key: FunctionLocal, with consumer: InstID,
     or handleFailure: (inout Self, Object.StateSummary) -> Void
   ) -> Bool {
     let summary = currentContext.locals[key]!.unwrapObject()!.summary

--- a/Sources/Compiler/IR/Analysis/DominatorTree.swift
+++ b/Sources/Compiler/IR/Analysis/DominatorTree.swift
@@ -119,9 +119,7 @@ struct DominatorTree {
   }
 
   private mutating func findImmediateDominator(
-    _ node: Node,
-    cfg: ControlFlowGraph,
-    blocks: DoublyLinkedList<Block>
+    _ node: Node, cfg: ControlFlowGraph, blocks: DoublyLinkedList<Block>
   ) -> Dominator {
     // Check the cache.
     if let dominator = immediateDominators[node] { return dominator }

--- a/Sources/Compiler/IR/Analysis/DominatorTree.swift
+++ b/Sources/Compiler/IR/Analysis/DominatorTree.swift
@@ -52,9 +52,7 @@ struct DominatorTree {
     let children: [Node: [Node]] = immediateDominators.reduce(
       into: [:],
       { (children, kv) in
-        if case .present(let parent) = kv.value {
-          children[parent, default: []].append(kv.key)
-        }
+        if case .present(let parent) = kv.value { children[parent, default: []].append(kv.key) }
       })
 
     var result = [root]
@@ -68,11 +66,7 @@ struct DominatorTree {
 
   /// Returns the immediate dominator of `block`, if any.
   func immediateDominator(of block: Node) -> Node? {
-    if case .present(let b) = immediateDominators[block]! {
-      return b
-    } else {
-      return nil
-    }
+    if case .present(let b) = immediateDominators[block]! { return b } else { return nil }
   }
 
   /// Returns a collection containing the strict dominators of `block`.
@@ -107,9 +101,7 @@ struct DominatorTree {
     // If `definition` is in the same block as `use`, check which comes first.
     if definition.block == use.user.block {
       for i in module[definition.function][definition.block].instructions.indices {
-        if i.address == definition.address {
-          return true
-        }
+        if i.address == definition.address { return true }
       }
       return false
     }
@@ -180,9 +172,7 @@ struct DominatorTree {
       default:
         var dominator = root
         outer: while let candidate = chains[0].popLast() {
-          for i in 1..<chains.count {
-            if chains[i].popLast() != candidate { break outer }
-          }
+          for i in 1..<chains.count { if chains[i].popLast() != candidate { break outer } }
           dominator = candidate
         }
 

--- a/Sources/Compiler/IR/Analysis/ImplicitReturnInsertionPass.swift
+++ b/Sources/Compiler/IR/Analysis/ImplicitReturnInsertionPass.swift
@@ -28,8 +28,7 @@ public struct ImplicitReturnInsertionPass: TransformPass {
         let range = module[functionID][i.address].instructions
           .last(where: { $0.range != nil })?.range
         diagnostics.append(
-          .missingFunctionReturn(
-            expectedReturnType: expectedReturnType, range: range))
+          .missingFunctionReturn(expectedReturnType: expectedReturnType, range: range))
       }
     }
 
@@ -40,10 +39,9 @@ public struct ImplicitReturnInsertionPass: TransformPass {
 
 extension Diagnostic {
 
-  fileprivate static func missingFunctionReturn(
-    expectedReturnType: AnyType,
-    range: SourceRange?
-  ) -> Diagnostic {
+  fileprivate static func missingFunctionReturn(expectedReturnType: AnyType, range: SourceRange?)
+    -> Diagnostic
+  {
     .error("missing return in function expected to return '\(expectedReturnType)'", range: range)
   }
 

--- a/Sources/Compiler/IR/Analysis/ImplicitReturnInsertionPass.swift
+++ b/Sources/Compiler/IR/Analysis/ImplicitReturnInsertionPass.swift
@@ -25,8 +25,8 @@ public struct ImplicitReturnInsertionPass: TransformPass {
         module.insert(ReturnInst(), at: ip)
       } else {
         // No return instruction, yet the function must return a non-void value.
-        let range = module[functionID][i.address].instructions
-          .last(where: { $0.range != nil })?.range
+        let range = module[functionID][i.address].instructions.last(where: { $0.range != nil })?
+          .range
         diagnostics.append(
           .missingFunctionReturn(expectedReturnType: expectedReturnType, range: range))
       }
@@ -41,8 +41,6 @@ extension Diagnostic {
 
   fileprivate static func missingFunctionReturn(expectedReturnType: AnyType, range: SourceRange?)
     -> Diagnostic
-  {
-    .error("missing return in function expected to return '\(expectedReturnType)'", range: range)
-  }
+  { .error("missing return in function expected to return '\(expectedReturnType)'", range: range) }
 
 }

--- a/Sources/Compiler/IR/Analysis/Lifetime.swift
+++ b/Sources/Compiler/IR/Analysis/Lifetime.swift
@@ -89,8 +89,7 @@ extension Module {
 
     // Find all blocks in which the operand is being used.
     var occurences = uses[operand, default: []].reduce(
-      into: Set<Function.BlockAddress>(),
-      { (blocks, use) in blocks.insert(use.user.block) })
+      into: Set<Function.BlockAddress>(), { (blocks, use) in blocks.insert(use.user.block) })
 
     // Propagate liveness starting from the blocks in which the operand is being used.
     let cfg = functions[origin.function].cfg

--- a/Sources/Compiler/IR/Analysis/Lifetime.swift
+++ b/Sources/Compiler/IR/Analysis/Lifetime.swift
@@ -50,10 +50,8 @@ struct Lifetime {
   var isEmpty: Bool {
     for blockCoverage in coverage.values {
       switch blockCoverage {
-      case .liveInAndOut, .liveOut, .liveIn, .closed(lastUse: .some):
-        return false
-      default:
-        continue
+      case .liveInAndOut, .liveOut, .liveIn, .closed(lastUse: .some): return false
+      default: continue
       }
     }
     return true
@@ -65,12 +63,9 @@ struct Lifetime {
       into: [],
       { (uses, blockCoverage) in
         switch blockCoverage {
-        case .liveIn(.some(let use)):
-          uses.append(use)
-        case .closed(.some(let use)):
-          uses.append(use)
-        default:
-          break
+        case .liveIn(.some(let use)): uses.append(use)
+        case .closed(.some(let use)): uses.append(use)
+        default: break
         }
       })
   }
@@ -123,15 +118,12 @@ extension Module {
     // Find the last use in each block for which the operand is not live out.
     for (block, bounds) in approximateCoverage {
       switch bounds {
-      case (true, true):
-        coverage[block] = .liveInAndOut
-      case (false, true):
-        coverage[block] = .liveOut
+      case (true, true): coverage[block] = .liveInAndOut
+      case (false, true): coverage[block] = .liveOut
       case (true, false):
         let id = Block.ID(function: origin.function, address: block)
         coverage[block] = .liveIn(lastUse: lastUse(of: operand, in: id))
-      case (false, false):
-        continue
+      case (false, false): continue
       }
     }
 
@@ -150,9 +142,7 @@ extension Module {
       guard let lhs = lhs else { return rhs }
       guard let rhs = rhs else { return lhs }
 
-      if lhs.user == rhs.user {
-        return lhs.index < rhs.index ? rhs : lhs
-      }
+      if lhs.user == rhs.user { return lhs.index < rhs.index ? rhs : lhs }
 
       let block = functions[lhs.user.function][lhs.user.block]
       if lhs.user.address.precedes(rhs.user.address, in: block.instructions) {
@@ -168,18 +158,12 @@ extension Module {
         switch (a, b) {
         case (.liveOut, .liveIn), (.liveIn, .liveOut):
           unreachable("definition does not dominate all uses")
-        case (.liveInAndOut, _), (_, .liveInAndOut):
-          return .liveInAndOut
-        case (.liveOut, _), (_, .liveOut):
-          return .liveOut
-        case (.liveIn(let lhs), .liveIn(let rhs)):
-          return .liveIn(lastUse: last(lhs, rhs))
-        case (.liveIn(let lhs), .closed(let rhs)):
-          return .liveIn(lastUse: last(lhs, rhs))
-        case (.closed(let lhs), .liveIn(let rhs)):
-          return .liveIn(lastUse: last(lhs, rhs))
-        case (.closed(let lhs), .closed(let rhs)):
-          return .liveIn(lastUse: last(lhs, rhs))
+        case (.liveInAndOut, _), (_, .liveInAndOut): return .liveInAndOut
+        case (.liveOut, _), (_, .liveOut): return .liveOut
+        case (.liveIn(let lhs), .liveIn(let rhs)): return .liveIn(lastUse: last(lhs, rhs))
+        case (.liveIn(let lhs), .closed(let rhs)): return .liveIn(lastUse: last(lhs, rhs))
+        case (.closed(let lhs), .liveIn(let rhs)): return .liveIn(lastUse: last(lhs, rhs))
+        case (.closed(let lhs), .closed(let rhs)): return .liveIn(lastUse: last(lhs, rhs))
         }
       })
     return Lifetime(operand: left.operand, coverage: coverage)

--- a/Sources/Compiler/IR/Analysis/LifetimePass.swift
+++ b/Sources/Compiler/IR/Analysis/LifetimePass.swift
@@ -8,9 +8,7 @@ public struct LifetimePass: TransformPass {
 
   public private(set) var diagnostics: [Diagnostic] = []
 
-  public init(program: TypedProgram) {
-    self.program = program
-  }
+  public init(program: TypedProgram) { self.program = program }
 
   public mutating func run(function functionID: Function.ID, module: inout Module) -> Bool {
     // Reinitialize the internal state of the pass.
@@ -43,8 +41,7 @@ public struct LifetimePass: TransformPass {
               at: InsertionPoint(after: lastUse.user.address, in: userBlock))
           }
 
-        default:
-          break
+        default: break
         }
       }
     }
@@ -65,8 +62,7 @@ public struct LifetimePass: TransformPass {
       case is BorrowInst:
         result = module.extend(
           lifetime: result, with: lifetime(of: .result(inst: use.user, index: 0), in: module))
-      default:
-        continue
+      default: continue
       }
     }
 

--- a/Sources/Compiler/IR/Block.swift
+++ b/Sources/Compiler/IR/Block.swift
@@ -18,9 +18,7 @@ public struct Block {
     }
 
     /// The ID of the `index`-th parameter of the block.
-    public func parameter(_ index: Int) -> Operand {
-      .parameter(block: self, index: index)
-    }
+    public func parameter(_ index: Int) -> Operand { .parameter(block: self, index: index) }
 
     /// The operand denoting the `index`-th result of the instruction at `instAddress` in the block
     /// identified by `self`.

--- a/Sources/Compiler/IR/Emitter.swift
+++ b/Sources/Compiler/IR/Emitter.swift
@@ -62,8 +62,7 @@ public struct Emitter {
     // Create the function entry.
     assert(module.functions[functionID].blocks.isEmpty)
     let entryID = module.createBasicBlock(
-      accepting: module.functions[functionID].inputs.map({ $0.type }),
-      atEndOf: functionID)
+      accepting: module.functions[functionID].inputs.map({ $0.type }), atEndOf: functionID)
     insertionPoint = InsertionPoint(endOf: entryID)
 
     // Configure the locals.
@@ -118,10 +117,7 @@ public struct Emitter {
   }
 
   /// Emits the given subscript declaration into `module`.
-  public mutating func emit(
-    subscript declID: NodeID<SubscriptDecl>,
-    into module: inout Module
-  ) {
+  public mutating func emit(subscript declID: NodeID<SubscriptDecl>, into module: inout Module) {
     fatalError("not implemented")
   }
 
@@ -161,8 +157,7 @@ public struct Emitter {
   }
 
   private mutating func emit(
-    storedLocalBinding decl: NodeID<BindingDecl>,
-    into module: inout Module
+    storedLocalBinding decl: NodeID<BindingDecl>, into module: inout Module
   ) {
     /// The pattern of the binding being emitted.
     let pattern = program.ast[decl].pattern
@@ -209,8 +204,7 @@ public struct Emitter {
 
         // Borrow the storage for initialization corresponding to the current name.
         let target = module.insert(
-          BorrowInst(.set, .address(declType), from: storage),
-          at: insertionPoint!)[0]
+          BorrowInst(.set, .address(declType), from: storage), at: insertionPoint!)[0]
 
         // Store the corresponding (part of) the initializer.
         module.insert(StoreInst(objects[path]!, to: target), at: insertionPoint!)
@@ -221,8 +215,7 @@ public struct Emitter {
   /// Emits borrowed bindings.
   private mutating func emit(
     borrowedLocalBinding decl: NodeID<BindingDecl>,
-    withCapability capability: RemoteType.Capability,
-    into module: inout Module
+    withCapability capability: RemoteType.Capability, into module: inout Module
   ) {
     /// The pattern of the binding being emitted.
     let pattern = program.ast[decl].pattern
@@ -243,8 +236,7 @@ public struct Emitter {
         source = storage
 
         let target = module.insert(
-          BorrowInst(.set, .address(exprType), from: storage),
-          at: insertionPoint!)[0]
+          BorrowInst(.set, .address(exprType), from: storage), at: insertionPoint!)[0]
         module.insert(StoreInst(value, to: target), at: insertionPoint!)
       }
 
@@ -255,13 +247,8 @@ public struct Emitter {
         stack[decl] =
           module.insert(
             BorrowInst(
-              capability,
-              .address(declType),
-              from: source,
-              at: path,
-              binding: decl,
-              range: program.ast[decl].origin),
-            at: insertionPoint!)[0]
+              capability, .address(declType), from: source, at: path, binding: decl,
+              range: program.ast[decl].origin), at: insertionPoint!)[0]
       }
     }
   }
@@ -324,9 +311,7 @@ public struct Emitter {
     }
 
     emitStackDeallocs(in: &module)
-    module.insert(
-      ReturnInst(value: value, range: program.ast[stmt].origin),
-      at: insertionPoint!)
+    module.insert(ReturnInst(value: value, range: program.ast[stmt].origin), at: insertionPoint!)
   }
 
   // MARK: r-values
@@ -360,22 +345,17 @@ public struct Emitter {
   }
 
   private mutating func emitR(
-    booleanLiteral expr: NodeID<BooleanLiteralExpr>,
-    into module: inout Module
+    booleanLiteral expr: NodeID<BooleanLiteralExpr>, into module: inout Module
   ) -> Operand {
     let value = Operand.constant(
       .integer(IntegerConstant(program.ast[expr].value ? 1 : 0, bitWidth: 1)))
 
     let boolType = program.ast.coreType(named: "Bool")!
     return module.insert(
-      RecordInst(objectType: .object(boolType), operands: [value]),
-      at: insertionPoint!)[0]
+      RecordInst(objectType: .object(boolType), operands: [value]), at: insertionPoint!)[0]
   }
 
-  private mutating func emitR(
-    cond expr: NodeID<CondExpr>,
-    into module: inout Module
-  ) -> Operand {
+  private mutating func emitR(cond expr: NodeID<CondExpr>, into module: inout Module) -> Operand {
     let functionID = insertionPoint!.block.function
 
     // If the expression is supposed to return a value, allocate storage for it.
@@ -404,19 +384,13 @@ public struct Emitter {
         condition =
           module.insert(
             CallInst(
-              returnType: .object(BuiltinType.i(1)),
-              calleeConvention: .let,
+              returnType: .object(BuiltinType.i(1)), calleeConvention: .let,
               callee: .constant(.builtin(BuiltinFunctionRef["i1_copy"]!)),
-              argumentConventions: [.let],
-              arguments: [condition]),
-            at: insertionPoint!)[0]
+              argumentConventions: [.let], arguments: [condition]), at: insertionPoint!)[0]
 
         module.insert(
           CondBranchInst(
-            condition: condition,
-            targetIfTrue: success,
-            targetIfFalse: failure,
-            range: nil),
+            condition: condition, targetIfTrue: success, targetIfFalse: failure, range: nil),
           at: insertionPoint!)
         insertionPoint = InsertionPoint(endOf: success)
 
@@ -435,8 +409,8 @@ public struct Emitter {
       let value = emitR(expr: thenExpr, into: &module)
       if let target = resultStorage {
         let target = module.insert(
-          BorrowInst(.set, .address(program.exprTypes[expr]!), from: target),
-          at: insertionPoint!)[0]
+          BorrowInst(.set, .address(program.exprTypes[expr]!), from: target), at: insertionPoint!)[
+            0]
         module.insert(StoreInst(value, to: target), at: insertionPoint!)
       }
       emitStackDeallocs(in: &module)
@@ -455,8 +429,8 @@ public struct Emitter {
       let value = emitR(expr: elseExpr, into: &module)
       if let target = resultStorage {
         let target = module.insert(
-          BorrowInst(.set, .address(program.exprTypes[expr]!), from: target),
-          at: insertionPoint!)[0]
+          BorrowInst(.set, .address(program.exprTypes[expr]!), from: target), at: insertionPoint!)[
+            0]
         module.insert(StoreInst(value, to: target), at: insertionPoint!)
       }
       emitStackDeallocs(in: &module)
@@ -474,23 +448,21 @@ public struct Emitter {
     insertionPoint = InsertionPoint(endOf: continuation)
     if let source = resultStorage {
       return module.insert(
-        LoadInst(LoweredType(lowering: program.exprTypes[expr]!), from: source),
-        at: insertionPoint!)[0]
+        LoadInst(LoweredType(lowering: program.exprTypes[expr]!), from: source), at: insertionPoint!
+      )[0]
     } else {
       return .constant(.void)
     }
   }
 
-  private mutating func emitR(
-    funCall expr: NodeID<FunCallExpr>,
-    into module: inout Module
-  ) -> Operand {
+  private mutating func emitR(funCall expr: NodeID<FunCallExpr>, into module: inout Module)
+    -> Operand
+  {
     let calleeType = program.exprTypes[program.ast[expr].callee]!.base as! LambdaType
 
     // Determine the callee's convention.
     let calleeConvention = calleeType.receiverEffect.map(
-      default: .let,
-      PassingConvention.init(matching:))
+      default: .let, PassingConvention.init(matching:))
 
     // Arguments are evaluated first, from left to right.
     var argumentConventions: [PassingConvention] = []
@@ -515,8 +487,7 @@ public struct Emitter {
         callee = .constant(
           .builtin(
             BuiltinFunctionRef(
-              name: program.ast[calleeID].name.value.stem,
-              type: .address(calleeType))))
+              name: program.ast[calleeID].name.value.stem, type: .address(calleeType))))
 
       case .direct(let calleeDecl) where calleeDecl.kind == FunctionDecl.self:
         // Callee is a direct reference to a function or initializer declaration.
@@ -572,8 +543,7 @@ public struct Emitter {
           switch program.ast[calleeID].domain {
           case .none:
             let receiver = module.insert(
-              LoadInst(.object(receiverType), from: stack[receiverDecl!]!),
-              at: insertionPoint!)[0]
+              LoadInst(.object(receiverType), from: stack[receiverDecl!]!), at: insertionPoint!)[0]
             arguments.insert(receiver, at: 0)
 
           case .expr(let receiverID):
@@ -602,17 +572,13 @@ public struct Emitter {
 
     return module.insert(
       CallInst(
-        returnType: .object(program.exprTypes[expr]!),
-        calleeConvention: calleeConvention,
-        callee: callee,
-        argumentConventions: argumentConventions,
-        arguments: arguments),
+        returnType: .object(program.exprTypes[expr]!), calleeConvention: calleeConvention,
+        callee: callee, argumentConventions: argumentConventions, arguments: arguments),
       at: insertionPoint!)[0]
   }
 
   private mutating func emitR(
-    integerLiteral expr: NodeID<IntegerLiteralExpr>,
-    into module: inout Module
+    integerLiteral expr: NodeID<IntegerLiteralExpr>, into module: inout Module
   ) -> Operand {
     let type = program.exprTypes[expr]!.base as! ProductType
 
@@ -641,17 +607,13 @@ public struct Emitter {
       at: insertionPoint!)[0]
   }
 
-  private mutating func emitR(
-    name expr: NodeID<NameExpr>,
-    into module: inout Module
-  ) -> Operand {
+  private mutating func emitR(name expr: NodeID<NameExpr>, into module: inout Module) -> Operand {
     switch program.referredDecls[expr]! {
     case .direct(let declID):
       // Lookup for a local symbol.
       if let source = stack[declID] {
         return module.insert(
-          LoadInst(.object(program.exprTypes[expr]!), from: source),
-          at: insertionPoint!)[0]
+          LoadInst(.object(program.exprTypes[expr]!), from: source), at: insertionPoint!)[0]
       }
 
       fatalError("not implemented")
@@ -661,16 +623,14 @@ public struct Emitter {
     }
   }
 
-  private mutating func emitR(
-    sequence expr: NodeID<SequenceExpr>,
-    into module: inout Module
-  ) -> Operand {
+  private mutating func emitR(sequence expr: NodeID<SequenceExpr>, into module: inout Module)
+    -> Operand
+  {
     emit(.sink, foldedSequence: program.foldedSequenceExprs[expr]!, into: &module)
   }
 
   private mutating func emit(
-    _ convention: PassingConvention,
-    foldedSequence expr: FoldedSequenceExpr,
+    _ convention: PassingConvention, foldedSequence expr: FoldedSequenceExpr,
     into module: inout Module
   ) -> Operand {
     switch expr {
@@ -708,12 +668,9 @@ public struct Emitter {
       // Emit the call.
       return module.insert(
         CallInst(
-          returnType: .object(calleeType.output),
-          calleeConvention: .let,
-          callee: calleeOperand,
+          returnType: .object(calleeType.output), calleeConvention: .let, callee: calleeOperand,
           argumentConventions: [lhsConvention, rhsType.convention],
-          arguments: [lhsOperand, rhsOperand]),
-        at: insertionPoint!)[0]
+          arguments: [lhsOperand, rhsOperand]), at: insertionPoint!)[0]
 
     case .leaf(let expr):
       switch convention {
@@ -732,9 +689,7 @@ public struct Emitter {
   }
 
   private mutating func emit(
-    argument expr: AnyExprID,
-    to parameterType: ParameterType,
-    into module: inout Module
+    argument expr: AnyExprID, to parameterType: ParameterType, into module: inout Module
   ) -> Operand {
     switch parameterType.convention {
     case .let:
@@ -755,9 +710,7 @@ public struct Emitter {
   ///
   /// - Requires: `expr` has a lambda type.
   private mutating func emitCallee(
-    _ expr: AnyExprID,
-    conventions: inout [PassingConvention],
-    arguments: inout [Operand],
+    _ expr: AnyExprID, conventions: inout [PassingConvention], arguments: inout [Operand],
     into module: inout Module
   ) -> Operand {
     let calleeType = program.exprTypes[expr]!.base as! LambdaType
@@ -772,8 +725,7 @@ public struct Emitter {
         return .constant(
           .builtin(
             BuiltinFunctionRef(
-              name: program.ast[nameExpr].name.value.stem,
-              type: .address(calleeType))))
+              name: program.ast[nameExpr].name.value.stem, type: .address(calleeType))))
 
       case .direct(let calleeDecl) where calleeDecl.kind == FunctionDecl.self:
         // Callee is a direct reference to a function or initializer declaration.
@@ -826,8 +778,7 @@ public struct Emitter {
           switch program.ast[nameExpr].domain {
           case .none:
             let receiver = module.insert(
-              LoadInst(.object(receiverType), from: stack[receiverDecl!]!),
-              at: insertionPoint!)[0]
+              LoadInst(.object(receiverType), from: stack[receiverDecl!]!), at: insertionPoint!)[0]
             arguments.insert(receiver, at: 0)
 
           case .expr(let receiverID):
@@ -860,14 +811,11 @@ public struct Emitter {
   /// Emits `expr` as a l-value with the specified capability into `module` at the current
   /// insertion point.
   private mutating func emitL<T: ExprID>(
-    expr: T,
-    withCapability capability: RemoteType.Capability,
-    into module: inout Module
+    expr: T, withCapability capability: RemoteType.Capability, into module: inout Module
   ) -> Operand {
     switch expr.kind {
     case NameExpr.self:
-      return emitL(
-        name: NodeID(rawValue: expr.rawValue), withCapability: capability, into: &module)
+      return emitL(name: NodeID(rawValue: expr.rawValue), withCapability: capability, into: &module)
 
     case SubscriptCallExpr.self:
       fatalError("not implemented")
@@ -880,19 +828,16 @@ public struct Emitter {
       stack.top.allocs.append(storage)
 
       let target = module.insert(
-        BorrowInst(.set, .address(exprType), from: storage),
-        at: insertionPoint!)[0]
+        BorrowInst(.set, .address(exprType), from: storage), at: insertionPoint!)[0]
       module.insert(StoreInst(value, to: target), at: insertionPoint!)
 
       return module.insert(
-        BorrowInst(capability, .address(exprType), from: storage),
-        at: insertionPoint!)[0]
+        BorrowInst(capability, .address(exprType), from: storage), at: insertionPoint!)[0]
     }
   }
 
   private mutating func emitL(
-    name expr: NodeID<NameExpr>,
-    withCapability capability: RemoteType.Capability,
+    name expr: NodeID<NameExpr>, withCapability capability: RemoteType.Capability,
     into module: inout Module
   ) -> Operand {
     switch program.referredDecls[expr]! {
@@ -932,17 +877,12 @@ public struct Emitter {
           let receiverInst = module[id.function][id.block][id.address] as? BorrowInst
         {
           module[id.function][id.block][id.address] = BorrowInst(
-            capability,
-            .address(program.exprTypes[expr]!),
-            from: receiverInst.location,
+            capability, .address(program.exprTypes[expr]!), from: receiverInst.location,
             at: receiverInst.path + [memberIndex])
           return receiver
         } else {
           let member = BorrowInst(
-            capability,
-            .address(program.exprTypes[expr]!),
-            from: receiver,
-            at: [memberIndex])
+            capability, .address(program.exprTypes[expr]!), from: receiver, at: [memberIndex])
           return module.insert(member, at: insertionPoint!)[0]
         }
 

--- a/Sources/Compiler/IR/Function.swift
+++ b/Sources/Compiler/IR/Function.swift
@@ -38,13 +38,11 @@ public struct Function {
 
     for source in blocks.indices {
       switch blocks[source.address].instructions.last {
-      case let inst as BranchInst:
-        result.define(source.address, predecessorOf: inst.target.address)
+      case let inst as BranchInst: result.define(source.address, predecessorOf: inst.target.address)
       case let inst as CondBranchInst:
         result.define(source.address, predecessorOf: inst.targetIfTrue.address)
         result.define(source.address, predecessorOf: inst.targetIfFalse.address)
-      default:
-        break
+      default: break
       }
     }
 
@@ -100,9 +98,7 @@ extension Function: Sequence {
 
   }
 
-  public func makeIterator() -> Iterator {
-    Iterator(self)
-  }
+  public func makeIterator() -> Iterator { Iterator(self) }
 
   public subscript(_ addresses: Element) -> Inst {
     get { blocks[addresses.block][addresses.inst] }

--- a/Sources/Compiler/IR/InsertionPoint.swift
+++ b/Sources/Compiler/IR/InsertionPoint.swift
@@ -35,9 +35,7 @@ public struct InsertionPoint {
 
   /// Creates an insertion point positioned right after `inst`.
   public init(after instID: InstID) {
-    self.init(
-      after: instID.address,
-      in: Block.ID(function: instID.function, address: instID.block))
+    self.init(after: instID.address, in: Block.ID(function: instID.function, address: instID.block))
   }
 
   /// Creates an insertion point positioned right before `inst` in `block`.
@@ -49,8 +47,7 @@ public struct InsertionPoint {
   /// Creates an insertion point positioned right before `inst`.
   public init(before instID: InstID) {
     self.init(
-      before: instID.address,
-      in: Block.ID(function: instID.function, address: instID.block))
+      before: instID.address, in: Block.ID(function: instID.function, address: instID.block))
   }
 
 }

--- a/Sources/Compiler/IR/LoweredType.swift
+++ b/Sources/Compiler/IR/LoweredType.swift
@@ -27,12 +27,9 @@ public struct LoweredType: Hashable {
     case let ty as ParameterType:
       self.astType = ty.bareType
       switch ty.convention {
-      case .let, .inout, .set:
-        self.isAddress = true
-      case .sink:
-        self.isAddress = false
-      case .yielded:
-        preconditionFailure("cannot lower yielded type")
+      case .let, .inout, .set: self.isAddress = true
+      case .sink: self.isAddress = false
+      case .yielded: preconditionFailure("cannot lower yielded type")
       }
 
     default:

--- a/Sources/Compiler/IR/Module+Description.swift
+++ b/Sources/Compiler/IR/Module+Description.swift
@@ -17,9 +17,7 @@ extension Module: CustomStringConvertible, TextOutputStreamable {
 
   public func write<Target: TextOutputStream>(to output: inout Target) {
     for i in 0..<functions.count {
-      if i > 0 {
-        output.write("\n\n")
-      }
+      if i > 0 { output.write("\n\n") }
       write(function: i, to: &output)
     }
   }
@@ -51,20 +49,15 @@ extension Module: CustomStringConvertible, TextOutputStreamable {
     /// Returns a human-readable representation of `operand`.
     func describe(operand: Operand) -> String {
       switch operand {
-      case .result, .parameter:
-        return operandNames[operand]!
-      case .constant(let value):
-        return String(describing: value)
+      case .result, .parameter: return operandNames[operand]!
+      case .constant(let value): return String(describing: value)
       }
     }
 
     // Dumps the function in the module.
     if let debugName = function.debugName { output.write("// \(debugName)\n") }
     output.write("@lowered fun \(function.name)(")
-    output.write(
-      function.inputs.lazy
-        .map({ (c, t) in "\(c) \(t)" })
-        .joined(separator: ", "))
+    output.write(function.inputs.lazy.map({ (c, t) in "\(c) \(t)" }).joined(separator: ", "))
     output.write(") -> \(function.output) {\n")
 
     for i in function.blocks.indices {
@@ -74,9 +67,9 @@ extension Module: CustomStringConvertible, TextOutputStreamable {
       output.write(blockNames[blockID]!)
       output.write("(")
       output.write(
-        block.inputs.enumerated().lazy
-          .map({ (j, t) in operandNames[.parameter(block: blockID, index: j)]! + " : \(t)" })
-          .joined(separator: ", "))
+        block.inputs.enumerated().lazy.map({ (j, t) in
+          operandNames[.parameter(block: blockID, index: j)]! + " : \(t)"
+        }).joined(separator: ", "))
       output.write("):\n")
 
       for j in block.instructions.indices {
@@ -85,22 +78,19 @@ extension Module: CustomStringConvertible, TextOutputStreamable {
         output.write("  ")
         if !block[j.address].types.isEmpty {
           output.write(
-            (0..<block[j.address].types.count)
-              .map({ k in operandNames[.result(inst: instID, index: k)]! })
-              .joined(separator: ", "))
+            (0..<block[j.address].types.count).map({ k in
+              operandNames[.result(inst: instID, index: k)]!
+            }).joined(separator: ", "))
           output.write(" = ")
         }
 
         switch block.instructions[j.address] {
-        case let inst as AllocStackInst:
-          output.write("alloc_stack \(inst.allocatedType)")
+        case let inst as AllocStackInst: output.write("alloc_stack \(inst.allocatedType)")
 
         case let inst as BorrowInst:
           output.write("borrow [\(inst.capability)] ")
           output.write(describe(operand: inst.location))
-          if !inst.path.isEmpty {
-            output.write(", \(inst.path.descriptions())")
-          }
+          if !inst.path.isEmpty { output.write(", \(inst.path.descriptions())") }
 
         case let inst as BranchInst:
           output.write("branch ")
@@ -143,9 +133,7 @@ extension Module: CustomStringConvertible, TextOutputStreamable {
         case let inst as LoadInst:
           output.write("load ")
           output.write(describe(operand: inst.source))
-          if !inst.path.isEmpty {
-            output.write(", \(inst.path.descriptions())")
-          }
+          if !inst.path.isEmpty { output.write(", \(inst.path.descriptions())") }
 
         case let inst as RecordInst:
           output.write("record \(inst.objectType)")
@@ -164,11 +152,9 @@ extension Module: CustomStringConvertible, TextOutputStreamable {
           output.write(", ")
           output.write(describe(operand: inst.target))
 
-        case is UnrechableInst:
-          output.write("unreachable")
+        case is UnrechableInst: output.write("unreachable")
 
-        default:
-          unreachable("unexpected instruction")
+        default: unreachable("unexpected instruction")
         }
 
         output.write("\n")

--- a/Sources/Compiler/IR/Module+Description.swift
+++ b/Sources/Compiler/IR/Module+Description.swift
@@ -26,8 +26,7 @@ extension Module: CustomStringConvertible, TextOutputStreamable {
 
   /// Writes a textual representation of the specified function into `output`.
   public func write<Target: TextOutputStream>(
-    function functionID: Function.ID,
-    to output: inout Target
+    function functionID: Function.ID, to output: inout Target
   ) {
     let function = functions[functionID]
 

--- a/Sources/Compiler/IR/Module.swift
+++ b/Sources/Compiler/IR/Module.swift
@@ -35,25 +35,20 @@ public struct Module {
     case .parameter(let block, let index):
       return functions[block.function][block.address].inputs[index]
 
-    case .constant(let constant):
-      return constant.type
+    case .constant(let constant): return constant.type
     }
   }
 
   /// Returns whether the module is well-formed.
   public func check() -> Bool {
-    for i in 0..<functions.count {
-      if !check(function: i) { return false }
-    }
+    for i in 0..<functions.count { if !check(function: i) { return false } }
     return true
   }
 
   /// Returns whether the specified function is well-formed.
   public func check(function functionID: Function.ID) -> Bool {
     for block in functions[functionID].blocks {
-      for inst in block.instructions {
-        if !inst.check(in: self) { return false }
-      }
+      for inst in block.instructions { if !inst.check(in: self) { return false } }
     }
     return true
   }
@@ -83,12 +78,9 @@ public struct Module {
 
         case let type:
           switch declType.receiverEffect {
-          case nil:
-            inputs.append((convention: .let, type: .address(type)))
-          case .inout:
-            inputs.append((convention: .inout, type: .address(type)))
-          case .sink:
-            inputs.append((convention: .sink, type: .object(type)))
+          case nil: inputs.append((convention: .let, type: .address(type)))
+          case .inout: inputs.append((convention: .inout, type: .address(type)))
+          case .sink: inputs.append((convention: .sink, type: .object(type)))
           }
         }
       }
@@ -99,11 +91,9 @@ public struct Module {
         inputs.append(parameterType.asIRFunctionInput())
       }
 
-    case is MethodType:
-      fatalError("not implemented")
+    case is MethodType: fatalError("not implemented")
 
-    default:
-      unreachable()
+    default: unreachable()
     }
 
     // Declare a new function in the module.
@@ -129,8 +119,7 @@ public struct Module {
   }
 
   /// Creates a basic block at the end of the specified function and returns its identifier.
-  @discardableResult
-  mutating func createBasicBlock(
+  @discardableResult mutating func createBasicBlock(
     accepting inputs: [LoweredType] = [], atEndOf function: Function.ID
   ) -> Block.ID {
     let address = functions[function].blocks.append(Block(inputs: inputs))
@@ -138,13 +127,11 @@ public struct Module {
   }
 
   /// Inserts `inst` at the specified insertion point.
-  @discardableResult
-  mutating func insert<I: Inst>(_ inst: I, at ip: InsertionPoint) -> [Operand] {
+  @discardableResult mutating func insert<I: Inst>(_ inst: I, at ip: InsertionPoint) -> [Operand] {
     // Inserts the instruction.
     let address: Block.InstAddress
     switch ip.position {
-    case .end:
-      address = functions[ip.block.function][ip.block.address].instructions.append(inst)
+    case .end: address = functions[ip.block.function][ip.block.address].instructions.append(inst)
     case .after(let i):
       address = functions[ip.block.function][ip.block.address].instructions.insert(inst, after: i)
     case .before(let i):
@@ -180,12 +167,9 @@ extension ParameterType {
   /// Returns `self` as an input to an IR function.
   func asIRFunctionInput() -> Function.Input {
     switch convention {
-    case .let, .inout, .set:
-      return (convention: convention, type: .address(bareType))
-    case .sink:
-      return (convention: convention, type: .object(bareType))
-    case .yielded:
-      preconditionFailure("cannot lower yielded parameter")
+    case .let, .inout, .set: return (convention: convention, type: .address(bareType))
+    case .sink: return (convention: convention, type: .object(bareType))
+    case .yielded: preconditionFailure("cannot lower yielded parameter")
     }
   }
 

--- a/Sources/Compiler/IR/Module.swift
+++ b/Sources/Compiler/IR/Module.swift
@@ -60,8 +60,7 @@ public struct Module {
 
   /// Returns the identifier of the Val IR function corresponding to `declID`.
   mutating func getOrCreateFunction(
-    correspondingTo declID: NodeID<FunctionDecl>,
-    program: TypedProgram
+    correspondingTo declID: NodeID<FunctionDecl>, program: TypedProgram
   ) -> Function.ID {
     if let id = loweredFunctions[declID] { return id }
 
@@ -80,9 +79,7 @@ public struct Module {
         case let type as RemoteType:
           precondition(type.capability != .yielded, "cannot lower yielded parameter")
           inputs.append(
-            (
-              convention: PassingConvention(matching: type.capability), type: .address(type.base)
-            ))
+            (convention: PassingConvention(matching: type.capability), type: .address(type.base)))
 
         case let type:
           switch declType.receiverEffect {
@@ -113,17 +110,13 @@ public struct Module {
     let loweredID = functions.count
     let locator = DeclLocator(identifying: declID, in: program)
     let function = Function(
-      name: locator.mangled,
-      debugName: locator.description,
-      linkage: program.ast[declID].isPublic ? .external : .module,
-      inputs: inputs,
-      output: output,
+      name: locator.mangled, debugName: locator.description,
+      linkage: program.ast[declID].isPublic ? .external : .module, inputs: inputs, output: output,
       blocks: [])
     functions.append(function)
 
     // Determine if the new function is the module's entry.
-    if program.declToScope[declID]?.kind == TopLevelDeclSet.self,
-      program.ast[declID].isPublic,
+    if program.declToScope[declID]?.kind == TopLevelDeclSet.self, program.ast[declID].isPublic,
       program.ast[declID].identifier?.value == "main"
     {
       assert(entryFunctionID == nil)
@@ -138,8 +131,7 @@ public struct Module {
   /// Creates a basic block at the end of the specified function and returns its identifier.
   @discardableResult
   mutating func createBasicBlock(
-    accepting inputs: [LoweredType] = [],
-    atEndOf function: Function.ID
+    accepting inputs: [LoweredType] = [], atEndOf function: Function.ID
   ) -> Block.ID {
     let address = functions[function].blocks.append(Block(inputs: inputs))
     return Block.ID(function: function, address: address)

--- a/Sources/Compiler/IR/Operands/Constant/BuiltinFunctionRef.swift
+++ b/Sources/Compiler/IR/Operands/Constant/BuiltinFunctionRef.swift
@@ -20,8 +20,6 @@ public struct BuiltinFunctionRef: ConstantProtocol, Hashable {
 
 extension BuiltinFunctionRef: CustomStringConvertible {
 
-  public var description: String {
-    "@builtin.\(name)"
-  }
+  public var description: String { "@builtin.\(name)" }
 
 }

--- a/Sources/Compiler/IR/Operands/Constant/FunctionReference.swift
+++ b/Sources/Compiler/IR/Operands/Constant/FunctionReference.swift
@@ -10,8 +10,6 @@ public struct FunctionRef: ConstantProtocol, Hashable {
 
 extension FunctionRef: CustomStringConvertible {
 
-  public var description: String {
-    "@\(name)"
-  }
+  public var description: String { "@\(name)" }
 
 }

--- a/Sources/Compiler/IR/Operands/Constant/IntegerConstant.swift
+++ b/Sources/Compiler/IR/Operands/Constant/IntegerConstant.swift
@@ -22,8 +22,6 @@ public struct IntegerConstant: ConstantProtocol, Hashable {
 
 extension IntegerConstant: CustomStringConvertible {
 
-  public var description: String {
-    "\(type.astType)(0x\(String(value.value, radix: 16)))"
-  }
+  public var description: String { "\(type.astType)(0x\(String(value.value, radix: 16)))" }
 
 }

--- a/Sources/Compiler/IR/Operands/FunctionLocal.swift
+++ b/Sources/Compiler/IR/Operands/FunctionLocal.swift
@@ -13,10 +13,8 @@ enum FunctionLocal: Hashable {
     switch operand {
     case .result(let inst, let index):
       self = .result(block: inst.block, address: inst.address, index: index)
-    case .parameter(let block, let index):
-      self = .param(block: block.address, index: index)
-    case .constant:
-      return nil
+    case .parameter(let block, let index): self = .param(block: block.address, index: index)
+    case .constant: return nil
     }
   }
 

--- a/Sources/Compiler/IR/Operands/Inst/AllocStackInst.swift
+++ b/Sources/Compiler/IR/Operands/Inst/AllocStackInst.swift
@@ -21,8 +21,6 @@ public struct AllocStackInst: Inst {
 
   public var isTerminator: Bool { false }
 
-  public func check(in module: Module) -> Bool {
-    true
-  }
+  public func check(in module: Module) -> Bool { true }
 
 }

--- a/Sources/Compiler/IR/Operands/Inst/BorrowInst.swift
+++ b/Sources/Compiler/IR/Operands/Inst/BorrowInst.swift
@@ -19,12 +19,8 @@ public struct BorrowInst: Inst {
   public let range: SourceRange?
 
   init(
-    _ capability: RemoteType.Capability,
-    _ borrowedType: LoweredType,
-    from location: Operand,
-    at path: [Int] = [],
-    binding: NodeID<VarDecl>? = nil,
-    range: SourceRange? = nil
+    _ capability: RemoteType.Capability, _ borrowedType: LoweredType, from location: Operand,
+    at path: [Int] = [], binding: NodeID<VarDecl>? = nil, range: SourceRange? = nil
   ) {
     self.borrowedType = borrowedType
     self.capability = capability

--- a/Sources/Compiler/IR/Operands/Inst/BranchInst.swift
+++ b/Sources/Compiler/IR/Operands/Inst/BranchInst.swift
@@ -19,8 +19,6 @@ public struct BranchInst: Inst {
 
   public var isTerminator: Bool { true }
 
-  public func check(in module: Module) -> Bool {
-    true
-  }
+  public func check(in module: Module) -> Bool { true }
 
 }

--- a/Sources/Compiler/IR/Operands/Inst/CallInst.swift
+++ b/Sources/Compiler/IR/Operands/Inst/CallInst.swift
@@ -15,12 +15,8 @@ public struct CallInst: Inst {
   public let range: SourceRange?
 
   public init(
-    returnType: LoweredType,
-    calleeConvention: PassingConvention,
-    callee: Operand,
-    argumentConventions: [PassingConvention],
-    arguments: [Operand],
-    range: SourceRange? = nil
+    returnType: LoweredType, calleeConvention: PassingConvention, callee: Operand,
+    argumentConventions: [PassingConvention], arguments: [Operand], range: SourceRange? = nil
   ) {
     self.returnType = returnType
     self.conventions = [calleeConvention] + argumentConventions

--- a/Sources/Compiler/IR/Operands/Inst/CallInst.swift
+++ b/Sources/Compiler/IR/Operands/Inst/CallInst.swift
@@ -26,11 +26,7 @@ public struct CallInst: Inst {
 
   /// Returns whether the instruction is a call to a built-in function.
   public var isBuiltinCall: Bool {
-    if case .constant(.builtin) = callee {
-      return true
-    } else {
-      return true
-    }
+    if case .constant(.builtin) = callee { return true } else { return true }
   }
 
   /// The callee.
@@ -63,11 +59,9 @@ public struct CallInst: Inst {
             return false
           }
 
-        case .constant(let c):
-          if !c.type.isAddress { return false }
+        case .constant(let c): if !c.type.isAddress { return false }
 
-        case .parameter:
-          return false
+        case .parameter: return false
         }
 
       case .inout:
@@ -80,8 +74,7 @@ public struct CallInst: Inst {
             return false
           }
 
-        default:
-          return false
+        default: return false
         }
 
       case .set:
@@ -94,16 +87,14 @@ public struct CallInst: Inst {
             return false
           }
 
-        default:
-          return false
+        default: return false
         }
 
       case .sink:
         // Operand of a `sink` parameter must have an object type.
         if module.type(of: operands[i]).isAddress { return false }
 
-      case .yielded:
-        fatalError("not implemented")
+      case .yielded: fatalError("not implemented")
       }
     }
 

--- a/Sources/Compiler/IR/Operands/Inst/DestructureInst.swift
+++ b/Sources/Compiler/IR/Operands/Inst/DestructureInst.swift
@@ -21,9 +21,7 @@ public struct DestructureInst: Inst {
 
   public func check(in module: Module) -> Bool {
     // Instruction results have object types.
-    for output in types {
-      if output.isAddress { return false }
-    }
+    for output in types { if output.isAddress { return false } }
 
     // Operand has an object type.
     if module.type(of: object).isAddress { return false }

--- a/Sources/Compiler/IR/Operands/Inst/EndBorrowInst.swift
+++ b/Sources/Compiler/IR/Operands/Inst/EndBorrowInst.swift
@@ -12,8 +12,6 @@ public struct EndBorrowInst: Inst {
 
   public var isTerminator: Bool { false }
 
-  public func check(in module: Module) -> Bool {
-    true
-  }
+  public func check(in module: Module) -> Bool { true }
 
 }

--- a/Sources/Compiler/IR/Operands/Inst/LoadInst.swift
+++ b/Sources/Compiler/IR/Operands/Inst/LoadInst.swift
@@ -14,10 +14,7 @@ public struct LoadInst: Inst {
   public let range: SourceRange?
 
   init(
-    _ objectType: LoweredType,
-    from source: Operand,
-    at path: [Int] = [],
-    range: SourceRange? = nil
+    _ objectType: LoweredType, from source: Operand, at path: [Int] = [], range: SourceRange? = nil
   ) {
     self.objectType = objectType
     self.source = source

--- a/Sources/Compiler/IR/Operands/Inst/ReturnInst.swift
+++ b/Sources/Compiler/IR/Operands/Inst/ReturnInst.swift
@@ -17,8 +17,6 @@ public struct ReturnInst: Inst {
 
   public var isTerminator: Bool { true }
 
-  public func check(in module: Module) -> Bool {
-    true
-  }
+  public func check(in module: Module) -> Bool { true }
 
 }

--- a/Sources/Compiler/IR/Operands/Inst/StoreInst.swift
+++ b/Sources/Compiler/IR/Operands/Inst/StoreInst.swift
@@ -21,8 +21,6 @@ public struct StoreInst: Inst {
 
   public var isTerminator: Bool { false }
 
-  public func check(in module: Module) -> Bool {
-    true
-  }
+  public func check(in module: Module) -> Bool { true }
 
 }

--- a/Sources/Compiler/IR/Operands/Inst/UnreachableInst.swift
+++ b/Sources/Compiler/IR/Operands/Inst/UnreachableInst.swift
@@ -9,8 +9,6 @@ public struct UnrechableInst: Inst {
 
   public var isTerminator: Bool { true }
 
-  public func check(in module: Module) -> Bool {
-    true
-  }
+  public func check(in module: Module) -> Bool { true }
 
 }

--- a/Sources/Compiler/IR/Operands/Operand.swift
+++ b/Sources/Compiler/IR/Operands/Operand.swift
@@ -11,29 +11,22 @@ public enum Operand: Hashable {
   case constant(Constant)
 
   /// The ID of the function in which the operand is defined, if any.
-  var function: Function.ID? {
-    block?.function
-  }
+  var function: Function.ID? { block?.function }
 
   /// The ID of the block in which the operand is defined, if any.
   var block: Block.ID? {
     switch self {
-    case .result(let inst, _):
-      return Block.ID(function: inst.function, address: inst.block)
-    case .parameter(let block, _):
-      return block
-    case .constant(_):
-      return nil
+    case .result(let inst, _): return Block.ID(function: inst.function, address: inst.block)
+    case .parameter(let block, _): return block
+    case .constant(_): return nil
     }
   }
 
   /// The ID of the instruction that produces this operand, if any.
   var inst: InstID? {
     switch self {
-    case .result(let inst, _):
-      return inst
-    default:
-      return nil
+    case .result(let inst, _): return inst
+    default: return nil
     }
   }
 

--- a/Sources/Compiler/Parse/Lexer.swift
+++ b/Sources/Compiler/Parse/Lexer.swift
@@ -30,9 +30,7 @@ public struct Lexer: IteratorProtocol, Sequence {
 
       // Skip line comments.
       if take(prefix: "//") != nil {
-        while (index < source.contents.endIndex) && !source.contents[index].isNewline {
-          discard()
-        }
+        while (index < source.contents.endIndex) && !source.contents[index].isNewline { discard() }
         continue
       }
 
@@ -127,8 +125,7 @@ public struct Lexer: IteratorProtocol, Sequence {
         token.origin.upperBound = index
         token.kind = .cast
 
-      default:
-        token.kind = .name
+      default: token.kind = .name
       }
 
       return token
@@ -189,8 +186,7 @@ public struct Lexer: IteratorProtocol, Sequence {
             return token
           }
 
-        default:
-          break
+        default: break
         }
 
         index = i
@@ -249,10 +245,7 @@ public struct Lexer: IteratorProtocol, Sequence {
     // Scan attributes.
     if head == "@" {
       discard()
-      token.kind =
-        take(while: { $0.isLetter || ($0 == "_") }).isEmpty
-        ? .invalid
-        : .attribute
+      token.kind = take(while: { $0.isLetter || ($0 == "_") }).isEmpty ? .invalid : .attribute
       token.origin.upperBound = index
       return token
     }
@@ -266,8 +259,7 @@ public struct Lexer: IteratorProtocol, Sequence {
         discard()
         oper = source.contents[token.origin.lowerBound..<index]
 
-      default:
-        oper = take(while: { $0.isOperator })
+      default: oper = take(while: { $0.isOperator })
       }
 
       switch oper {
@@ -318,8 +310,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       // Fall back to a simple colon.
       token.kind = .colon
 
-    default:
-      break
+    default: break
     }
 
     // Either the token is punctuation, or it's kind is `invalid`.
@@ -349,8 +340,7 @@ public struct Lexer: IteratorProtocol, Sequence {
 
   /// Returns the current index and consumes `prefix` from the stream, or returns `nil` if the
   /// stream starts with a different prefix.
-  private mutating func take<T: Sequence>(prefix: T) -> String.Index?
-  where T.Element == Character {
+  private mutating func take<T: Sequence>(prefix: T) -> String.Index? where T.Element == Character {
     var newIndex = index
     for ch in prefix {
       if newIndex == source.contents.endIndex || source.contents[newIndex] != ch { return nil }
@@ -364,9 +354,7 @@ public struct Lexer: IteratorProtocol, Sequence {
   /// Consumes the longest substring that satisfies the given predicate.
   private mutating func take(while predicate: (Character) -> Bool) -> Substring {
     let start = index
-    while let ch = peek(), predicate(ch) {
-      index = source.contents.index(after: index)
-    }
+    while let ch = peek(), predicate(ch) { index = source.contents.index(after: index) }
 
     return source.contents[start..<index]
   }
@@ -399,13 +387,9 @@ extension Character {
   }
 
   /// Indicates whether `self` represents a binary digit.
-  fileprivate var isBinDigit: Bool {
-    self == "0" || self == "1" || self == "_"
-  }
+  fileprivate var isBinDigit: Bool { self == "0" || self == "1" || self == "_" }
 
   /// Indicates whether `self` represents an operator.
-  fileprivate var isOperator: Bool {
-    "<>=+-*/%&|!?^~".contains(self)
-  }
+  fileprivate var isOperator: Bool { "<>=+-*/%&|!?^~".contains(self) }
 
 }

--- a/Sources/Compiler/Parse/Parser+Diagnostics.swift
+++ b/Sources/Compiler/Parse/Parser+Diagnostics.swift
@@ -9,27 +9,19 @@ extension Diagnostic {
   }
 
   static func diagnose(
-    expected subject: String,
-    at location: SourceLocation,
-    children: [Diagnostic] = []
+    expected subject: String, at location: SourceLocation, children: [Diagnostic] = []
   ) -> Diagnostic {
     .error("expected \(subject)", range: location..<location, children: children)
   }
 
   static func diagnose(
-    expected closerDescription: String,
-    matching opener: Token,
-    in state: ParserState
+    expected closerDescription: String, matching opener: Token, in state: ParserState
   ) -> Diagnostic {
     .diagnose(
-      expected: "'\(closerDescription)'",
-      at: state.currentLocation,
+      expected: "'\(closerDescription)'", at: state.currentLocation,
       children: [
-        .error(
-          "to match this '\(state.lexer.source[opener.origin])'",
-          range: opener.origin)
-      ]
-    )
+        .error("to match this '\(state.lexer.source[opener.origin])'", range: opener.origin)
+      ])
   }
 
   static func diagnose(infixOperatorRequiresWhitespacesAt range: SourceRange?) -> Diagnostic {

--- a/Sources/Compiler/Parse/Parser+Diagnostics.swift
+++ b/Sources/Compiler/Parse/Parser+Diagnostics.swift
@@ -10,9 +10,7 @@ extension Diagnostic {
 
   static func diagnose(
     expected subject: String, at location: SourceLocation, children: [Diagnostic] = []
-  ) -> Diagnostic {
-    .error("expected \(subject)", range: location..<location, children: children)
-  }
+  ) -> Diagnostic { .error("expected \(subject)", range: location..<location, children: children) }
 
   static func diagnose(
     expected closerDescription: String, matching opener: Token, in state: ParserState

--- a/Sources/Compiler/Parse/Parser.swift
+++ b/Sources/Compiler/Parse/Parser.swift
@@ -174,77 +174,59 @@ public enum Parser {
       // Look ahead to select the appropriate declaration parser.
       switch state.peek()?.kind {
       case .let, .inout, .var, .sink:
-        return try parseBindingDecl(withPrologue: prologue, in: &state)
-          .map(AnyDeclID.init)
+        return try parseBindingDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
 
       case .fun, .infix, .postfix, .prefix:
-        return try parseFunctionOrMethodDecl(withPrologue: prologue, in: &state)
-          .map(AnyDeclID.init)
+        return try parseFunctionOrMethodDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
 
-      case .`init`:
-        return try parseInitDecl(withPrologue: prologue, in: &state)
-          .map(AnyDeclID.init)
+      case .`init`: return try parseInitDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
 
       case .subscript:
-        return try parseSubscriptDecl(withPrologue: prologue, in: &state)
-          .map(AnyDeclID.init)
+        return try parseSubscriptDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
 
       case .property:
-        return try parsePropertyDecl(withPrologue: prologue, in: &state)
-          .map(AnyDeclID.init)
+        return try parsePropertyDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
 
       case .namespace:
-        return try parseNamespaceDecl(withPrologue: prologue, in: &state)
-          .map(AnyDeclID.init)
+        return try parseNamespaceDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
 
-      case .trait:
-        return try parseTraitDecl(withPrologue: prologue, in: &state)
-          .map(AnyDeclID.init)
+      case .trait: return try parseTraitDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
 
       case .type:
         if state.isAtTraitScope {
-          return try parseAssociatedTypeDecl(withPrologue: prologue, in: &state)
-            .map(AnyDeclID.init)
+          return try parseAssociatedTypeDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
         } else {
-          return try parseProductTypeDecl(withPrologue: prologue, in: &state)
-            .map(AnyDeclID.init)
+          return try parseProductTypeDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
         }
 
       case .typealias:
-        return try parseTypeAliasDecl(withPrologue: prologue, in: &state)
-          .map(AnyDeclID.init)
+        return try parseTypeAliasDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
 
       case .conformance:
-        return try parseConformanceDecl(withPrologue: prologue, in: &state)
-          .map(AnyDeclID.init)
+        return try parseConformanceDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
 
       case .extension:
-        return try parseExtensionDecl(withPrologue: prologue, in: &state)
-          .map(AnyDeclID.init)
+        return try parseExtensionDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
 
       case .import:
-        return try parseImportDecl(withPrologue: prologue, in: &state)
-          .map(AnyDeclID.init)
+        return try parseImportDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
 
       case .operator:
-        return try parseOperatorDecl(withPrologue: prologue, in: &state)
-          .map(AnyDeclID.init)
+        return try parseOperatorDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
 
       case .name:
         let introducer = state.lexer.source[state.peek()!.origin]
         if introducer == "value" && state.isAtTypeScope {
           // Note: associated values are parsed at any type scope to produce better diagnostics
           // when they are not at trait scope.
-          return try parseAssociatedValueDecl(withPrologue: prologue, in: &state)
-            .map(AnyDeclID.init)
+          return try parseAssociatedValueDecl(withPrologue: prologue, in: &state).map(
+            AnyDeclID.init)
         }
         if introducer == "memberwise" && state.isAtTypeScope {
-          return try parseMemberwiseInitDecl(withPrologue: prologue, in: &state)
-            .map(AnyDeclID.init)
+          return try parseMemberwiseInitDecl(withPrologue: prologue, in: &state).map(AnyDeclID.init)
         }
 
-      default:
-        break
+      default: break
       }
 
       if prologue.isEmpty {
@@ -324,10 +306,8 @@ public enum Parser {
   ) throws -> NodeID<AssociatedTypeDecl>? {
     // Parse the parts of the declaration.
     let parser =
-      (take(.type).and(take(.name))
-        .and(maybe(conformanceList))
-        .and(maybe(whereClause))
-        .and(maybe(take(.assign).and(expr).second)))
+      (take(.type).and(take(.name)).and(maybe(conformanceList)).and(maybe(whereClause)).and(
+        maybe(take(.assign).and(expr).second)))
     guard let parts = try parser.parse(&state) else { return nil }
 
     // Associated type declarations shall not have attributes.
@@ -361,9 +341,8 @@ public enum Parser {
   ) throws -> NodeID<AssociatedValueDecl>? {
     // Parse the parts of the declaration.
     let parser =
-      (take(nameTokenWithValue: "value").and(take(.name))
-        .and(maybe(whereClause))
-        .and(maybe(take(.assign).and(expr).second)))
+      (take(nameTokenWithValue: "value").and(take(.name)).and(maybe(whereClause)).and(
+        maybe(take(.assign).and(expr).second)))
     guard let parts = try parser.parse(&state) else { return nil }
 
     // Associated value declarations shall not have attributes.
@@ -396,9 +375,7 @@ public enum Parser {
     throws -> NodeID<BindingDecl>?
   {
     // Parse the parts of the declaration.
-    let parser =
-      (bindingPattern
-        .and(maybe(take(.assign).and(expr).second)))
+    let parser = (bindingPattern.and(maybe(take(.assign).and(expr).second)))
     guard let (pattern, initializer) = try parser.parse(&state) else { return nil }
 
     // Create a new `BindingDecl`.
@@ -418,10 +395,8 @@ public enum Parser {
   {
     // Parse the parts of the declaration.
     let parser =
-      (take(.conformance).and(expr)
-        .and(conformanceList)
-        .and(maybe(whereClause))
-        .and(Apply({ (s) in try parseTypeDeclBody(in: &s, wrappedIn: .extensionBody) })))
+      (take(.conformance).and(expr).and(conformanceList).and(maybe(whereClause)).and(
+        Apply({ (s) in try parseTypeDeclBody(in: &s, wrappedIn: .extensionBody) })))
     guard let parts = try parser.parse(&state) else { return nil }
 
     // Conformance declarations shall not have attributes.
@@ -451,9 +426,8 @@ public enum Parser {
   {
     // Parse the parts of the declaration.
     let parser =
-      (take(.extension).and(expr)
-        .and(maybe(whereClause))
-        .and(Apply({ (s) in try parseTypeDeclBody(in: &s, wrappedIn: .extensionBody) })))
+      (take(.extension).and(expr).and(maybe(whereClause)).and(
+        Apply({ (s) in try parseTypeDeclBody(in: &s, wrappedIn: .extensionBody) })))
     guard let parts = try parser.parse(&state) else { return nil }
 
     // Extension declarations shall not have attributes.
@@ -669,8 +643,8 @@ public enum Parser {
   {
     // Parse the parts of the declaration.
     let parser =
-      (take(.namespace).and(take(.name))
-        .and(Apply({ (s) in try parseTypeDeclBody(in: &s, wrappedIn: .namespaceBody) })))
+      (take(.namespace).and(take(.name)).and(
+        Apply({ (s) in try parseTypeDeclBody(in: &s, wrappedIn: .namespaceBody) })))
     guard let parts = try parser.parse(&state) else { return nil }
 
     // Namespace declarations shall not have attributes.
@@ -700,9 +674,8 @@ public enum Parser {
   {
     // Parse the parts of the declaration.
     let parser =
-      (take(.operator).and(operatorNotation)
-        .and(operator_)
-        .and(maybe(take(.colon).and(precedenceGroup).second)))
+      (take(.operator).and(operatorNotation).and(operator_).and(
+        maybe(take(.colon).and(precedenceGroup).second)))
     guard let parts = try parser.parse(&state) else { return nil }
 
     // Operator declarations shall not have attributes.
@@ -792,9 +765,7 @@ public enum Parser {
           asNonStaticMember: isNonStaticMember)
         return [impl]
       }
-    } catch {
-      state.restore(from: backup)
-    }
+    } catch { state.restore(from: backup) }
 
     // Parse the left delimiter.
     if state.take(.lBrace) == nil { return nil }
@@ -846,10 +817,8 @@ public enum Parser {
       origin = state.range(from: startIndex)
     } else {
       switch body! {
-      case .expr(let id):
-        origin = state.ast[id].origin!
-      case .block(let id):
-        origin = state.ast[id].origin!
+      case .expr(let id): origin = state.ast[id].origin!
+      case .block(let id): origin = state.ast[id].origin!
       }
     }
 
@@ -867,9 +836,8 @@ public enum Parser {
   {
     // Parse the parts of the declaration.
     let parser =
-      (take(.trait).and(take(.name))
-        .and(maybe(conformanceList))
-        .and(Apply({ (s) in try parseTypeDeclBody(in: &s, wrappedIn: .traitBody) })))
+      (take(.trait).and(take(.name)).and(maybe(conformanceList)).and(
+        Apply({ (s) in try parseTypeDeclBody(in: &s, wrappedIn: .traitBody) })))
     guard let parts = try parser.parse(&state) else { return nil }
 
     // Trait declarations shall not have attributes.
@@ -894,10 +862,8 @@ public enum Parser {
   {
     // Parse the parts of the declaration.
     let parser =
-      (take(.type).and(take(.name))
-        .and(maybe(genericClause))
-        .and(maybe(conformanceList))
-        .and(Apply({ (s) in try parseTypeDeclBody(in: &s, wrappedIn: .productBody) })))
+      (take(.type).and(take(.name)).and(maybe(genericClause)).and(maybe(conformanceList)).and(
+        Apply({ (s) in try parseTypeDeclBody(in: &s, wrappedIn: .productBody) })))
     guard let parts = try parser.parse(&state) else { return nil }
 
     // Product type declarations shall not have attributes.
@@ -953,10 +919,7 @@ public enum Parser {
   {
     // Parse the parts of the declaration.
     let parser =
-      (take(.typealias).and(take(.name))
-        .and(maybe(genericClause))
-        .and(take(.assign))
-        .and(expr))
+      (take(.typealias).and(take(.name)).and(maybe(genericClause)).and(take(.assign)).and(expr))
     guard let parts = try parser.parse(&state) else { return nil }
 
     // Type alias declarations shall not have attributes.
@@ -1029,56 +992,48 @@ public enum Parser {
   }
 
   private static let functionOrMethodDeclBody = TryCatch(
-    trying:
-      methodDeclBody
-      .map({ (state, body) -> FunctionOrMethodDeclBody in .method(body) }),
-    orCatchingAndApplying:
-      functionDeclBody
-      .map({ (state, body) -> FunctionOrMethodDeclBody in .function(body) }))
+    trying: methodDeclBody.map({ (state, body) -> FunctionOrMethodDeclBody in .method(body) }),
+    orCatchingAndApplying: functionDeclBody.map({ (state, body) -> FunctionOrMethodDeclBody in
+      .function(body)
+    }))
 
   static let functionDeclBody = inContext(
     .functionBody,
     apply: TryCatch(
-      trying: take(.lBrace).and(expr).and(take(.rBrace))
-        .map({ (state, tree) -> FunctionDecl.Body in .expr(tree.0.1) }),
-      orCatchingAndApplying:
-        braceStmt
-        .map({ (state, id) -> FunctionDecl.Body in .block(id) })))
+      trying: take(.lBrace).and(expr).and(take(.rBrace)).map({ (state, tree) -> FunctionDecl.Body in
+        .expr(tree.0.1)
+      }), orCatchingAndApplying: braceStmt.map({ (state, id) -> FunctionDecl.Body in .block(id) })))
 
   static let methodDeclBody =
-    (take(.lBrace).and(methodImplDecl+).and(take(.rBrace))
-      .map({ (state, tree) -> [NodeID<MethodImplDecl>] in
-        var introducers: Set<ImplIntroducer> = []
-        var duplicateIntroducer: SourceRepresentable<ImplIntroducer>? = nil
-        for implID in tree.0.1 {
-          let introducer = state.ast[implID].introducer
-          if !introducers.insert(introducer.value).inserted { duplicateIntroducer = introducer }
-        }
+    (take(.lBrace).and(methodImplDecl+).and(take(.rBrace)).map({
+      (state, tree) -> [NodeID<MethodImplDecl>] in var introducers: Set<ImplIntroducer> = []
+      var duplicateIntroducer: SourceRepresentable<ImplIntroducer>? = nil
+      for implID in tree.0.1 {
+        let introducer = state.ast[implID].introducer
+        if !introducers.insert(introducer.value).inserted { duplicateIntroducer = introducer }
+      }
 
-        if let introducer = duplicateIntroducer {
-          throw DiagnosedError(.diagnose(duplicateImplementationIntroducer: introducer))
-        } else {
-          return tree.0.1
-        }
-      }))
+      if let introducer = duplicateIntroducer {
+        throw DiagnosedError(.diagnose(duplicateImplementationIntroducer: introducer))
+      } else {
+        return tree.0.1
+      }
+    }))
 
   static let methodImplDecl =
-    (methodIntroducer.and(maybe(methodImplBody))
-      .map({ (state, tree) -> NodeID<MethodImplDecl> in
-        let receiver = try state.ast.insert(
-          wellFormed: ParameterDecl(identifier: SourceRepresentable(value: "self"), origin: nil))
-        return try state.ast.insert(
-          wellFormed: MethodImplDecl(
-            introducer: tree.0, receiver: receiver, body: tree.1,
-            origin: tree.0.origin!.extended(upTo: state.currentIndex)))
-      }))
+    (methodIntroducer.and(maybe(methodImplBody)).map({ (state, tree) -> NodeID<MethodImplDecl> in
+      let receiver = try state.ast.insert(
+        wellFormed: ParameterDecl(identifier: SourceRepresentable(value: "self"), origin: nil))
+      return try state.ast.insert(
+        wellFormed: MethodImplDecl(
+          introducer: tree.0, receiver: receiver, body: tree.1,
+          origin: tree.0.origin!.extended(upTo: state.currentIndex)))
+    }))
 
   static let methodImplBody = TryCatch(
-    trying: take(.lBrace).and(expr).and(take(.rBrace))
-      .map({ (state, tree) -> MethodImplDecl.Body in .expr(tree.0.1) }),
-    orCatchingAndApplying:
-      braceStmt
-      .map({ (state, id) -> MethodImplDecl.Body in .block(id) }))
+    trying: take(.lBrace).and(expr).and(take(.rBrace)).map({ (state, tree) -> MethodImplDecl.Body in
+      .expr(tree.0.1)
+    }), orCatchingAndApplying: braceStmt.map({ (state, id) -> MethodImplDecl.Body in .block(id) }))
 
   static let methodIntroducer = translate([
     .let: ImplIntroducer.let, .inout: ImplIntroducer.inout, .set: ImplIntroducer.set,
@@ -1088,9 +1043,7 @@ public enum Parser {
   static let initDeclBody = inContext(.functionBody, apply: braceStmt)
 
   static let operator_ =
-    (Apply<ParserState, SourceRepresentable<Identifier>>({ (state) in
-      state.takeOperator()
-    }))
+    (Apply<ParserState, SourceRepresentable<Identifier>>({ (state) in state.takeOperator() }))
 
   static let operatorNotation = translate([
     .infix: OperatorNotation.infix, .prefix: OperatorNotation.prefix,
@@ -1100,18 +1053,17 @@ public enum Parser {
   static let precedenceGroup = ContextualKeyword<PrecedenceGroup>()
 
   static let propertyDeclHead =
-    (take(.property).and(take(.name))
-      .map({ (state, tree) -> PropertyDeclHead in
-        PropertyDeclHead(
-          introducer: SourceRepresentable(value: .property, range: tree.0.origin),
-          stem: SourceRepresentable(token: tree.1, in: state.lexer.source))
-      }))
+    (take(.property).and(take(.name)).map({ (state, tree) -> PropertyDeclHead in
+      PropertyDeclHead(
+        introducer: SourceRepresentable(value: .property, range: tree.0.origin),
+        stem: SourceRepresentable(token: tree.1, in: state.lexer.source))
+    }))
 
   static let propertyDeclSignature = (take(.colon).and(expr).second)
 
   static let subscriptDeclHead =
-    (take(.subscript).and(maybe(take(.name))).and(maybe(genericClause)).and(maybe(captureList))
-      .map({ (state, tree) -> SubscriptDeclHead in
+    (take(.subscript).and(maybe(take(.name))).and(maybe(genericClause)).and(maybe(captureList)).map(
+      { (state, tree) -> SubscriptDeclHead in
         SubscriptDeclHead(
           introducer: SourceRepresentable(value: .subscript, range: tree.0.0.0.origin),
           stem: tree.0.0.1.map({ SourceRepresentable(token: $0, in: state.lexer.source) }),
@@ -1132,11 +1084,10 @@ public enum Parser {
   static let subscriptImplDecl = (subscriptIntroducer.and(maybe(subscriptImplDeclBody)))
 
   static let subscriptImplDeclBody = TryCatch(
-    trying: take(.lBrace).and(expr).and(take(.rBrace))
-      .map({ (state, tree) -> SubscriptImplDecl.Body in .expr(tree.0.1) }),
-    orCatchingAndApplying:
-      braceStmt
-      .map({ (state, id) -> SubscriptImplDecl.Body in .block(id) }))
+    trying: take(.lBrace).and(expr).and(take(.rBrace)).map({
+      (state, tree) -> SubscriptImplDecl.Body in .expr(tree.0.1)
+    }),
+    orCatchingAndApplying: braceStmt.map({ (state, id) -> SubscriptImplDecl.Body in .block(id) }))
 
   static let subscriptIntroducer = translate([
     .let: ImplIntroducer.let, .inout: ImplIntroducer.inout, .set: ImplIntroducer.set,
@@ -1148,23 +1099,21 @@ public enum Parser {
       switch state.peek()?.kind {
       case .let, .inout, .var, .sink:
         return try parseDeclPrologue(in: &state, then: parseBindingDecl(withPrologue:in:))
-      default:
-        return nil
+      default: return nil
       }
     }))
 
   static let parameterDecl =
-    (parameterInterface
-      .and(maybe(take(.colon).and(parameterTypeExpr)))
-      .and(maybe(take(.assign).and(expr)))
-      .map({ (state, tree) -> NodeID<ParameterDecl> in
-        try state.ast.insert(
-          wellFormed: ParameterDecl(
-            label: tree.0.0.label, identifier: tree.0.0.name, annotation: tree.0.1?.1,
-            defaultValue: tree.1?.1,
-            origin: state.range(
-              from: tree.0.0.label?.origin!.lowerBound ?? tree.0.0.name.origin!.lowerBound)))
-      }))
+    (parameterInterface.and(maybe(take(.colon).and(parameterTypeExpr))).and(
+      maybe(take(.assign).and(expr))
+    ).map({ (state, tree) -> NodeID<ParameterDecl> in
+      try state.ast.insert(
+        wellFormed: ParameterDecl(
+          label: tree.0.0.label, identifier: tree.0.0.name, annotation: tree.0.1?.1,
+          defaultValue: tree.1?.1,
+          origin: state.range(
+            from: tree.0.0.label?.origin!.lowerBound ?? tree.0.0.name.origin!.lowerBound)))
+    }))
 
   typealias ParameterInterface = (
     label: SourceRepresentable<Identifier>?, name: SourceRepresentable<Identifier>
@@ -1204,52 +1153,48 @@ public enum Parser {
     }))
 
   static let memberModifier =
-    (take(.static)
-      .map({ (_, token) -> SourceRepresentable<MemberModifier> in
-        SourceRepresentable(value: .static, range: token.origin)
-      }))
+    (take(.static).map({ (_, token) -> SourceRepresentable<MemberModifier> in
+      SourceRepresentable(value: .static, range: token.origin)
+    }))
 
   static let accessModifier =
-    (take(.public)
-      .map({ (_, token) -> SourceRepresentable<AccessModifier> in
-        SourceRepresentable(value: .public, range: token.origin)
-      }))
+    (take(.public).map({ (_, token) -> SourceRepresentable<AccessModifier> in
+      SourceRepresentable(value: .public, range: token.origin)
+    }))
 
   static let captureList = inContext(
     .captureList,
-    apply: (take(.lBrack)
-      .and(bindingDecl.and(zeroOrMany(take(.comma).and(bindingDecl).second)))
-      .and(take(.rBrack))
-      .map({ (_, tree) -> [NodeID<BindingDecl>] in [tree.0.1.0] + tree.0.1.1 })))
+    apply: (take(.lBrack).and(bindingDecl.and(zeroOrMany(take(.comma).and(bindingDecl).second)))
+      .and(take(.rBrack)).map({ (_, tree) -> [NodeID<BindingDecl>] in [tree.0.1.0] + tree.0.1.1 })))
 
   static let genericClause =
-    (take(.lAngle).and(genericParameterListContents).and(maybe(whereClause)).and(take(.rAngle))
-      .map({ (state, tree) -> SourceRepresentable<GenericClause> in
+    (take(.lAngle).and(genericParameterListContents).and(maybe(whereClause)).and(take(.rAngle)).map(
+      { (state, tree) -> SourceRepresentable<GenericClause> in
         return SourceRepresentable(
           value: GenericClause(parameters: tree.0.0.1, whereClause: tree.0.1),
           range: tree.0.0.0.origin.extended(upTo: state.currentIndex))
       }))
 
   static let genericParameterListContents =
-    (genericParameter.and(zeroOrMany(take(.comma).and(genericParameter).second))
-      .map({ (_, tree) -> [NodeID<GenericParameterDecl>] in [tree.0] + tree.1 }))
+    (genericParameter.and(zeroOrMany(take(.comma).and(genericParameter).second)).map({
+      (_, tree) -> [NodeID<GenericParameterDecl>] in [tree.0] + tree.1
+    }))
 
   static let genericParameter =
-    (maybe(typeAttribute).andCollapsingSoftFailures(take(.name))
-      .and(maybe(take(.colon).and(traitComposition)))
-      .and(maybe(take(.assign).and(expr)))
-      .map({ (state, tree) -> NodeID<GenericParameterDecl> in
-        try state.ast.insert(
-          wellFormed: GenericParameterDecl(
-            identifier: SourceRepresentable(token: tree.0.0.1, in: state.lexer.source),
-            conformances: tree.0.1?.1 ?? [], defaultValue: tree.1?.1,
-            origin: state.range(from: tree.0.0.0?.origin.lowerBound ?? tree.0.0.1.origin.lowerBound)
-          ))
-      }))
+    (maybe(typeAttribute).andCollapsingSoftFailures(take(.name)).and(
+      maybe(take(.colon).and(traitComposition))
+    ).and(maybe(take(.assign).and(expr))).map({ (state, tree) -> NodeID<GenericParameterDecl> in
+      try state.ast.insert(
+        wellFormed: GenericParameterDecl(
+          identifier: SourceRepresentable(token: tree.0.0.1, in: state.lexer.source),
+          conformances: tree.0.1?.1 ?? [], defaultValue: tree.1?.1,
+          origin: state.range(from: tree.0.0.0?.origin.lowerBound ?? tree.0.0.1.origin.lowerBound)))
+    }))
 
   static let conformanceList =
-    (take(.colon).and(nameTypeExpr).and(zeroOrMany(take(.comma).and(nameTypeExpr).second))
-      .map({ (state, tree) -> [NodeID<NameExpr>] in [tree.0.1] + tree.1 }))
+    (take(.colon).and(nameTypeExpr).and(zeroOrMany(take(.comma).and(nameTypeExpr).second)).map({
+      (state, tree) -> [NodeID<NameExpr>] in [tree.0.1] + tree.1
+    }))
 
   // MARK: Expressions
 
@@ -1288,14 +1233,10 @@ public enum Parser {
 
     let castKind: CastExpr.Kind
     switch state.lexer.source[infixOperator.origin] {
-    case "as":
-      castKind = .up
-    case "as!":
-      castKind = .down
-    case "as!!":
-      castKind = .builtinPointerConversion
-    default:
-      unreachable()
+    case "as": castKind = .up
+    case "as!": castKind = .down
+    case "as!!": castKind = .builtinPointerConversion
+    default: unreachable()
     }
 
     let expr = try state.ast.insert(
@@ -1365,9 +1306,7 @@ public enum Parser {
       let operand = try state.expect("expression", using: parsePostfixExpr(in:))
 
       // There must be no space before the next expression.
-      if isSeparated {
-        state.diagnostics.append(.diagnose(separatedPrefixOperatorAt: op.origin))
-      }
+      if isSeparated { state.diagnostics.append(.diagnose(separatedPrefixOperatorAt: op.origin)) }
 
       let callee = try state.ast.insert(
         wellFormed: NameExpr(
@@ -1389,9 +1328,7 @@ public enum Parser {
       let operand = try state.expect("expression", using: parsePostfixExpr(in:))
 
       // There must be no space before the next expression.
-      if isSeparated {
-        state.diagnostics.append(.diagnose(separatedMutationMarkerAt: op.origin))
-      }
+      if isSeparated { state.diagnostics.append(.diagnose(separatedMutationMarkerAt: op.origin)) }
 
       let expr = try state.ast.insert(
         wellFormed: InoutExpr(
@@ -1601,8 +1538,7 @@ public enum Parser {
       // compound literal expression (e.g., `[x, y]`).
       return try parseLambdaTypeOrCompoundLiteralExpr(in: &state)
 
-    default:
-      return nil
+    default: return nil
     }
   }
 
@@ -1684,18 +1620,14 @@ public enum Parser {
 
     // Backtrack and parse an unlabeled argument.
     state.restore(from: backup)
-    if let value = try parseExpr(in: &state) {
-      return LabeledArgument(label: nil, value: value)
-    }
+    if let value = try parseExpr(in: &state) { return LabeledArgument(label: nil, value: value) }
 
     return nil
   }
 
   private static func parseEntityName(in state: inout ParserState) throws -> SourceRepresentable<
     Name
-  >? {
-    try parseFunctionEntityName(in: &state) ?? parseOperatorEntityName(in: &state)
-  }
+  >? { try parseFunctionEntityName(in: &state) ?? parseOperatorEntityName(in: &state) }
 
   private static func parseFunctionEntityName(in state: inout ParserState) throws
     -> SourceRepresentable<Name>?
@@ -1729,9 +1661,7 @@ public enum Parser {
           break
         }
 
-        if state.takeWithoutSkippingWhitespace(.colon) == nil {
-          break
-        }
+        if state.takeWithoutSkippingWhitespace(.colon) == nil { break }
 
         if state.takeWithoutSkippingWhitespace(.rParen) != nil {
           closeParenFound = true
@@ -1801,11 +1731,9 @@ public enum Parser {
   private static let lambdaBody = inContext(
     .functionBody,
     apply: TryCatch(
-      trying: take(.lBrace).and(expr).and(take(.rBrace))
-        .map({ (state, tree) -> FunctionDecl.Body in .expr(tree.0.1) }),
-      orCatchingAndApplying:
-        braceStmt
-        .map({ (state, id) -> FunctionDecl.Body in .block(id) })))
+      trying: take(.lBrace).and(expr).and(take(.rBrace)).map({ (state, tree) -> FunctionDecl.Body in
+        .expr(tree.0.1)
+      }), orCatchingAndApplying: braceStmt.map({ (state, id) -> FunctionDecl.Body in .block(id) })))
 
   private static func parseConditionalExpr(in state: inout ParserState) throws -> NodeID<CondExpr>?
   {
@@ -1835,11 +1763,9 @@ public enum Parser {
   }
 
   private static let conditionalExprBody = TryCatch(
-    trying: take(.lBrace).and(expr).and(take(.rBrace))
-      .map({ (state, tree) -> CondExpr.Body in .expr(tree.0.1) }),
-    orCatchingAndApplying:
-      braceStmt
-      .map({ (state, id) -> CondExpr.Body in .block(id) }))
+    trying: take(.lBrace).and(expr).and(take(.rBrace)).map({ (state, tree) -> CondExpr.Body in
+      .expr(tree.0.1)
+    }), orCatchingAndApplying: braceStmt.map({ (state, id) -> CondExpr.Body in .block(id) }))
 
   private static func parseMatchExpr(in state: inout ParserState) throws -> NodeID<MatchExpr>? {
     // Parse the introducer.
@@ -1857,20 +1783,18 @@ public enum Parser {
   }
 
   static let matchCase =
-    (pattern.and(maybe(take(.where).and(expr))).and(matchCaseBody)
-      .map({ (state, tree) -> NodeID<MatchCase> in
-        try state.ast.insert(
-          wellFormed: MatchCase(
-            pattern: tree.0.0, condition: tree.0.1?.1, body: tree.1,
-            origin: state.ast[tree.0.0].origin!.extended(upTo: state.currentIndex)))
-      }))
+    (pattern.and(maybe(take(.where).and(expr))).and(matchCaseBody).map({
+      (state, tree) -> NodeID<MatchCase> in
+      try state.ast.insert(
+        wellFormed: MatchCase(
+          pattern: tree.0.0, condition: tree.0.1?.1, body: tree.1,
+          origin: state.ast[tree.0.0].origin!.extended(upTo: state.currentIndex)))
+    }))
 
   private static let matchCaseBody = TryCatch(
-    trying: take(.lBrace).and(expr).and(take(.rBrace))
-      .map({ (state, tree) -> MatchCase.Body in .expr(tree.0.1) }),
-    orCatchingAndApplying:
-      braceStmt
-      .map({ (state, id) -> MatchCase.Body in .block(id) }))
+    trying: take(.lBrace).and(expr).and(take(.rBrace)).map({ (state, tree) -> MatchCase.Body in
+      .expr(tree.0.1)
+    }), orCatchingAndApplying: braceStmt.map({ (state, id) -> MatchCase.Body in .block(id) }))
 
   private static func parseSpawnExpr(in state: inout ParserState) throws -> NodeID<SpawnExpr>? {
     // Parse the introducer.
@@ -1900,9 +1824,7 @@ public enum Parser {
 
   private static func parseLambdaTypeOrTupleExpr(in state: inout ParserState) throws -> AnyExprID? {
     // Expect a left parenthesis.
-    guard
-      let opener = state.peek(), opener.kind == .lParen
-    else { return nil }
+    guard let opener = state.peek(), opener.kind == .lParen else { return nil }
 
     // Assume we're parsing a lambda type expression until we reach the point where we should
     // consume a right arrow. Commit to that choice only if there's one.
@@ -1910,9 +1832,7 @@ public enum Parser {
 
     // Parse the parameters or backtrack and parse a tuple expression.
     let parameters: [LambdaTypeExpr.Parameter]
-    do {
-      parameters = try parseLambdaParameterList(in: &state)!
-    } catch {
+    do { parameters = try parseLambdaParameterList(in: &state)! } catch {
       state.restore(from: backup)
       return try parseTupleOrParenthesizedExpr(in: &state)
     }
@@ -1973,9 +1893,7 @@ public enum Parser {
 
     // Parse the parameters or backtrack and parse a compound literal.
     let parameters: [LambdaTypeExpr.Parameter]
-    do {
-      parameters = try parseLambdaParameterList(in: &state)!
-    } catch {
+    do { parameters = try parseLambdaParameterList(in: &state)! } catch {
       state.restore(from: backup)
       return try parseCompoundLiteral(in: &state)
     }
@@ -2041,9 +1959,7 @@ public enum Parser {
 
     // Backtrack and parse an unlabeled element.
     state.restore(from: backup)
-    if let value = try expr.parse(&state) {
-      return TupleExpr.Element(value: value)
-    }
+    if let value = try expr.parse(&state) { return TupleExpr.Element(value: value) }
 
     return nil
   }
@@ -2077,9 +1993,7 @@ public enum Parser {
 
     // Backtrack and parse an unlabeled element.
     state.restore(from: backup)
-    if let type = try expr.parse(&state) {
-      return TupleTypeExpr.Element(type: type)
-    }
+    if let type = try expr.parse(&state) { return TupleTypeExpr.Element(type: type) }
 
     return nil
   }
@@ -2088,9 +2002,7 @@ public enum Parser {
     let backup = state.backup()
 
     // Attempt to parse a map literal.
-    do {
-      if let expr = try mapLiteral.parse(&state) { return AnyExprID(expr) }
-    } catch {}
+    do { if let expr = try mapLiteral.parse(&state) { return AnyExprID(expr) } } catch {}
 
     // Backtrack and parse a buffer literal.
     state.restore(from: backup)
@@ -2098,16 +2010,17 @@ public enum Parser {
   }
 
   private static let bufferLiteral =
-    (take(.lBrack).and(maybe(bufferComponentListContents)).and(take(.rBrack))
-      .map({ (state, tree) -> NodeID<BufferLiteralExpr> in
-        try state.ast.insert(
-          wellFormed: BufferLiteralExpr(
-            elements: tree.0.1 ?? [], origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
-      }))
+    (take(.lBrack).and(maybe(bufferComponentListContents)).and(take(.rBrack)).map({
+      (state, tree) -> NodeID<BufferLiteralExpr> in
+      try state.ast.insert(
+        wellFormed: BufferLiteralExpr(
+          elements: tree.0.1 ?? [], origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
+    }))
 
   private static let bufferComponentListContents =
-    (expr.and(zeroOrMany(take(.comma).and(expr).second))
-      .map({ (state, tree) -> [AnyExprID] in [tree.0] + tree.1 }))
+    (expr.and(zeroOrMany(take(.comma).and(expr).second)).map({ (state, tree) -> [AnyExprID] in
+      [tree.0] + tree.1
+    }))
 
   private static let mapLiteral =
     (take(.lBrack).and(mapComponentListContents.or(mapComponentEmptyContents)).and(take(.rBrack))
@@ -2118,37 +2031,33 @@ public enum Parser {
       }))
 
   private static let mapComponentEmptyContents =
-    (take(.colon)
-      .map({ (_, _) -> [MapLiteralExpr.Element] in [] }))
+    (take(.colon).map({ (_, _) -> [MapLiteralExpr.Element] in [] }))
 
   private static let mapComponentListContents =
-    (mapComponent.and(zeroOrMany(take(.comma).and(mapComponent).second))
-      .map({ (state, tree) -> [MapLiteralExpr.Element] in [tree.0] + tree.1 }))
+    (mapComponent.and(zeroOrMany(take(.comma).and(mapComponent).second)).map({
+      (state, tree) -> [MapLiteralExpr.Element] in [tree.0] + tree.1
+    }))
 
   private static let mapComponent =
-    (expr.and(take(.colon)).and(expr)
-      .map({ (_, tree) -> MapLiteralExpr.Element in
-        MapLiteralExpr.Element(key: tree.0.0, value: tree.1)
-      }))
+    (expr.and(take(.colon)).and(expr).map({ (_, tree) -> MapLiteralExpr.Element in
+      MapLiteralExpr.Element(key: tree.0.0, value: tree.1)
+    }))
 
   private static let callArgument = Apply(parseArgument(in:))
 
   static let conditionalClause =
-    (conditionalClauseItem.and(zeroOrMany(take(.comma).and(conditionalClauseItem).second))
-      .map({ (_, tree) -> [ConditionItem] in [tree.0] + tree.1 }))
+    (conditionalClauseItem.and(zeroOrMany(take(.comma).and(conditionalClauseItem).second)).map({
+      (_, tree) -> [ConditionItem] in [tree.0] + tree.1
+    }))
 
   static let conditionalClauseItem = Choose(
-    bindingPattern.and(take(.assign)).and(expr)
-      .map({ (state, tree) -> ConditionItem in
-        let id = try state.ast.insert(
-          wellFormed: BindingDecl(
-            pattern: tree.0.0, initializer: tree.1,
-            origin: state.ast[tree.0.0].origin!.extended(upTo: state.currentIndex)))
-        return .decl(id)
-      }),
-    or:
-      expr
-      .map({ (_, id) -> ConditionItem in .expr(id) }))
+    bindingPattern.and(take(.assign)).and(expr).map({ (state, tree) -> ConditionItem in
+      let id = try state.ast.insert(
+        wellFormed: BindingDecl(
+          pattern: tree.0.0, initializer: tree.1,
+          origin: state.ast[tree.0.0].origin!.extended(upTo: state.currentIndex)))
+      return .decl(id)
+    }), or: expr.map({ (_, id) -> ConditionItem in .expr(id) }))
 
   // MARK: Comma-separated lists
 
@@ -2158,9 +2067,7 @@ public enum Parser {
 
   private static func parseStaticArgumentList(in state: inout ParserState) throws
     -> [LabeledArgument]?
-  {
-    try parseList(in: &state, with: staticArgumentList)
-  }
+  { try parseList(in: &state, with: staticArgumentList) }
 
   private static let functionCallArgumentList = DelimitedCommaSeparatedList(
     openerKind: .lParen, closerKind: .rParen, closerDescription: ")",
@@ -2168,9 +2075,7 @@ public enum Parser {
 
   private static func parseFunctionCallArgumentList(in state: inout ParserState) throws
     -> [LabeledArgument]?
-  {
-    try parseList(in: &state, with: functionCallArgumentList)
-  }
+  { try parseList(in: &state, with: functionCallArgumentList) }
 
   private static let subscriptCallArgumentList = DelimitedCommaSeparatedList(
     openerKind: .lBrack, closerKind: .rBrack, closerDescription: "]",
@@ -2178,9 +2083,7 @@ public enum Parser {
 
   private static func parseSubscriptCallArgumentList(in state: inout ParserState) throws
     -> [LabeledArgument]?
-  {
-    try parseList(in: &state, with: subscriptCallArgumentList)
-  }
+  { try parseList(in: &state, with: subscriptCallArgumentList) }
 
   private static let attributeArgumentList = DelimitedCommaSeparatedList(
     openerKind: .lParen, closerKind: .rParen, closerDescription: ")",
@@ -2188,18 +2091,14 @@ public enum Parser {
 
   private static func parseAttributeArgumentList(in state: inout ParserState) throws -> [Attribute
     .Argument]?
-  {
-    try parseList(in: &state, with: attributeArgumentList)
-  }
+  { try parseList(in: &state, with: attributeArgumentList) }
 
   private static let parameterList = DelimitedCommaSeparatedList(
     openerKind: .lParen, closerKind: .rParen, closerDescription: ")", elementParser: parameterDecl)
 
   private static func parseParameterList(in state: inout ParserState) throws -> [NodeID<
     ParameterDecl
-  >]? {
-    try parseList(in: &state, with: parameterList)
-  }
+  >]? { try parseList(in: &state, with: parameterList) }
 
   private static let lambdaParameterList = DelimitedCommaSeparatedList(
     openerKind: .lParen, closerKind: .rParen, closerDescription: ")",
@@ -2207,9 +2106,7 @@ public enum Parser {
 
   private static func parseLambdaParameterList(in state: inout ParserState) throws
     -> [LambdaTypeExpr.Parameter]?
-  {
-    try parseList(in: &state, with: lambdaParameterList)
-  }
+  { try parseList(in: &state, with: lambdaParameterList) }
 
   private static func parseList<C: Combinator>(
     in state: inout ParserState, with parser: DelimitedCommaSeparatedList<C>
@@ -2235,11 +2132,8 @@ public enum Parser {
 
   private static func anyPattern<Base: Combinator>(_ base: Base) -> AnyCombinator<
     ParserState, AnyPatternID
-  >
-  where Base.Context == ParserState, Base.Element: PatternID {
-    AnyCombinator(parse: { (state) in
-      try base.parse(&state).map(AnyPatternID.init(_:))
-    })
+  > where Base.Context == ParserState, Base.Element: PatternID {
+    AnyCombinator(parse: { (state) in try base.parse(&state).map(AnyPatternID.init(_:)) })
   }
 
   static let pattern: Recursive<ParserState, AnyPatternID> = (Recursive(_pattern.parse(_:)))
@@ -2251,21 +2145,18 @@ public enum Parser {
     ]))
 
   static let bindingPattern =
-    (bindingIntroducer
-      .and(
-        inContext(
-          .bindingPattern,
-          apply: oneOf([
-            anyPattern(namePattern), anyPattern(tuplePattern), anyPattern(wildcardPattern),
-          ]))
-      )
-      .and(maybe(take(.colon).and(expr)))
-      .map({ (state, tree) -> NodeID<BindingPattern> in
-        try state.ast.insert(
-          wellFormed: BindingPattern(
-            introducer: tree.0.0, subpattern: tree.0.1, annotation: tree.1?.1,
-            origin: tree.0.0.origin!.extended(upTo: state.currentIndex)))
-      }))
+    (bindingIntroducer.and(
+      inContext(
+        .bindingPattern,
+        apply: oneOf([
+          anyPattern(namePattern), anyPattern(tuplePattern), anyPattern(wildcardPattern),
+        ]))
+    ).and(maybe(take(.colon).and(expr))).map({ (state, tree) -> NodeID<BindingPattern> in
+      try state.ast.insert(
+        wellFormed: BindingPattern(
+          introducer: tree.0.0, subpattern: tree.0.1, annotation: tree.1?.1,
+          origin: tree.0.0.origin!.extended(upTo: state.currentIndex)))
+    }))
 
   static let bindingIntroducer =
     (Apply<ParserState, SourceRepresentable<BindingPattern.Introducer>>({ (state) in
@@ -2290,8 +2181,7 @@ public enum Parser {
         _ = try state.expect("'let'", using: { $0.take(.let) })
         introducer = .sinklet
 
-      default:
-        return nil
+      default: return nil
       }
 
       return SourceRepresentable(
@@ -2301,15 +2191,11 @@ public enum Parser {
   static let exprPattern =
     (Apply<ParserState, AnyPatternID>({ (state) -> AnyPatternID? in
       // Attempt to parse tuples as patterns as deeply as possible.
-      if let patternID = try tuplePattern.parse(&state) {
-        return AnyPatternID(patternID)
-      }
+      if let patternID = try tuplePattern.parse(&state) { return AnyPatternID(patternID) }
 
       // Attempt to parse a name pattern if we're in the context of a binding pattern.
       if state.contexts.last == .bindingPattern {
-        if let patternID = try namePattern.parse(&state) {
-          return AnyPatternID(patternID)
-        }
+        if let patternID = try namePattern.parse(&state) { return AnyPatternID(patternID) }
       }
 
       // Default to an expression.
@@ -2320,30 +2206,28 @@ public enum Parser {
     }))
 
   static let namePattern =
-    (take(.name)
-      .map({ (state, token) -> NodeID<NamePattern> in
-        let declID = try state.ast.insert(
-          wellFormed: VarDecl(identifier: SourceRepresentable(token: token, in: state.lexer.source))
-        )
-        return try state.ast.insert(wellFormed: NamePattern(decl: declID, origin: token.origin))
-      }))
+    (take(.name).map({ (state, token) -> NodeID<NamePattern> in
+      let declID = try state.ast.insert(
+        wellFormed: VarDecl(identifier: SourceRepresentable(token: token, in: state.lexer.source)))
+      return try state.ast.insert(wellFormed: NamePattern(decl: declID, origin: token.origin))
+    }))
 
   static let tuplePattern =
-    (take(.lParen).and(maybe(tuplePatternElementList)).and(take(.rParen))
-      .map({ (state, tree) -> NodeID<TuplePattern> in
-        try state.ast.insert(
-          wellFormed: TuplePattern(
-            elements: tree.0.1 ?? [],
-            origin: tree.0.0.origin.extended(upTo: tree.1.origin.upperBound)))
-      }))
+    (take(.lParen).and(maybe(tuplePatternElementList)).and(take(.rParen)).map({
+      (state, tree) -> NodeID<TuplePattern> in
+      try state.ast.insert(
+        wellFormed: TuplePattern(
+          elements: tree.0.1 ?? [], origin: tree.0.0.origin.extended(upTo: tree.1.origin.upperBound)
+        ))
+    }))
 
   static let tuplePatternElementList =
-    (tuplePatternElement.and(zeroOrMany(take(.comma).and(tuplePatternElement).second))
-      .map({ (_, tree) -> [TuplePattern.Element] in [tree.0] + tree.1 }))
+    (tuplePatternElement.and(zeroOrMany(take(.comma).and(tuplePatternElement).second)).map({
+      (_, tree) -> [TuplePattern.Element] in [tree.0] + tree.1
+    }))
 
   static let tuplePatternElement =
-    (Apply<ParserState, TuplePattern.Element>({ (state) in
-      let backup = state.backup()
+    (Apply<ParserState, TuplePattern.Element>({ (state) in let backup = state.backup()
 
       // Parse a labeled element.
       if let label = state.take(if: { $0.isLabel }) {
@@ -2365,20 +2249,16 @@ public enum Parser {
     }))
 
   static let wildcardPattern =
-    (take(.under)
-      .map({ (state, token) -> NodeID<WildcardPattern> in
-        try state.ast.insert(wellFormed: WildcardPattern(origin: token.origin))
-      }))
+    (take(.under).map({ (state, token) -> NodeID<WildcardPattern> in
+      try state.ast.insert(wellFormed: WildcardPattern(origin: token.origin))
+    }))
 
   // MARK: Statements
 
   private static func anyStmt<Base: Combinator>(_ base: Base) -> AnyCombinator<
     ParserState, AnyStmtID
-  >
-  where Base.Context == ParserState, Base.Element: StmtID {
-    AnyCombinator(parse: { (state) in
-      try base.parse(&state).map(AnyStmtID.init(_:))
-    })
+  > where Base.Context == ParserState, Base.Element: StmtID {
+    AnyCombinator(parse: { (state) in try base.parse(&state).map(AnyStmtID.init(_:)) })
   }
 
   static let stmt: Recursive<ParserState, AnyStmtID> = (Recursive(_stmt.parse(_:)))
@@ -2391,53 +2271,49 @@ public enum Parser {
     ]))
 
   static let braceStmt =
-    (take(.lBrace)
-      .and(zeroOrMany(take(.semi)))
-      .and(zeroOrMany(stmt.and(zeroOrMany(take(.semi))).first))
-      .and(take(.rBrace))
-      .map({ (state, tree) -> NodeID<BraceStmt> in
-        try state.ast.insert(
-          wellFormed: BraceStmt(
-            stmts: tree.0.1, origin: tree.0.0.0.origin.extended(upTo: state.currentIndex)))
-      }))
+    (take(.lBrace).and(zeroOrMany(take(.semi))).and(
+      zeroOrMany(stmt.and(zeroOrMany(take(.semi))).first)
+    ).and(take(.rBrace)).map({ (state, tree) -> NodeID<BraceStmt> in
+      try state.ast.insert(
+        wellFormed: BraceStmt(
+          stmts: tree.0.1, origin: tree.0.0.0.origin.extended(upTo: state.currentIndex)))
+    }))
 
   static let discardStmt =
-    (take(.under).and(take(.assign)).and(expr)
-      .map({ (state, tree) -> NodeID<DiscardStmt> in
-        try state.ast.insert(
-          wellFormed: DiscardStmt(
-            expr: tree.1, origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
-      }))
+    (take(.under).and(take(.assign)).and(expr).map({ (state, tree) -> NodeID<DiscardStmt> in
+      try state.ast.insert(
+        wellFormed: DiscardStmt(
+          expr: tree.1, origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
+    }))
 
   static let doWhileStmt =
-    (take(.do).and(loopBody).and(take(.while)).and(expr)
-      .map({ (state, tree) -> NodeID<DoWhileStmt> in
-        try state.ast.insert(
-          wellFormed: DoWhileStmt(
-            body: tree.0.0.1, condition: tree.1,
-            origin: tree.0.0.0.origin.extended(upTo: state.currentIndex)))
-      }))
+    (take(.do).and(loopBody).and(take(.while)).and(expr).map({
+      (state, tree) -> NodeID<DoWhileStmt> in
+      try state.ast.insert(
+        wellFormed: DoWhileStmt(
+          body: tree.0.0.1, condition: tree.1,
+          origin: tree.0.0.0.origin.extended(upTo: state.currentIndex)))
+    }))
 
   static let whileStmt =
-    (take(.while).and(conditionalClause).and(loopBody)
-      .map({ (state, tree) -> NodeID<WhileStmt> in
-        try state.ast.insert(
-          wellFormed: WhileStmt(
-            condition: tree.0.1, body: tree.1,
-            origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
-      }))
+    (take(.while).and(conditionalClause).and(loopBody).map({ (state, tree) -> NodeID<WhileStmt> in
+      try state.ast.insert(
+        wellFormed: WhileStmt(
+          condition: tree.0.1, body: tree.1,
+          origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
+    }))
 
   static let forStmt =
-    (take(.for).and(bindingPattern).and(forRange).and(maybe(forFilter)).and(loopBody)
-      .map({ (state, tree) -> NodeID<ForStmt> in
-        let decl = try state.ast.insert(
-          wellFormed: BindingDecl(
-            pattern: tree.0.0.0.1, initializer: nil, origin: state.ast[tree.0.0.0.1].origin))
-        return try state.ast.insert(
-          wellFormed: ForStmt(
-            binding: decl, domain: tree.0.0.1, filter: tree.0.1, body: tree.1,
-            origin: tree.0.0.0.0.origin.extended(upTo: state.currentIndex)))
-      }))
+    (take(.for).and(bindingPattern).and(forRange).and(maybe(forFilter)).and(loopBody).map({
+      (state, tree) -> NodeID<ForStmt> in
+      let decl = try state.ast.insert(
+        wellFormed: BindingDecl(
+          pattern: tree.0.0.0.1, initializer: nil, origin: state.ast[tree.0.0.0.1].origin))
+      return try state.ast.insert(
+        wellFormed: ForStmt(
+          binding: decl, domain: tree.0.0.1, filter: tree.0.1, body: tree.1,
+          origin: tree.0.0.0.0.origin.extended(upTo: state.currentIndex)))
+    }))
 
   static let forRange = (take(.in).and(expr).second)
 
@@ -2446,36 +2322,31 @@ public enum Parser {
   static let loopBody = inContext(.loopBody, apply: braceStmt)
 
   static let returnStmt =
-    (take(.return).and(maybe(onSameLine(expr)))
-      .map({ (state, tree) -> NodeID<ReturnStmt> in
-        try state.ast.insert(
-          wellFormed: ReturnStmt(
-            value: tree.1, origin: tree.0.origin.extended(upTo: state.currentIndex)))
-      }))
+    (take(.return).and(maybe(onSameLine(expr))).map({ (state, tree) -> NodeID<ReturnStmt> in
+      try state.ast.insert(
+        wellFormed: ReturnStmt(
+          value: tree.1, origin: tree.0.origin.extended(upTo: state.currentIndex)))
+    }))
 
   static let yieldStmt =
-    (take(.yield).and(onSameLine(expr))
-      .map({ (state, tree) -> NodeID<YieldStmt> in
-        try state.ast.insert(
-          wellFormed: YieldStmt(
-            value: tree.1, origin: tree.0.origin.extended(upTo: state.currentIndex)))
-      }))
+    (take(.yield).and(onSameLine(expr)).map({ (state, tree) -> NodeID<YieldStmt> in
+      try state.ast.insert(
+        wellFormed: YieldStmt(
+          value: tree.1, origin: tree.0.origin.extended(upTo: state.currentIndex)))
+    }))
 
   static let breakStmt =
-    (take(.break)
-      .map({ (state, token) -> NodeID<BreakStmt> in
-        try state.ast.insert(wellFormed: BreakStmt(origin: token.origin))
-      }))
+    (take(.break).map({ (state, token) -> NodeID<BreakStmt> in
+      try state.ast.insert(wellFormed: BreakStmt(origin: token.origin))
+    }))
 
   static let continueStmt =
-    (take(.break)
-      .map({ (state, token) -> NodeID<ContinueStmt> in
-        try state.ast.insert(wellFormed: ContinueStmt(origin: token.origin))
-      }))
+    (take(.break).map({ (state, token) -> NodeID<ContinueStmt> in
+      try state.ast.insert(wellFormed: ContinueStmt(origin: token.origin))
+    }))
 
   static let bindingStmt =
-    (Apply<ParserState, AnyStmtID>({ (state) -> AnyStmtID? in
-      let backup = state.backup()
+    (Apply<ParserState, AnyStmtID>({ (state) -> AnyStmtID? in let backup = state.backup()
       do {
         if let element = try conditionalBindingStmt.parse(&state) { return AnyStmtID(element) }
       } catch {}
@@ -2491,22 +2362,21 @@ public enum Parser {
     }))
 
   static let conditionalBindingStmt =
-    (bindingDecl.and(take(.else)).and(conditionalBindingFallback)
-      .map({ (state, tree) -> NodeID<CondBindingStmt> in
-        let bindingRange = state.ast[tree.0.0].origin!
+    (bindingDecl.and(take(.else)).and(conditionalBindingFallback).map({
+      (state, tree) -> NodeID<CondBindingStmt> in let bindingRange = state.ast[tree.0.0].origin!
 
-        if state.ast[tree.0.0].initializer == nil {
-          throw DiagnosedError(
-            .error(
-              "conditional binding requires an initializer",
-              range: bindingRange.extended(upTo: bindingRange.lowerBound)))
-        }
+      if state.ast[tree.0.0].initializer == nil {
+        throw DiagnosedError(
+          .error(
+            "conditional binding requires an initializer",
+            range: bindingRange.extended(upTo: bindingRange.lowerBound)))
+      }
 
-        return try state.ast.insert(
-          wellFormed: CondBindingStmt(
-            binding: tree.0.0, fallback: tree.1,
-            origin: bindingRange.extended(upTo: state.currentIndex)))
-      }))
+      return try state.ast.insert(
+        wellFormed: CondBindingStmt(
+          binding: tree.0.0, fallback: tree.1,
+          origin: bindingRange.extended(upTo: state.currentIndex)))
+    }))
 
   static let conditionalBindingFallback =
     (conditionalBindingFallbackStmt.or(conditionalBindingFallbackExpr))
@@ -2519,10 +2389,9 @@ public enum Parser {
       .map({ (_, id) -> CondBindingStmt.Fallback in .exit(id) }))
 
   static let declStmt =
-    (Apply(parseDecl)
-      .map({ (state, decl) -> NodeID<DeclStmt> in
-        try state.ast.insert(wellFormed: DeclStmt(decl: decl, origin: state.ast[decl].origin))
-      }))
+    (Apply(parseDecl).map({ (state, decl) -> NodeID<DeclStmt> in
+      try state.ast.insert(wellFormed: DeclStmt(decl: decl, origin: state.ast[decl].origin))
+    }))
 
   static let exprStmt = Apply(parseExprOrAssignStmt(in:))
 
@@ -2579,15 +2448,14 @@ public enum Parser {
   static let receiverEffect = translate([.inout: ReceiverEffect.inout, .sink: ReceiverEffect.sink])
 
   static let parameterTypeExpr =
-    (maybe(passingConvention)
-      .andCollapsingSoftFailures(expr)
-      .map({ (state, tree) -> NodeID<ParameterTypeExpr> in
-        try state.ast.insert(
-          wellFormed: ParameterTypeExpr(
-            convention: tree.0 ?? SourceRepresentable(value: .let), bareType: tree.1,
-            origin: state.range(
-              from: tree.0?.origin!.lowerBound ?? state.ast[tree.1].origin!.lowerBound)))
-      }))
+    (maybe(passingConvention).andCollapsingSoftFailures(expr).map({
+      (state, tree) -> NodeID<ParameterTypeExpr> in
+      try state.ast.insert(
+        wellFormed: ParameterTypeExpr(
+          convention: tree.0 ?? SourceRepresentable(value: .let), bareType: tree.1,
+          origin: state.range(
+            from: tree.0?.origin!.lowerBound ?? state.ast[tree.1].origin!.lowerBound)))
+    }))
 
   static let passingConvention = translate([
     .let: PassingConvention.let, .inout: PassingConvention.inout, .set: PassingConvention.set,
@@ -2595,18 +2463,17 @@ public enum Parser {
   ])
 
   static let whereClause =
-    (take(.where).and(whereClauseConstraintList)
-      .map({ (state, tree) -> SourceRepresentable<WhereClause> in
-        SourceRepresentable(
-          value: WhereClause(constraints: tree.1),
-          range: tree.0.origin.extended(upTo: state.currentIndex))
-      }))
+    (take(.where).and(whereClauseConstraintList).map({
+      (state, tree) -> SourceRepresentable<WhereClause> in
+      SourceRepresentable(
+        value: WhereClause(constraints: tree.1),
+        range: tree.0.origin.extended(upTo: state.currentIndex))
+    }))
 
   static let whereClauseConstraintList =
-    (whereClauseConstraint.and(zeroOrMany(take(.comma).and(whereClauseConstraint).second))
-      .map({ (state, tree) -> [SourceRepresentable<WhereClause.ConstraintExpr>] in
-        [tree.0] + tree.1
-      }))
+    (whereClauseConstraint.and(zeroOrMany(take(.comma).and(whereClauseConstraint).second)).map({
+      (state, tree) -> [SourceRepresentable<WhereClause.ConstraintExpr>] in [tree.0] + tree.1
+    }))
 
   static let whereClauseConstraint = (typeConstraint.or(valueConstraint))
 
@@ -2634,15 +2501,16 @@ public enum Parser {
     }))
 
   static let valueConstraint =
-    (valueAttribute.and(expr)
-      .map({ (state, tree) -> SourceRepresentable<WhereClause.ConstraintExpr> in
-        SourceRepresentable(
-          value: .value(tree.1), range: tree.0.origin.extended(upTo: state.currentIndex))
-      }))
+    (valueAttribute.and(expr).map({
+      (state, tree) -> SourceRepresentable<WhereClause.ConstraintExpr> in
+      SourceRepresentable(
+        value: .value(tree.1), range: tree.0.origin.extended(upTo: state.currentIndex))
+    }))
 
   static let traitComposition =
-    (nameTypeExpr.and(zeroOrMany(take(.ampersand).and(nameTypeExpr).second))
-      .map({ (state, tree) -> TraitComposition in [tree.0] + tree.1 }))
+    (nameTypeExpr.and(zeroOrMany(take(.ampersand).and(nameTypeExpr).second)).map({
+      (state, tree) -> TraitComposition in [tree.0] + tree.1
+    }))
 
   // MARK: Attributes
 
@@ -2702,9 +2570,7 @@ struct DeclPrologue {
   let memberModifiers: Set<SourceRepresentable<MemberModifier>>
 
   /// Indicates whether the prologue contains the `static` member modifier.
-  var isStatic: Bool {
-    memberModifiers.contains(where: { (m) in m.value == .static })
-  }
+  var isStatic: Bool { memberModifiers.contains(where: { (m) in m.value == .static }) }
 
 }
 
@@ -2822,9 +2688,7 @@ struct TakeKind: Combinator {
   /// The kind of the token to consume.
   let kind: Token.Kind
 
-  func parse(_ state: inout ParserState) throws -> Token? {
-    state.take(kind)
-  }
+  func parse(_ state: inout ParserState) throws -> Token? { state.take(kind) }
 
 }
 
@@ -2964,9 +2828,7 @@ struct DelimitedCommaSeparatedList<E: Combinator>: Combinator where E.Context ==
 }
 
 /// Creates a combinator that parses tokens with the specified kind.
-private func take(_ kind: Token.Kind) -> TakeKind {
-  TakeKind(kind: kind)
-}
+private func take(_ kind: Token.Kind) -> TakeKind { TakeKind(kind: kind) }
 
 /// Creates a combinator that parses name tokens with the specified value.
 private func take(nameTokenWithValue value: String) -> Apply<ParserState, Token> {
@@ -2980,8 +2842,7 @@ private func attribute(_ name: String) -> Apply<ParserState, Token> {
 
 /// Creates a combinator that translates token kinds to instances of type.
 private func translate<T>(_ table: [Token.Kind: T]) -> Apply<ParserState, SourceRepresentable<T>> {
-  Apply({ (state) in
-    guard let head = state.peek() else { return nil }
+  Apply({ (state) in guard let head = state.peek() else { return nil }
     if let translation = table[head.kind] {
       _ = state.take()
       return SourceRepresentable(value: translation, range: head.origin)
@@ -2995,15 +2856,12 @@ private func translate<T>(_ table: [Token.Kind: T]) -> Apply<ParserState, Source
 /// that context afterward.
 private func inContext<Base: Combinator>(_ context: ParserState.Context, apply base: Base)
   -> WrapInContext<Base>
-{
-  WrapInContext(context: context, base: base)
-}
+{ WrapInContext(context: context, base: base) }
 
 /// Creates a combinator that applies `base` only if its input is not preceeded by whitespaces.
 private func withoutLeadingWhitespace<Base: Combinator>(_ base: Base) -> Apply<
   ParserState, Base.Element
->
-where Base.Context == ParserState {
+> where Base.Context == ParserState {
   Apply({ (state) in try state.hasLeadingWhitespace ? nil : base.parse(&state) })
 }
 
@@ -3012,9 +2870,7 @@ private func onSameLine<Base: Combinator>(_ base: Base) -> Apply<ParserState, Ba
 where Base.Context == ParserState {
   Apply({ (state) in
     if let t = state.peek() {
-      return try state.hasNewline(before: t)
-        ? nil
-        : base.parse(&state)
+      return try state.hasNewline(before: t) ? nil : base.parse(&state)
     } else {
       // Let `base` handle end of stream.
       return try base.parse(&state)

--- a/Sources/Compiler/Parse/Parser.swift
+++ b/Sources/Compiler/Parse/Parser.swift
@@ -23,11 +23,9 @@ public enum Parser {
   ///
   /// - Returns: `(translation, diagnostics)` where `diagnostics` are the diagnostics produced by
   ///   the parser and `translation` is the ID of parsed translation unit.
-  public static func parse(
-    _ input: SourceFile,
-    into module: NodeID<ModuleDecl>,
-    in ast: inout AST
-  ) throws -> (translation: NodeID<TopLevelDeclSet>, diagnostics: [Diagnostic]) {
+  public static func parse(_ input: SourceFile, into module: NodeID<ModuleDecl>, in ast: inout AST)
+    throws -> (translation: NodeID<TopLevelDeclSet>, diagnostics: [Diagnostic])
+  {
     // Initialize the parser's state.
     var state = ParserState(ast: ast, lexer: Lexer(tokenizing: input))
 
@@ -81,15 +79,13 @@ public enum Parser {
       case .unterminatedBlockComment:
         // Nothing to parse after an unterminated block comment.
         state.diagnostics.append(
-          .diagnose(
-            unterminatedCommentEndingAt: head.origin.last() ?? head.origin.first()))
+          .diagnose(unterminatedCommentEndingAt: head.origin.last() ?? head.origin.first()))
         break
 
       case .unterminatedString:
         // Nothing to parse after an unterminated string.
         state.diagnostics.append(
-          .diagnose(
-            unterminatedStringEndingAt: head.origin.last() ?? head.origin.first()))
+          .diagnose(unterminatedStringEndingAt: head.origin.last() ?? head.origin.first()))
         break
 
       default:
@@ -133,9 +129,7 @@ public enum Parser {
         // Catch access modifiers declared after member modifiers.
         if let member = memberModifiers.first {
           state.diagnostics.append(
-            .diagnose(
-              memberModifier: member,
-              appearsBeforeAccessModifier: access))
+            .diagnose(memberModifier: member, appearsBeforeAccessModifier: access))
         }
 
         // Catch duplicate access modifiers.
@@ -169,20 +163,14 @@ public enum Parser {
 
     // Apply the continuation.
     let prologue = DeclPrologue(
-      isEmpty: isPrologueEmpty,
-      startIndex: startIndex,
-      attributes: attributes,
-      accessModifiers: accessModifiers,
-      memberModifiers: memberModifiers)
+      isEmpty: isPrologueEmpty, startIndex: startIndex, attributes: attributes,
+      accessModifiers: accessModifiers, memberModifiers: memberModifiers)
     return try continuation(prologue, &state)
   }
 
   /// Parses a declaration in `state`.
   static func parseDecl(in state: inout ParserState) throws -> AnyDeclID? {
-    func continuation(
-      prologue: DeclPrologue,
-      state: inout ParserState
-    ) throws -> AnyDeclID? {
+    func continuation(prologue: DeclPrologue, state: inout ParserState) throws -> AnyDeclID? {
       // Look ahead to select the appropriate declaration parser.
       switch state.peek()?.kind {
       case .let, .inout, .var, .sink:
@@ -281,8 +269,7 @@ public enum Parser {
   ///   - state: A mutable projection of the parser's state.
   ///   - context: The parser context in which members should be parsed.
   private static func parseTypeDeclBody(
-    in state: inout ParserState,
-    wrappedIn context: ParserState.Context
+    in state: inout ParserState, wrappedIn context: ParserState.Context
   ) throws -> [AnyDeclID] {
     // Parse the left delimiter.
     let opener = try state.expect("'{'", using: { $0.take(.lBrace) })
@@ -316,10 +303,8 @@ public enum Parser {
       guard let head = state.take() else {
         state.diagnostics.append(
           .diagnose(
-            expected: "'}'",
-            at: state.currentLocation,
-            children: [.error("to match this '{'", range: opener.origin)]
-          ))
+            expected: "'}'", at: state.currentLocation,
+            children: [.error("to match this '{'", range: opener.origin)]))
         break
       }
 
@@ -335,8 +320,7 @@ public enum Parser {
 
   /// Parses an instance of `AssociatedTypeDecl`.
   static func parseAssociatedTypeDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
+    withPrologue prologue: DeclPrologue, in state: inout ParserState
   ) throws -> NodeID<AssociatedTypeDecl>? {
     // Parse the parts of the declaration.
     let parser =
@@ -354,13 +338,11 @@ public enum Parser {
     // Associated type declarations shall not have modifiers.
     if !prologue.accessModifiers.isEmpty {
       throw DiagnosedError(
-        prologue.accessModifiers.map(
-          Diagnostic.diagnose(unexpectedAccessModifier:)))
+        prologue.accessModifiers.map(Diagnostic.diagnose(unexpectedAccessModifier:)))
     }
     if !prologue.memberModifiers.isEmpty {
       throw DiagnosedError(
-        prologue.memberModifiers.map(
-          Diagnostic.diagnose(unexpectedMemberModifier:)))
+        prologue.memberModifiers.map(Diagnostic.diagnose(unexpectedMemberModifier:)))
     }
 
     // Create a new `AssociatedTypeDecl`.
@@ -368,17 +350,14 @@ public enum Parser {
       wellFormed: AssociatedTypeDecl(
         introducerRange: parts.0.0.0.0.origin,
         identifier: SourceRepresentable(token: parts.0.0.0.1, in: state.lexer.source),
-        conformances: parts.0.0.1 ?? [],
-        whereClause: parts.0.1,
-        defaultValue: parts.1,
+        conformances: parts.0.0.1 ?? [], whereClause: parts.0.1, defaultValue: parts.1,
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Parses an instance of `AssociatedValueDecl`.
   static func parseAssociatedValueDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
+    withPrologue prologue: DeclPrologue, in state: inout ParserState
   ) throws -> NodeID<AssociatedValueDecl>? {
     // Parse the parts of the declaration.
     let parser =
@@ -395,13 +374,11 @@ public enum Parser {
     // Associated value declarations shall not have modifiers.
     if !prologue.accessModifiers.isEmpty {
       throw DiagnosedError(
-        prologue.accessModifiers.map(
-          Diagnostic.diagnose(unexpectedAccessModifier:)))
+        prologue.accessModifiers.map(Diagnostic.diagnose(unexpectedAccessModifier:)))
     }
     if !prologue.memberModifiers.isEmpty {
       throw DiagnosedError(
-        prologue.memberModifiers.map(
-          Diagnostic.diagnose(unexpectedMemberModifier:)))
+        prologue.memberModifiers.map(Diagnostic.diagnose(unexpectedMemberModifier:)))
     }
 
     // Create a new `AssociatedValueDecl`.
@@ -409,17 +386,15 @@ public enum Parser {
       wellFormed: AssociatedValueDecl(
         introducerRange: parts.0.0.0.origin,
         identifier: SourceRepresentable(token: parts.0.0.1, in: state.lexer.source),
-        whereClause: parts.0.1,
-        defaultValue: parts.1,
+        whereClause: parts.0.1, defaultValue: parts.1,
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Parses an instance of `BindingDecl`.
-  static func parseBindingDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
-  ) throws -> NodeID<BindingDecl>? {
+  static func parseBindingDecl(withPrologue prologue: DeclPrologue, in state: inout ParserState)
+    throws -> NodeID<BindingDecl>?
+  {
     // Parse the parts of the declaration.
     let parser =
       (bindingPattern
@@ -431,20 +406,16 @@ public enum Parser {
     assert(prologue.memberModifiers.count <= 1)
     let decl = try state.ast.insert(
       wellFormed: BindingDecl(
-        attributes: prologue.attributes,
-        accessModifier: prologue.accessModifiers.first,
-        memberModifier: prologue.memberModifiers.first,
-        pattern: pattern,
-        initializer: initializer,
+        attributes: prologue.attributes, accessModifier: prologue.accessModifiers.first,
+        memberModifier: prologue.memberModifiers.first, pattern: pattern, initializer: initializer,
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Parses an instance of `ConformanceDecl`.
-  static func parseConformanceDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
-  ) throws -> NodeID<ConformanceDecl>? {
+  static func parseConformanceDecl(withPrologue prologue: DeclPrologue, in state: inout ParserState)
+    throws -> NodeID<ConformanceDecl>?
+  {
     // Parse the parts of the declaration.
     let parser =
       (take(.conformance).and(expr)
@@ -461,28 +432,23 @@ public enum Parser {
     // Conformance declarations shall not have member modifiers.
     if !prologue.memberModifiers.isEmpty {
       throw DiagnosedError(
-        prologue.memberModifiers.map(
-          Diagnostic.diagnose(unexpectedMemberModifier:)))
+        prologue.memberModifiers.map(Diagnostic.diagnose(unexpectedMemberModifier:)))
     }
 
     // Create a new `ConformanceDecl`.
     assert(prologue.accessModifiers.count <= 1)
     let decl = try state.ast.insert(
       wellFormed: ConformanceDecl(
-        accessModifier: prologue.accessModifiers.first,
-        subject: parts.0.0.0.1,
-        conformances: parts.0.0.1,
-        whereClause: parts.0.1,
-        members: parts.1,
+        accessModifier: prologue.accessModifiers.first, subject: parts.0.0.0.1,
+        conformances: parts.0.0.1, whereClause: parts.0.1, members: parts.1,
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Parses an instance of `ExtensionDecl`.
-  static func parseExtensionDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
-  ) throws -> NodeID<ExtensionDecl>? {
+  static func parseExtensionDecl(withPrologue prologue: DeclPrologue, in state: inout ParserState)
+    throws -> NodeID<ExtensionDecl>?
+  {
     // Parse the parts of the declaration.
     let parser =
       (take(.extension).and(expr)
@@ -498,31 +464,25 @@ public enum Parser {
     // Extension declarations shall not have modifiers.
     if !prologue.accessModifiers.isEmpty {
       throw DiagnosedError(
-        prologue.accessModifiers.map(
-          Diagnostic.diagnose(unexpectedAccessModifier:)))
+        prologue.accessModifiers.map(Diagnostic.diagnose(unexpectedAccessModifier:)))
     }
     if !prologue.memberModifiers.isEmpty {
       throw DiagnosedError(
-        prologue.memberModifiers.map(
-          Diagnostic.diagnose(unexpectedMemberModifier:)))
+        prologue.memberModifiers.map(Diagnostic.diagnose(unexpectedMemberModifier:)))
     }
 
     // Create a new `ExtensionDecl`.
     assert(prologue.accessModifiers.count <= 1)
     let decl = try state.ast.insert(
       wellFormed: ExtensionDecl(
-        accessModifier: prologue.accessModifiers.first,
-        subject: parts.0.0.1,
-        whereClause: parts.0.1,
-        members: parts.1,
-        origin: state.range(from: prologue.startIndex)))
+        accessModifier: prologue.accessModifiers.first, subject: parts.0.0.1,
+        whereClause: parts.0.1, members: parts.1, origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Parses an instance of `FunctionDecl` or `MethodDecl`.
   static func parseFunctionOrMethodDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
+    withPrologue prologue: DeclPrologue, in state: inout ParserState
   ) throws -> AnyDeclID? {
     // Parse the signature of the function or method.
     guard let head = try parseFunctionDeclHead(in: &state) else { return nil }
@@ -536,47 +496,30 @@ public enum Parser {
     case .method(let impls):
       return try AnyDeclID(
         buildMethodDecl(
-          prologue: prologue,
-          head: head,
-          signature: signature,
-          impls: impls,
-          in: &state))
+          prologue: prologue, head: head, signature: signature, impls: impls, in: &state))
 
     case .function(let body):
       return try AnyDeclID(
         buildFunctionDecl(
-          prologue: prologue,
-          head: head,
-          signature: signature,
-          body: body,
-          in: &state))
+          prologue: prologue, head: head, signature: signature, body: body, in: &state))
 
     case nil:
       return try AnyDeclID(
         buildFunctionDecl(
-          prologue: prologue,
-          head: head,
-          signature: signature,
-          body: nil,
-          in: &state))
+          prologue: prologue, head: head, signature: signature, body: nil, in: &state))
     }
   }
 
   /// Builds a new instance of `FunctionDecl` from its parsed parts.
   private static func buildFunctionDecl(
-    prologue: DeclPrologue,
-    head: FunctionDeclHead,
-    signature: FunctionDeclSignature,
-    body: FunctionDecl.Body?,
-    in state: inout ParserState
+    prologue: DeclPrologue, head: FunctionDeclHead, signature: FunctionDeclSignature,
+    body: FunctionDecl.Body?, in state: inout ParserState
   ) throws -> NodeID<FunctionDecl> {
     // Non-static member function declarations require an implicit receiver parameter.
     let receiver: NodeID<ParameterDecl>?
     if state.isAtTypeScope && !prologue.isStatic {
       receiver = try state.ast.insert(
-        wellFormed: ParameterDecl(
-          identifier: SourceRepresentable(value: "self"),
-          origin: nil))
+        wellFormed: ParameterDecl(identifier: SourceRepresentable(value: "self"), origin: nil))
     } else {
       receiver = nil
     }
@@ -586,30 +529,19 @@ public enum Parser {
     assert(prologue.memberModifiers.count <= 1)
     let decl = try state.ast.insert(
       wellFormed: FunctionDecl(
-        introducerRange: head.name.introducerRange,
-        attributes: prologue.attributes,
+        introducerRange: head.name.introducerRange, attributes: prologue.attributes,
         accessModifier: prologue.accessModifiers.first,
-        memberModifier: prologue.memberModifiers.first,
-        receiverEffect: signature.receiverEffect,
-        notation: head.name.notation,
-        identifier: head.name.stem,
-        genericClause: head.genericClause,
-        explicitCaptures: head.captures,
-        parameters: signature.parameters,
-        receiver: receiver,
-        output: signature.output,
-        body: body,
-        origin: state.range(from: prologue.startIndex)))
+        memberModifier: prologue.memberModifiers.first, receiverEffect: signature.receiverEffect,
+        notation: head.name.notation, identifier: head.name.stem, genericClause: head.genericClause,
+        explicitCaptures: head.captures, parameters: signature.parameters, receiver: receiver,
+        output: signature.output, body: body, origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Builds a new instance of `Method` from its parsed parts.
   private static func buildMethodDecl(
-    prologue: DeclPrologue,
-    head: FunctionDeclHead,
-    signature: FunctionDeclSignature,
-    impls: [NodeID<MethodImplDecl>],
-    in state: inout ParserState
+    prologue: DeclPrologue, head: FunctionDeclHead, signature: FunctionDeclSignature,
+    impls: [NodeID<MethodImplDecl>], in state: inout ParserState
   ) throws -> NodeID<MethodDecl> {
     // Method declarations cannot be static.
     if let modifier = prologue.memberModifiers.first(where: { (m) in m.value == .static }) {
@@ -630,24 +562,18 @@ public enum Parser {
     assert(prologue.accessModifiers.count <= 1)
     let decl = try state.ast.insert(
       wellFormed: MethodDecl(
-        introducerRange: head.name.introducerRange,
-        attributes: prologue.attributes,
-        accessModifier: prologue.accessModifiers.first,
-        notation: head.name.notation,
-        identifier: head.name.stem,
-        genericClause: head.genericClause,
-        parameters: signature.parameters,
-        output: signature.output,
-        impls: impls,
+        introducerRange: head.name.introducerRange, attributes: prologue.attributes,
+        accessModifier: prologue.accessModifiers.first, notation: head.name.notation,
+        identifier: head.name.stem, genericClause: head.genericClause,
+        parameters: signature.parameters, output: signature.output, impls: impls,
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Parses an instance of `ImportDecl`.
-  static func parseImportDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
-  ) throws -> NodeID<ImportDecl>? {
+  static func parseImportDecl(withPrologue prologue: DeclPrologue, in state: inout ParserState)
+    throws -> NodeID<ImportDecl>?
+  {
     // Parse the parts of the declaration.
     let parser = (take(.import).and(take(.name)))
     guard let parts = try parser.parse(&state) else { return nil }
@@ -660,13 +586,11 @@ public enum Parser {
     // Import declarations shall not have modifiers.
     if !prologue.accessModifiers.isEmpty {
       throw DiagnosedError(
-        prologue.accessModifiers.map(
-          Diagnostic.diagnose(unexpectedAccessModifier:)))
+        prologue.accessModifiers.map(Diagnostic.diagnose(unexpectedAccessModifier:)))
     }
     if !prologue.memberModifiers.isEmpty {
       throw DiagnosedError(
-        prologue.memberModifiers.map(
-          Diagnostic.diagnose(unexpectedMemberModifier:)))
+        prologue.memberModifiers.map(Diagnostic.diagnose(unexpectedMemberModifier:)))
     }
 
     // Create a new `ImportDecl`.
@@ -679,10 +603,9 @@ public enum Parser {
   }
 
   /// Parses an instance of `InitializerDecl`.
-  static func parseInitDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
-  ) throws -> NodeID<InitializerDecl>? {
+  static func parseInitDecl(withPrologue prologue: DeclPrologue, in state: inout ParserState) throws
+    -> NodeID<InitializerDecl>?
+  {
     // Parse the signature of the initializer.
     guard let introducer = state.take(.`init`) else { return nil }
     let genericClause = try genericClause.parse(&state)
@@ -698,9 +621,7 @@ public enum Parser {
 
     // Init declarations require an implicit receiver parameter.
     let receiver = try state.ast.insert(
-      wellFormed: ParameterDecl(
-        identifier: SourceRepresentable(value: "self"),
-        origin: nil))
+      wellFormed: ParameterDecl(identifier: SourceRepresentable(value: "self"), origin: nil))
 
     // Create a new `InitializerDecl`.
     assert(prologue.accessModifiers.count <= 1)
@@ -708,20 +629,15 @@ public enum Parser {
     let decl = try! state.ast.insert(
       wellFormed: InitializerDecl(
         introducer: SourceRepresentable(value: .`init`, range: introducer.origin),
-        attributes: prologue.attributes,
-        accessModifier: prologue.accessModifiers.first,
-        genericClause: genericClause,
-        parameters: parameters,
-        receiver: receiver,
-        body: body,
+        attributes: prologue.attributes, accessModifier: prologue.accessModifiers.first,
+        genericClause: genericClause, parameters: parameters, receiver: receiver, body: body,
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Parses an instance of `InitializerDecl`.
   static func parseMemberwiseInitDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
+    withPrologue prologue: DeclPrologue, in state: inout ParserState
   ) throws -> NodeID<InitializerDecl>? {
     // Parse the parts of the declaration.
     let parser = (take(nameTokenWithValue: "memberwise").and(take(.`init`)))
@@ -734,30 +650,23 @@ public enum Parser {
 
     // Init declarations require an implicit receiver parameter.
     let receiver = try state.ast.insert(
-      wellFormed: ParameterDecl(
-        identifier: SourceRepresentable(value: "self"),
-        origin: nil))
+      wellFormed: ParameterDecl(identifier: SourceRepresentable(value: "self"), origin: nil))
 
     // Create a new `InitializerDecl`.
     assert(prologue.accessModifiers.count <= 1)
     let decl = try state.ast.insert(
       wellFormed: InitializerDecl(
         introducer: SourceRepresentable(value: .memberwiseInit, range: parts.0.origin),
-        attributes: prologue.attributes,
-        accessModifier: prologue.accessModifiers.first,
-        genericClause: nil,
-        parameters: [],
-        receiver: receiver,
-        body: nil,
+        attributes: prologue.attributes, accessModifier: prologue.accessModifiers.first,
+        genericClause: nil, parameters: [], receiver: receiver, body: nil,
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Parses an instance of `NamespaceDecl`.
-  static func parseNamespaceDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
-  ) throws -> NodeID<NamespaceDecl>? {
+  static func parseNamespaceDecl(withPrologue prologue: DeclPrologue, in state: inout ParserState)
+    throws -> NodeID<NamespaceDecl>?
+  {
     // Parse the parts of the declaration.
     let parser =
       (take(.namespace).and(take(.name))
@@ -779,19 +688,16 @@ public enum Parser {
     assert(prologue.accessModifiers.count <= 1)
     let decl = try state.ast.insert(
       wellFormed: NamespaceDecl(
-        introducerRange: parts.0.0.origin,
-        accessModifier: prologue.accessModifiers.first,
-        identifier: SourceRepresentable(token: parts.0.1, in: state.lexer.source),
-        members: parts.1,
+        introducerRange: parts.0.0.origin, accessModifier: prologue.accessModifiers.first,
+        identifier: SourceRepresentable(token: parts.0.1, in: state.lexer.source), members: parts.1,
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Parses an instance of `OperatorDecl`.
-  static func parseOperatorDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
-  ) throws -> NodeID<OperatorDecl>? {
+  static func parseOperatorDecl(withPrologue prologue: DeclPrologue, in state: inout ParserState)
+    throws -> NodeID<OperatorDecl>?
+  {
     // Parse the parts of the declaration.
     let parser =
       (take(.operator).and(operatorNotation)
@@ -814,85 +720,64 @@ public enum Parser {
     assert(prologue.accessModifiers.count <= 1)
     let decl = try state.ast.insert(
       wellFormed: OperatorDecl(
-        introducerRange: parts.0.0.0.origin,
-        accessModifier: prologue.accessModifiers.first,
-        notation: parts.0.0.1,
-        name: parts.0.1,
-        precedenceGroup: parts.1,
+        introducerRange: parts.0.0.0.origin, accessModifier: prologue.accessModifiers.first,
+        notation: parts.0.0.1, name: parts.0.1, precedenceGroup: parts.1,
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Parses an instance of `SubscriptDecl` representing a property declaration.
-  static func parsePropertyDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
-  ) throws -> NodeID<SubscriptDecl>? {
+  static func parsePropertyDecl(withPrologue prologue: DeclPrologue, in state: inout ParserState)
+    throws -> NodeID<SubscriptDecl>?
+  {
     guard let (head, signature) = try propertyDeclHead.and(propertyDeclSignature).parse(&state)
     else { return nil }
 
     let isNonStatic = state.isAtTypeScope && !prologue.isStatic
     let impls = try state.expect(
-      "'{'",
-      using: { (s) in try parseSubscriptDeclBody(in: &s, asNonStaticMember: isNonStatic) })
+      "'{'", using: { (s) in try parseSubscriptDeclBody(in: &s, asNonStaticMember: isNonStatic) })
 
     // Create a new `SubscriptDecl`.
     assert(prologue.accessModifiers.count <= 1)
     assert(prologue.memberModifiers.count <= 1)
     let decl = try state.ast.insert(
       wellFormed: SubscriptDecl(
-        introducer: head.introducer,
-        attributes: prologue.attributes,
+        introducer: head.introducer, attributes: prologue.attributes,
         accessModifier: prologue.accessModifiers.first,
-        memberModifier: prologue.memberModifiers.first,
-        identifier: head.stem,
-        genericClause: nil,
-        explicitCaptures: [],
-        parameters: nil,
-        output: signature,
-        impls: impls,
+        memberModifier: prologue.memberModifiers.first, identifier: head.stem, genericClause: nil,
+        explicitCaptures: [], parameters: nil, output: signature, impls: impls,
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Parses an instance of `SubscriptDecl`.
-  static func parseSubscriptDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
-  ) throws -> NodeID<SubscriptDecl>? {
+  static func parseSubscriptDecl(withPrologue prologue: DeclPrologue, in state: inout ParserState)
+    throws -> NodeID<SubscriptDecl>?
+  {
     // Parse the signature of the subscript.
     guard let head = try subscriptDeclHead.parse(&state) else { return nil }
-    let signature = try state.expect(
-      "subscript signature",
-      using: parseSubscriptDeclSignature(in:))
+    let signature = try state.expect("subscript signature", using: parseSubscriptDeclSignature(in:))
 
     let isNonStatic = state.isAtTypeScope && !prologue.isStatic
     let impls = try state.expect(
-      "'{'",
-      using: { (s) in try parseSubscriptDeclBody(in: &s, asNonStaticMember: isNonStatic) })
+      "'{'", using: { (s) in try parseSubscriptDeclBody(in: &s, asNonStaticMember: isNonStatic) })
 
     // Create a new `SubscriptDecl`.
     assert(prologue.accessModifiers.count <= 1)
     assert(prologue.memberModifiers.count <= 1)
     let decl = try state.ast.insert(
       wellFormed: SubscriptDecl(
-        introducer: head.introducer,
-        attributes: prologue.attributes,
+        introducer: head.introducer, attributes: prologue.attributes,
         accessModifier: prologue.accessModifiers.first,
-        memberModifier: prologue.memberModifiers.first,
-        identifier: head.stem,
-        genericClause: head.genericClause,
-        explicitCaptures: head.captures,
-        parameters: signature.parameters,
-        output: signature.output,
-        impls: impls,
+        memberModifier: prologue.memberModifiers.first, identifier: head.stem,
+        genericClause: head.genericClause, explicitCaptures: head.captures,
+        parameters: signature.parameters, output: signature.output, impls: impls,
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   static func parseSubscriptDeclBody(
-    in state: inout ParserState,
-    asNonStaticMember isNonStaticMember: Bool
+    in state: inout ParserState, asNonStaticMember isNonStaticMember: Bool
   ) throws -> [NodeID<SubscriptImplDecl>]? {
     // Push the context.
     state.contexts.append(.subscriptBody)
@@ -903,9 +788,7 @@ public enum Parser {
     do {
       if let body = try subscriptImplDeclBody.parse(&state) {
         let impl = try buildSubscriptImplDecl(
-          in: &state,
-          withIntroducer: SourceRepresentable(value: .let),
-          body: body,
+          in: &state, withIntroducer: SourceRepresentable(value: .let), body: body,
           asNonStaticMember: isNonStaticMember)
         return [impl]
       }
@@ -928,10 +811,7 @@ public enum Parser {
       // Parse an implementation.
       if let (introducer, body) = try subscriptImplDecl.parse(&state) {
         let impl = try buildSubscriptImplDecl(
-          in: &state,
-          withIntroducer: introducer,
-          body: body,
-          asNonStaticMember: isNonStaticMember)
+          in: &state, withIntroducer: introducer, body: body, asNonStaticMember: isNonStaticMember)
         impls.append(impl)
 
         if !introducers.insert(introducer.value).inserted { duplicateIntroducer = introducer }
@@ -949,18 +829,14 @@ public enum Parser {
   }
 
   private static func buildSubscriptImplDecl(
-    in state: inout ParserState,
-    withIntroducer introducer: SourceRepresentable<ImplIntroducer>,
-    body: SubscriptImplDecl.Body?,
-    asNonStaticMember isNonStaticMember: Bool
+    in state: inout ParserState, withIntroducer introducer: SourceRepresentable<ImplIntroducer>,
+    body: SubscriptImplDecl.Body?, asNonStaticMember isNonStaticMember: Bool
   ) throws -> NodeID<SubscriptImplDecl> {
     // Non-static member subscript declarations require an implicit receiver parameter.
     let receiver: NodeID<ParameterDecl>?
     if isNonStaticMember {
       receiver = try state.ast.insert(
-        wellFormed: ParameterDecl(
-          identifier: SourceRepresentable(value: "self"),
-          origin: nil))
+        wellFormed: ParameterDecl(identifier: SourceRepresentable(value: "self"), origin: nil))
     } else {
       receiver = nil
     }
@@ -980,19 +856,15 @@ public enum Parser {
     // Create a new `SubscriptImplDecl`.
     let decl = try state.ast.insert(
       wellFormed: SubscriptImplDecl(
-        introducer: introducer,
-        receiver: receiver,
-        body: body,
-        origin: origin))
+        introducer: introducer, receiver: receiver, body: body, origin: origin))
 
     return decl
   }
 
   /// Parses an instance of `TraitDecl`.
-  static func parseTraitDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
-  ) throws -> NodeID<TraitDecl>? {
+  static func parseTraitDecl(withPrologue prologue: DeclPrologue, in state: inout ParserState)
+    throws -> NodeID<TraitDecl>?
+  {
     // Parse the parts of the declaration.
     let parser =
       (take(.trait).and(take(.name))
@@ -1011,17 +883,15 @@ public enum Parser {
       wellFormed: TraitDecl(
         accessModifier: prologue.accessModifiers.first,
         identifier: SourceRepresentable(token: parts.0.0.1, in: state.lexer.source),
-        refinements: parts.0.1 ?? [],
-        members: parts.1,
+        refinements: parts.0.1 ?? [], members: parts.1,
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Parses an instance of `ProductTypeDecl`.
-  static func parseProductTypeDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
-  ) throws -> NodeID<ProductTypeDecl>? {
+  static func parseProductTypeDecl(withPrologue prologue: DeclPrologue, in state: inout ParserState)
+    throws -> NodeID<ProductTypeDecl>?
+  {
     // Parse the parts of the declaration.
     let parser =
       (take(.type).and(take(.name))
@@ -1051,19 +921,15 @@ public enum Parser {
       wellFormed: ProductTypeDecl(
         accessModifier: prologue.accessModifiers.first,
         identifier: SourceRepresentable(token: parts.0.0.0.1, in: state.lexer.source),
-        genericClause: parts.0.0.1,
-        conformances: parts.0.1 ?? [],
-        members: members,
-        memberwiseInit: memberwiseInit,
-        origin: state.range(from: prologue.startIndex)))
+        genericClause: parts.0.0.1, conformances: parts.0.1 ?? [], members: members,
+        memberwiseInit: memberwiseInit, origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
   /// Returns the first memberwise initializer declaration in `members` or synthesizes an implicit
   /// one, appends it into `members`, and returns it.
   private static func findOrSynthesizeMemberwiseInitDecl(
-    in members: inout [AnyDeclID],
-    updating state: inout ParserState
+    in members: inout [AnyDeclID], updating state: inout ParserState
   ) -> NodeID<InitializerDecl> {
     for member in members where member.kind == InitializerDecl.self {
       let m = NodeID<InitializerDecl>(rawValue: member.rawValue)
@@ -1071,28 +937,20 @@ public enum Parser {
     }
 
     let receiver = try! state.ast.insert(
-      wellFormed: ParameterDecl(
-        identifier: SourceRepresentable(value: "self"),
-        origin: nil))
+      wellFormed: ParameterDecl(identifier: SourceRepresentable(value: "self"), origin: nil))
     let m = try! state.ast.insert(
       wellFormed: InitializerDecl(
-        introducer: SourceRepresentable(value: .memberwiseInit),
-        attributes: [],
-        accessModifier: nil,
-        genericClause: nil,
-        parameters: [],
-        receiver: receiver,
-        body: nil,
+        introducer: SourceRepresentable(value: .memberwiseInit), attributes: [],
+        accessModifier: nil, genericClause: nil, parameters: [], receiver: receiver, body: nil,
         origin: nil))
     members.append(AnyDeclID(m))
     return m
   }
 
   /// Parses an instance of `TypeAliasDecl`.
-  static func parseTypeAliasDecl(
-    withPrologue prologue: DeclPrologue,
-    in state: inout ParserState
-  ) throws -> NodeID<TypeAliasDecl>? {
+  static func parseTypeAliasDecl(withPrologue prologue: DeclPrologue, in state: inout ParserState)
+    throws -> NodeID<TypeAliasDecl>?
+  {
     // Parse the parts of the declaration.
     let parser =
       (take(.typealias).and(take(.name))
@@ -1118,15 +976,13 @@ public enum Parser {
       wellFormed: TypeAliasDecl(
         accessModifier: prologue.accessModifiers.first,
         identifier: SourceRepresentable(token: parts.0.0.0.1, in: state.lexer.source),
-        genericClause: parts.0.0.1,
-        body: .typeExpr(parts.1),
+        genericClause: parts.0.0.1, body: .typeExpr(parts.1),
         origin: state.range(from: prologue.startIndex)))
     return decl
   }
 
-  private static func parseFunctionDeclHead(
-    in state: inout ParserState
-  ) throws -> FunctionDeclHead? {
+  private static func parseFunctionDeclHead(in state: inout ParserState) throws -> FunctionDeclHead?
+  {
     // Parse the function's introducer and identifier.
     guard let name = try parseFunctionDeclIntroducerAndIdentifier(in: &state) else { return nil }
 
@@ -1136,32 +992,28 @@ public enum Parser {
     return FunctionDeclHead(name: name, genericClause: genericClause, captures: captures)
   }
 
-  static func parseFunctionDeclIntroducerAndIdentifier(
-    in state: inout ParserState
-  ) throws -> FunctionDeclName? {
+  static func parseFunctionDeclIntroducerAndIdentifier(in state: inout ParserState) throws
+    -> FunctionDeclName?
+  {
     if let introducer = state.take(.fun) {
       let stem = try state.expect("identifier", using: { $0.take(.name) })
       return FunctionDeclName(
         introducerRange: introducer.origin,
-        stem: SourceRepresentable(token: stem, in: state.lexer.source),
-        notation: nil)
+        stem: SourceRepresentable(token: stem, in: state.lexer.source), notation: nil)
     }
 
     if let notation = try operatorNotation.parse(&state) {
       _ = try state.expect("'fun'", using: { $0.take(.fun) })
       let stem = try state.expect("operator", using: operator_)
-      return FunctionDeclName(
-        introducerRange: notation.origin!,
-        stem: stem,
-        notation: notation)
+      return FunctionDeclName(introducerRange: notation.origin!, stem: stem, notation: notation)
     }
 
     return nil
   }
 
-  static func parseFunctionDeclSignature(
-    in state: inout ParserState
-  ) throws -> FunctionDeclSignature? {
+  static func parseFunctionDeclSignature(in state: inout ParserState) throws
+    -> FunctionDeclSignature?
+  {
     guard let parameters = try parseParameterList(in: &state) else { return nil }
 
     let effect = try receiverEffect.parse(&state)
@@ -1182,8 +1034,7 @@ public enum Parser {
       .map({ (state, body) -> FunctionOrMethodDeclBody in .method(body) }),
     orCatchingAndApplying:
       functionDeclBody
-      .map({ (state, body) -> FunctionOrMethodDeclBody in .function(body) })
-  )
+      .map({ (state, body) -> FunctionOrMethodDeclBody in .function(body) }))
 
   static let functionDeclBody = inContext(
     .functionBody,
@@ -1192,8 +1043,7 @@ public enum Parser {
         .map({ (state, tree) -> FunctionDecl.Body in .expr(tree.0.1) }),
       orCatchingAndApplying:
         braceStmt
-        .map({ (state, id) -> FunctionDecl.Body in .block(id) })
-    ))
+        .map({ (state, id) -> FunctionDecl.Body in .block(id) })))
 
   static let methodDeclBody =
     (take(.lBrace).and(methodImplDecl+).and(take(.rBrace))
@@ -1216,14 +1066,10 @@ public enum Parser {
     (methodIntroducer.and(maybe(methodImplBody))
       .map({ (state, tree) -> NodeID<MethodImplDecl> in
         let receiver = try state.ast.insert(
-          wellFormed: ParameterDecl(
-            identifier: SourceRepresentable(value: "self"),
-            origin: nil))
+          wellFormed: ParameterDecl(identifier: SourceRepresentable(value: "self"), origin: nil))
         return try state.ast.insert(
           wellFormed: MethodImplDecl(
-            introducer: tree.0,
-            receiver: receiver,
-            body: tree.1,
+            introducer: tree.0, receiver: receiver, body: tree.1,
             origin: tree.0.origin!.extended(upTo: state.currentIndex)))
       }))
 
@@ -1232,13 +1078,10 @@ public enum Parser {
       .map({ (state, tree) -> MethodImplDecl.Body in .expr(tree.0.1) }),
     orCatchingAndApplying:
       braceStmt
-      .map({ (state, id) -> MethodImplDecl.Body in .block(id) })
-  )
+      .map({ (state, id) -> MethodImplDecl.Body in .block(id) }))
 
   static let methodIntroducer = translate([
-    .let: ImplIntroducer.let,
-    .inout: ImplIntroducer.inout,
-    .set: ImplIntroducer.set,
+    .let: ImplIntroducer.let, .inout: ImplIntroducer.inout, .set: ImplIntroducer.set,
     .sink: ImplIntroducer.sink,
   ])
 
@@ -1250,8 +1093,7 @@ public enum Parser {
     }))
 
   static let operatorNotation = translate([
-    .infix: OperatorNotation.infix,
-    .prefix: OperatorNotation.prefix,
+    .infix: OperatorNotation.infix, .prefix: OperatorNotation.prefix,
     .postfix: OperatorNotation.postfix,
   ])
 
@@ -1273,13 +1115,12 @@ public enum Parser {
         SubscriptDeclHead(
           introducer: SourceRepresentable(value: .subscript, range: tree.0.0.0.origin),
           stem: tree.0.0.1.map({ SourceRepresentable(token: $0, in: state.lexer.source) }),
-          genericClause: tree.0.1,
-          captures: tree.1 ?? [])
+          genericClause: tree.0.1, captures: tree.1 ?? [])
       }))
 
-  static func parseSubscriptDeclSignature(
-    in state: inout ParserState
-  ) throws -> SubscriptDeclSignature? {
+  static func parseSubscriptDeclSignature(in state: inout ParserState) throws
+    -> SubscriptDeclSignature?
+  {
     guard let parameters = try parseParameterList(in: &state) else { return nil }
 
     _ = try state.expect("':'", using: { $0.take(.colon) })
@@ -1295,13 +1136,10 @@ public enum Parser {
       .map({ (state, tree) -> SubscriptImplDecl.Body in .expr(tree.0.1) }),
     orCatchingAndApplying:
       braceStmt
-      .map({ (state, id) -> SubscriptImplDecl.Body in .block(id) })
-  )
+      .map({ (state, id) -> SubscriptImplDecl.Body in .block(id) }))
 
   static let subscriptIntroducer = translate([
-    .let: ImplIntroducer.let,
-    .inout: ImplIntroducer.inout,
-    .set: ImplIntroducer.set,
+    .let: ImplIntroducer.let, .inout: ImplIntroducer.inout, .set: ImplIntroducer.set,
     .sink: ImplIntroducer.sink,
   ])
 
@@ -1322,17 +1160,14 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<ParameterDecl> in
         try state.ast.insert(
           wellFormed: ParameterDecl(
-            label: tree.0.0.label,
-            identifier: tree.0.0.name,
-            annotation: tree.0.1?.1,
+            label: tree.0.0.label, identifier: tree.0.0.name, annotation: tree.0.1?.1,
             defaultValue: tree.1?.1,
             origin: state.range(
               from: tree.0.0.label?.origin!.lowerBound ?? tree.0.0.name.origin!.lowerBound)))
       }))
 
   typealias ParameterInterface = (
-    label: SourceRepresentable<Identifier>?,
-    name: SourceRepresentable<Identifier>
+    label: SourceRepresentable<Identifier>?, name: SourceRepresentable<Identifier>
   )
 
   static let parameterInterface =
@@ -1347,8 +1182,7 @@ public enum Parser {
         if labelCandidate.kind == .under {
           // case `_ name`
           return (
-            label: nil,
-            name: SourceRepresentable(token: nameCandidate, in: state.lexer.source)
+            label: nil, name: SourceRepresentable(token: nameCandidate, in: state.lexer.source)
           )
         } else {
           // case `label name`
@@ -1366,8 +1200,7 @@ public enum Parser {
         return (label: name, name: name)
       }
 
-      throw DiagnosedError(
-        .diagnose(expected: "parameter name", at: labelCandidate.origin.first()))
+      throw DiagnosedError(.diagnose(expected: "parameter name", at: labelCandidate.origin.first()))
     }))
 
   static let memberModifier =
@@ -1409,10 +1242,9 @@ public enum Parser {
         try state.ast.insert(
           wellFormed: GenericParameterDecl(
             identifier: SourceRepresentable(token: tree.0.0.1, in: state.lexer.source),
-            conformances: tree.0.1?.1 ?? [],
-            defaultValue: tree.1?.1,
-            origin: state.range(
-              from: tree.0.0.0?.origin.lowerBound ?? tree.0.0.1.origin.lowerBound)))
+            conformances: tree.0.1?.1 ?? [], defaultValue: tree.1?.1,
+            origin: state.range(from: tree.0.0.0?.origin.lowerBound ?? tree.0.0.1.origin.lowerBound)
+          ))
       }))
 
   static let conformanceList =
@@ -1446,9 +1278,7 @@ public enum Parser {
   /// Parses a type expression from the stream, then transforms `lhs` into a `CastExpr`, using
   /// `infixOperator` to determine the cast kind.
   private static func appendInfixTail(
-    to lhs: inout AnyExprID,
-    forCastOperator infixOperator: Token,
-    in state: inout ParserState
+    to lhs: inout AnyExprID, forCastOperator infixOperator: Token, in state: inout ParserState
   ) throws {
     if !state.hasLeadingWhitespace {
       state.diagnostics.append(.diagnose(infixOperatorRequiresWhitespacesAt: infixOperator.origin))
@@ -1470,9 +1300,7 @@ public enum Parser {
 
     let expr = try state.ast.insert(
       wellFormed: CastExpr(
-        left: lhs,
-        right: rhs,
-        kind: castKind,
+        left: lhs, right: rhs, kind: castKind,
         origin: state.ast[lhs].origin!.extended(upTo: state.currentIndex)))
     lhs = AnyExprID(expr)
   }
@@ -1480,10 +1308,9 @@ public enum Parser {
   /// Parses a sequence of pairs of infix operators and prefix expressions from the stream. If the
   /// sequence isn't empty, transforms `lhs` into a `SequenceExpr` and returns `true`. Otherwise,
   /// returns `false.
-  private static func appendInfixTail(
-    to lhs: inout AnyExprID,
-    in state: inout ParserState
-  ) throws -> Bool {
+  private static func appendInfixTail(to lhs: inout AnyExprID, in state: inout ParserState) throws
+    -> Bool
+  {
     var tail: [SequenceExpr.TailElement] = []
 
     while true {
@@ -1502,9 +1329,7 @@ public enum Parser {
         }
 
         // Otherwise, complain about missing whitespaces.
-        state.diagnostics.append(
-          .diagnose(
-            infixOperatorRequiresWhitespacesAt: operatorStem.origin))
+        state.diagnostics.append(.diagnose(infixOperatorRequiresWhitespacesAt: operatorStem.origin))
       }
 
       // If we can't parse an operand, the tail is empty.
@@ -1525,9 +1350,7 @@ public enum Parser {
 
     let expr = try state.ast.insert(
       wellFormed: SequenceExpr(
-        head: lhs,
-        tail: tail,
-        origin: state.ast[lhs].origin!.extended(upTo: state.currentIndex)))
+        head: lhs, tail: tail, origin: state.ast[lhs].origin!.extended(upTo: state.currentIndex)))
     lhs = AnyExprID(expr)
     return true
   }
@@ -1550,15 +1373,12 @@ public enum Parser {
         wellFormed: NameExpr(
           domain: .expr(operand),
           name: SourceRepresentable(
-            value: Name(stem: op.value, notation: .prefix),
-            range: op.origin),
+            value: Name(stem: op.value, notation: .prefix), range: op.origin),
           origin: state.range(from: op.origin!.lowerBound)))
 
       let call = try state.ast.insert(
         wellFormed: FunCallExpr(
-          callee: AnyExprID(callee),
-          arguments: [],
-          origin: state.ast[callee].origin))
+          callee: AnyExprID(callee), arguments: [], origin: state.ast[callee].origin))
       return AnyExprID(call)
     }
 
@@ -1575,8 +1395,7 @@ public enum Parser {
 
       let expr = try state.ast.insert(
         wellFormed: InoutExpr(
-          operatorRange: op.origin,
-          subject: operand,
+          operatorRange: op.origin, subject: operand,
           origin: state.range(from: op.origin.lowerBound)))
       return AnyExprID(expr)
     }
@@ -1600,15 +1419,12 @@ public enum Parser {
         wellFormed: NameExpr(
           domain: .expr(operand),
           name: SourceRepresentable(
-            value: Name(stem: op.value, notation: .postfix),
-            range: op.origin),
+            value: Name(stem: op.value, notation: .postfix), range: op.origin),
           origin: state.range(from: state.ast[operand].origin!.lowerBound)))
 
       let call = try state.ast.insert(
         wellFormed: FunCallExpr(
-          callee: AnyExprID(callee),
-          arguments: [],
-          origin: state.ast[callee].origin))
+          callee: AnyExprID(callee), arguments: [], origin: state.ast[callee].origin))
       return AnyExprID(call)
     } else {
       return operand
@@ -1627,9 +1443,7 @@ public enum Parser {
         if let index = state.takeMemberIndex() {
           let expr = try state.ast.insert(
             wellFormed: TupleMemberExpr(
-              tuple: head,
-              index: index,
-              origin: state.range(from: headOrigin.lowerBound)))
+              tuple: head, index: index, origin: state.range(from: headOrigin.lowerBound)))
           head = AnyExprID(expr)
           continue
         }
@@ -1637,9 +1451,7 @@ public enum Parser {
         if let component = try parseNameExprComponent(in: &state) {
           let expr = try state.ast.insert(
             wellFormed: NameExpr(
-              domain: .expr(head),
-              name: component.name,
-              arguments: component.arguments,
+              domain: .expr(head), name: component.name, arguments: component.arguments,
               origin: state.range(from: headOrigin.lowerBound)))
           head = AnyExprID(expr)
           continue
@@ -1655,9 +1467,7 @@ public enum Parser {
         let lens = try state.expect("expression", using: parsePrimaryExpr(in:))
         let expr = try state.ast.insert(
           wellFormed: ConformanceLensTypeExpr(
-            subject: head,
-            lens: lens,
-            origin: state.range(from: headOrigin.lowerBound)))
+            subject: head, lens: lens, origin: state.range(from: headOrigin.lowerBound)))
         head = AnyExprID(expr)
         continue
       }
@@ -1670,9 +1480,7 @@ public enum Parser {
         let arguments = try parseFunctionCallArgumentList(in: &state)!
         let expr = try state.ast.insert(
           wellFormed: FunCallExpr(
-            callee: head,
-            arguments: arguments,
-            origin: state.range(from: headOrigin.lowerBound)))
+            callee: head, arguments: arguments, origin: state.range(from: headOrigin.lowerBound)))
         head = AnyExprID(expr)
         continue
       }
@@ -1682,9 +1490,7 @@ public enum Parser {
         let arguments = try parseSubscriptCallArgumentList(in: &state)!
         let expr = try state.ast.insert(
           wellFormed: SubscriptCallExpr(
-            callee: head,
-            arguments: arguments,
-            origin: state.range(from: headOrigin.lowerBound)))
+            callee: head, arguments: arguments, origin: state.range(from: headOrigin.lowerBound)))
         head = AnyExprID(expr)
         continue
       }
@@ -1713,8 +1519,7 @@ public enum Parser {
       _ = state.take()
       let expr = try state.ast.insert(
         wellFormed: BooleanLiteralExpr(
-          value: state.lexer.source[head.origin] == "true",
-          origin: head.origin))
+          value: state.lexer.source[head.origin] == "true", origin: head.origin))
       return AnyExprID(expr)
 
     case .int:
@@ -1722,8 +1527,7 @@ public enum Parser {
       _ = state.take()
       let expr = try state.ast.insert(
         wellFormed: IntegerLiteralExpr(
-          value: state.lexer.source[head.origin].filter({ $0 != "_" }),
-          origin: head.origin))
+          value: state.lexer.source[head.origin].filter({ $0 != "_" }), origin: head.origin))
       return AnyExprID(expr)
 
     case .float:
@@ -1731,8 +1535,7 @@ public enum Parser {
       _ = state.take()
       let expr = try state.ast.insert(
         wellFormed: FloatLiteralExpr(
-          value: state.lexer.source[head.origin].filter({ $0 != "_" }),
-          origin: head.origin))
+          value: state.lexer.source[head.origin].filter({ $0 != "_" }), origin: head.origin))
       return AnyExprID(expr)
 
     case .string:
@@ -1740,8 +1543,8 @@ public enum Parser {
       _ = state.take()
       let expr = try state.ast.insert(
         wellFormed: StringLiteralExpr(
-          value: String(state.lexer.source[head.origin].dropFirst().dropLast()),
-          origin: head.origin))
+          value: String(state.lexer.source[head.origin].dropFirst().dropLast()), origin: head.origin
+        ))
       return AnyExprID(expr)
 
     case .nil:
@@ -1803,9 +1606,9 @@ public enum Parser {
     }
   }
 
-  private static func parseExistentialTypeExpr(
-    in state: inout ParserState
-  ) throws -> NodeID<ExistentialTypeExpr>? {
+  private static func parseExistentialTypeExpr(in state: inout ParserState) throws -> NodeID<
+    ExistentialTypeExpr
+  >? {
     // Parse the introducer.
     guard let introducer = state.take(.any) else { return nil }
 
@@ -1815,29 +1618,26 @@ public enum Parser {
 
     return try state.ast.insert(
       wellFormed: ExistentialTypeExpr(
-        traits: traits,
-        whereClause: clause,
+        traits: traits, whereClause: clause,
         origin: introducer.origin.extended(
           toCover: clause?.origin ?? state.ast[traits.last!].origin!)))
   }
 
-  private static func parsePrimaryDeclRefExpr(
-    in state: inout ParserState
-  ) throws -> NodeID<NameExpr>? {
+  private static func parsePrimaryDeclRefExpr(in state: inout ParserState) throws -> NodeID<
+    NameExpr
+  >? {
     // Parse the name component.
     let component = try state.expect("identifier", using: parseNameExprComponent(in:))
 
     return try state.ast.insert(
       wellFormed: NameExpr(
-        domain: .none,
-        name: component.name,
-        arguments: component.arguments,
+        domain: .none, name: component.name, arguments: component.arguments,
         origin: component.origin))
   }
 
-  private static func parseImplicitMemberDeclRefExpr(
-    in state: inout ParserState
-  ) throws -> NodeID<NameExpr>? {
+  private static func parseImplicitMemberDeclRefExpr(in state: inout ParserState) throws -> NodeID<
+    NameExpr
+  >? {
     // Parse the leading dot.
     guard let head = state.take(.dot) else { return nil }
 
@@ -1846,15 +1646,13 @@ public enum Parser {
 
     return try state.ast.insert(
       wellFormed: NameExpr(
-        domain: .implicit,
-        name: component.name,
-        arguments: component.arguments,
+        domain: .implicit, name: component.name, arguments: component.arguments,
         origin: state.range(from: head.origin.lowerBound)))
   }
 
-  private static func parseNameExprComponent(
-    in state: inout ParserState
-  ) throws -> NameExprComponent? {
+  private static func parseNameExprComponent(in state: inout ParserState) throws
+    -> NameExprComponent?
+  {
     // Parse the name of the component.
     guard let name = try parseEntityName(in: &state) else { return nil }
 
@@ -1868,9 +1666,7 @@ public enum Parser {
     }
 
     return NameExprComponent(
-      origin: name.origin!.extended(upTo: state.currentIndex),
-      name: name,
-      arguments: arguments)
+      origin: name.origin!.extended(upTo: state.currentIndex), name: name, arguments: arguments)
   }
 
   private static func parseArgument(in state: inout ParserState) throws -> LabeledArgument? {
@@ -1881,8 +1677,7 @@ public enum Parser {
       if state.take(.colon) != nil {
         if let value = try parseExpr(in: &state) {
           return LabeledArgument(
-            label: SourceRepresentable(token: label, in: state.lexer.source),
-            value: value)
+            label: SourceRepresentable(token: label, in: state.lexer.source), value: value)
         }
       }
     }
@@ -1896,15 +1691,15 @@ public enum Parser {
     return nil
   }
 
-  private static func parseEntityName(
-    in state: inout ParserState
-  ) throws -> SourceRepresentable<Name>? {
+  private static func parseEntityName(in state: inout ParserState) throws -> SourceRepresentable<
+    Name
+  >? {
     try parseFunctionEntityName(in: &state) ?? parseOperatorEntityName(in: &state)
   }
 
-  private static func parseFunctionEntityName(
-    in state: inout ParserState
-  ) throws -> SourceRepresentable<Name>? {
+  private static func parseFunctionEntityName(in state: inout ParserState) throws
+    -> SourceRepresentable<Name>?
+  {
     // Parse the stem identifier.
     guard let identifier = state.take(if: { t in t.isOf(kind: [.name, .under]) }) else {
       return nil
@@ -1962,15 +1757,13 @@ public enum Parser {
 
     return SourceRepresentable(
       value: Name(
-        stem: String(state.lexer.source[identifier.origin]),
-        labels: labels,
-        introducer: introducer?.value),
-      range: state.range(from: identifier.origin.lowerBound))
+        stem: String(state.lexer.source[identifier.origin]), labels: labels,
+        introducer: introducer?.value), range: state.range(from: identifier.origin.lowerBound))
   }
 
-  private static func parseOperatorEntityName(
-    in state: inout ParserState
-  ) throws -> SourceRepresentable<Name>? {
+  private static func parseOperatorEntityName(in state: inout ParserState) throws
+    -> SourceRepresentable<Name>?
+  {
     // Parse the operator notation.
     guard let notation = state.take(if: { t in t.isOf(kind: [.infix, .prefix, .postfix]) }) else {
       return nil
@@ -1998,16 +1791,11 @@ public enum Parser {
 
     let decl = try state.ast.insert(
       wellFormed: FunctionDecl(
-        introducerRange: introducer.origin,
-        receiverEffect: signature.receiverEffect,
-        explicitCaptures: explicitCaptures ?? [],
-        parameters: signature.parameters,
-        output: signature.output,
-        body: body,
-        isInExprContext: true,
+        introducerRange: introducer.origin, receiverEffect: signature.receiverEffect,
+        explicitCaptures: explicitCaptures ?? [], parameters: signature.parameters,
+        output: signature.output, body: body, isInExprContext: true,
         origin: state.range(from: introducer.origin.lowerBound)))
-    return try state.ast.insert(
-      wellFormed: LambdaExpr(decl: decl, origin: state.ast[decl].origin))
+    return try state.ast.insert(wellFormed: LambdaExpr(decl: decl, origin: state.ast[decl].origin))
   }
 
   private static let lambdaBody = inContext(
@@ -2017,8 +1805,7 @@ public enum Parser {
         .map({ (state, tree) -> FunctionDecl.Body in .expr(tree.0.1) }),
       orCatchingAndApplying:
         braceStmt
-        .map({ (state, id) -> FunctionDecl.Body in .block(id) })
-    ))
+        .map({ (state, id) -> FunctionDecl.Body in .block(id) })))
 
   private static func parseConditionalExpr(in state: inout ParserState) throws -> NodeID<CondExpr>?
   {
@@ -2043,9 +1830,7 @@ public enum Parser {
 
     return try state.ast.insert(
       wellFormed: CondExpr(
-        condition: condition,
-        success: body,
-        failure: elseClause,
+        condition: condition, success: body, failure: elseClause,
         origin: state.range(from: introducer.origin.lowerBound)))
   }
 
@@ -2054,8 +1839,7 @@ public enum Parser {
       .map({ (state, tree) -> CondExpr.Body in .expr(tree.0.1) }),
     orCatchingAndApplying:
       braceStmt
-      .map({ (state, id) -> CondExpr.Body in .block(id) })
-  )
+      .map({ (state, id) -> CondExpr.Body in .block(id) }))
 
   private static func parseMatchExpr(in state: inout ParserState) throws -> NodeID<MatchExpr>? {
     // Parse the introducer.
@@ -2064,14 +1848,12 @@ public enum Parser {
     // Parse the parts of the expression.
     let subject = try state.expect("subject", using: parseExpr(in:))
     let cases = try state.expect(
-      "match body",
-      using: take(.lBrace).and(zeroOrMany(matchCase)).and(take(.rBrace)))
+      "match body", using: take(.lBrace).and(zeroOrMany(matchCase)).and(take(.rBrace)))
 
     return try state.ast.insert(
       wellFormed: MatchExpr(
-        subject: subject,
-        cases: cases.0.1,
-        origin: state.range(from: introducer.origin.lowerBound)))
+        subject: subject, cases: cases.0.1, origin: state.range(from: introducer.origin.lowerBound))
+    )
   }
 
   static let matchCase =
@@ -2079,9 +1861,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<MatchCase> in
         try state.ast.insert(
           wellFormed: MatchCase(
-            pattern: tree.0.0,
-            condition: tree.0.1?.1,
-            body: tree.1,
+            pattern: tree.0.0, condition: tree.0.1?.1, body: tree.1,
             origin: state.ast[tree.0.0].origin!.extended(upTo: state.currentIndex)))
       }))
 
@@ -2090,8 +1870,7 @@ public enum Parser {
       .map({ (state, tree) -> MatchCase.Body in .expr(tree.0.1) }),
     orCatchingAndApplying:
       braceStmt
-      .map({ (state, id) -> MatchCase.Body in .block(id) })
-  )
+      .map({ (state, id) -> MatchCase.Body in .block(id) }))
 
   private static func parseSpawnExpr(in state: inout ParserState) throws -> NodeID<SpawnExpr>? {
     // Parse the introducer.
@@ -2113,24 +1892,16 @@ public enum Parser {
 
     let decl = try state.ast.insert(
       wellFormed: FunctionDecl(
-        introducerRange: introducer.origin,
-        receiverEffect: effect,
-        explicitCaptures: explicitCaptures,
-        output: output,
-        body: body,
-        isInExprContext: true,
+        introducerRange: introducer.origin, receiverEffect: effect,
+        explicitCaptures: explicitCaptures, output: output, body: body, isInExprContext: true,
         origin: state.range(from: introducer.origin.lowerBound)))
-    return try state.ast.insert(
-      wellFormed: SpawnExpr(decl: decl, origin: state.ast[decl].origin))
+    return try state.ast.insert(wellFormed: SpawnExpr(decl: decl, origin: state.ast[decl].origin))
   }
 
-  private static func parseLambdaTypeOrTupleExpr(
-    in state: inout ParserState
-  ) throws -> AnyExprID? {
+  private static func parseLambdaTypeOrTupleExpr(in state: inout ParserState) throws -> AnyExprID? {
     // Expect a left parenthesis.
     guard
-      let opener = state.peek(),
-      opener.kind == .lParen
+      let opener = state.peek(), opener.kind == .lParen
     else { return nil }
 
     // Assume we're parsing a lambda type expression until we reach the point where we should
@@ -2154,9 +1925,7 @@ public enum Parser {
       // tuple. Otherwise, backtrack and parse a tuple expression.
       if (effect == nil) && parameters.isEmpty {
         let expr = try state.ast.insert(
-          wellFormed: TupleExpr(
-            elements: [],
-            origin: state.range(from: opener.origin.lowerBound)))
+          wellFormed: TupleExpr(elements: [], origin: state.range(from: opener.origin.lowerBound)))
         return AnyExprID(expr)
       }
 
@@ -2168,17 +1937,14 @@ public enum Parser {
 
     let expr = try state.ast.insert(
       wellFormed: LambdaTypeExpr(
-        receiverEffect: effect,
-        environment: nil,
-        parameters: parameters,
-        output: output,
+        receiverEffect: effect, environment: nil, parameters: parameters, output: output,
         origin: state.range(from: opener.origin.lowerBound)))
     return AnyExprID(expr)
   }
 
-  private static func parseLambdaTypeOrCompoundLiteralExpr(
-    in state: inout ParserState
-  ) throws -> AnyExprID? {
+  private static func parseLambdaTypeOrCompoundLiteralExpr(in state: inout ParserState) throws
+    -> AnyExprID?
+  {
     // Assume we're parsing a lambda type expression until we reach the point where we should
     // consume an effect or a right arrow. Commit to that choice if we successfully parsed a
     // non-empty parameter list at that point.
@@ -2228,29 +1994,24 @@ public enum Parser {
     // Synthesize the environment as an empty tuple if we parsed `[]`.
     let e =
       try environement
-      ?? AnyExprID(
-        state.ast.insert(wellFormed: TupleTypeExpr(elements: [], origin: nil)))
+      ?? AnyExprID(state.ast.insert(wellFormed: TupleTypeExpr(elements: [], origin: nil)))
 
     let expr = try state.ast.insert(
       wellFormed: LambdaTypeExpr(
-        receiverEffect: effect,
-        environment: e,
-        parameters: parameters,
-        output: output,
+        receiverEffect: effect, environment: e, parameters: parameters, output: output,
         origin: state.range(from: opener.origin.lowerBound)))
     return AnyExprID(expr)
   }
 
-  private static func parseTupleOrParenthesizedExpr(
-    in state: inout ParserState
-  ) throws -> AnyExprID? {
+  private static func parseTupleOrParenthesizedExpr(in state: inout ParserState) throws
+    -> AnyExprID?
+  {
     // Parse the elements.
     guard let elementList = try tupleExprElementList.parse(&state) else { return nil }
 
     // If there's only one element without any label and we didn't parse a trailing separator,
     // interpret the element's value as a parenthesized expression.
-    if elementList.trailingSeparator == nil,
-      elementList.elements.count == 1,
+    if elementList.trailingSeparator == nil, elementList.elements.count == 1,
       elementList.elements[0].label == nil
     {
       return elementList.elements[0].value
@@ -2263,9 +2024,9 @@ public enum Parser {
     return AnyExprID(expr)
   }
 
-  private static func parseTupleExprElement(
-    in state: inout ParserState
-  ) throws -> TupleExpr.Element? {
+  private static func parseTupleExprElement(in state: inout ParserState) throws -> TupleExpr
+    .Element?
+  {
     let backup = state.backup()
 
     // Parse a labeled element.
@@ -2273,8 +2034,7 @@ public enum Parser {
       if state.take(.colon) != nil {
         if let value = try expr.parse(&state) {
           return TupleExpr.Element(
-            label: SourceRepresentable(token: label, in: state.lexer.source),
-            value: value)
+            label: SourceRepresentable(token: label, in: state.lexer.source), value: value)
         }
       }
     }
@@ -2288,9 +2048,9 @@ public enum Parser {
     return nil
   }
 
-  private static func parseTupleTypeExpr(
-    in state: inout ParserState
-  ) throws -> NodeID<TupleTypeExpr>? {
+  private static func parseTupleTypeExpr(in state: inout ParserState) throws -> NodeID<
+    TupleTypeExpr
+  >? {
     // Parse the elements.
     guard let elementList = try tupleTypeExprElementList.parse(&state) else { return nil }
 
@@ -2300,9 +2060,9 @@ public enum Parser {
         origin: state.range(from: elementList.opener.origin.lowerBound)))
   }
 
-  private static func parseTupleTypeExprElement(
-    in state: inout ParserState
-  ) throws -> TupleTypeExpr.Element? {
+  private static func parseTupleTypeExprElement(in state: inout ParserState) throws -> TupleTypeExpr
+    .Element?
+  {
     let backup = state.backup()
 
     // Parse a labeled element.
@@ -2310,8 +2070,7 @@ public enum Parser {
       if state.take(.colon) != nil {
         if let type = try expr.parse(&state) {
           return TupleTypeExpr.Element(
-            label: SourceRepresentable(token: label, in: state.lexer.source),
-            type: type)
+            label: SourceRepresentable(token: label, in: state.lexer.source), type: type)
         }
       }
     }
@@ -2343,8 +2102,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<BufferLiteralExpr> in
         try state.ast.insert(
           wellFormed: BufferLiteralExpr(
-            elements: tree.0.1 ?? [],
-            origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
+            elements: tree.0.1 ?? [], origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
       }))
 
   private static let bufferComponentListContents =
@@ -2356,8 +2114,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<MapLiteralExpr> in
         try state.ast.insert(
           wellFormed: MapLiteralExpr(
-            elements: tree.0.1,
-            origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
+            elements: tree.0.1, origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
       }))
 
   private static let mapComponentEmptyContents =
@@ -2385,93 +2142,77 @@ public enum Parser {
       .map({ (state, tree) -> ConditionItem in
         let id = try state.ast.insert(
           wellFormed: BindingDecl(
-            pattern: tree.0.0,
-            initializer: tree.1,
+            pattern: tree.0.0, initializer: tree.1,
             origin: state.ast[tree.0.0].origin!.extended(upTo: state.currentIndex)))
         return .decl(id)
       }),
     or:
       expr
-      .map({ (_, id) -> ConditionItem in .expr(id) })
-  )
+      .map({ (_, id) -> ConditionItem in .expr(id) }))
 
   // MARK: Comma-separated lists
 
   private static let staticArgumentList = DelimitedCommaSeparatedList(
-    openerKind: .lAngle,
-    closerKind: .rAngle,
-    closerDescription: ">",
+    openerKind: .lAngle, closerKind: .rAngle, closerDescription: ">",
     elementParser: Apply(parseArgument(in:)))
 
-  private static func parseStaticArgumentList(
-    in state: inout ParserState
-  ) throws -> [LabeledArgument]? {
+  private static func parseStaticArgumentList(in state: inout ParserState) throws
+    -> [LabeledArgument]?
+  {
     try parseList(in: &state, with: staticArgumentList)
   }
 
   private static let functionCallArgumentList = DelimitedCommaSeparatedList(
-    openerKind: .lParen,
-    closerKind: .rParen,
-    closerDescription: ")",
+    openerKind: .lParen, closerKind: .rParen, closerDescription: ")",
     elementParser: Apply(parseArgument(in:)))
 
-  private static func parseFunctionCallArgumentList(
-    in state: inout ParserState
-  ) throws -> [LabeledArgument]? {
+  private static func parseFunctionCallArgumentList(in state: inout ParserState) throws
+    -> [LabeledArgument]?
+  {
     try parseList(in: &state, with: functionCallArgumentList)
   }
 
   private static let subscriptCallArgumentList = DelimitedCommaSeparatedList(
-    openerKind: .lBrack,
-    closerKind: .rBrack,
-    closerDescription: "]",
+    openerKind: .lBrack, closerKind: .rBrack, closerDescription: "]",
     elementParser: Apply(parseArgument(in:)))
 
-  private static func parseSubscriptCallArgumentList(
-    in state: inout ParserState
-  ) throws -> [LabeledArgument]? {
+  private static func parseSubscriptCallArgumentList(in state: inout ParserState) throws
+    -> [LabeledArgument]?
+  {
     try parseList(in: &state, with: subscriptCallArgumentList)
   }
 
   private static let attributeArgumentList = DelimitedCommaSeparatedList(
-    openerKind: .lParen,
-    closerKind: .rParen,
-    closerDescription: ")",
+    openerKind: .lParen, closerKind: .rParen, closerDescription: ")",
     elementParser: Apply(parseAttributeArgument(in:)))
 
-  private static func parseAttributeArgumentList(
-    in state: inout ParserState
-  ) throws -> [Attribute.Argument]? {
+  private static func parseAttributeArgumentList(in state: inout ParserState) throws -> [Attribute
+    .Argument]?
+  {
     try parseList(in: &state, with: attributeArgumentList)
   }
 
   private static let parameterList = DelimitedCommaSeparatedList(
-    openerKind: .lParen,
-    closerKind: .rParen,
-    closerDescription: ")",
-    elementParser: parameterDecl)
+    openerKind: .lParen, closerKind: .rParen, closerDescription: ")", elementParser: parameterDecl)
 
-  private static func parseParameterList(
-    in state: inout ParserState
-  ) throws -> [NodeID<ParameterDecl>]? {
+  private static func parseParameterList(in state: inout ParserState) throws -> [NodeID<
+    ParameterDecl
+  >]? {
     try parseList(in: &state, with: parameterList)
   }
 
   private static let lambdaParameterList = DelimitedCommaSeparatedList(
-    openerKind: .lParen,
-    closerKind: .rParen,
-    closerDescription: ")",
+    openerKind: .lParen, closerKind: .rParen, closerDescription: ")",
     elementParser: Apply(parseLambdaParameter(in:)))
 
-  private static func parseLambdaParameterList(
-    in state: inout ParserState
-  ) throws -> [LambdaTypeExpr.Parameter]? {
+  private static func parseLambdaParameterList(in state: inout ParserState) throws
+    -> [LambdaTypeExpr.Parameter]?
+  {
     try parseList(in: &state, with: lambdaParameterList)
   }
 
   private static func parseList<C: Combinator>(
-    in state: inout ParserState,
-    with parser: DelimitedCommaSeparatedList<C>
+    in state: inout ParserState, with parser: DelimitedCommaSeparatedList<C>
   ) throws -> [C.Element]? where C.Context == ParserState {
     guard let result = try parser.parse(&state) else { return nil }
 
@@ -2483,22 +2224,18 @@ public enum Parser {
   }
 
   private static let tupleExprElementList = DelimitedCommaSeparatedList(
-    openerKind: .lParen,
-    closerKind: .rParen,
-    closerDescription: ")",
+    openerKind: .lParen, closerKind: .rParen, closerDescription: ")",
     elementParser: Apply(parseTupleExprElement(in:)))
 
   private static let tupleTypeExprElementList = DelimitedCommaSeparatedList(
-    openerKind: .lBrace,
-    closerKind: .rBrace,
-    closerDescription: "}",
+    openerKind: .lBrace, closerKind: .rBrace, closerDescription: "}",
     elementParser: Apply(parseTupleTypeExprElement(in:)))
 
   // MARK: Patterns
 
-  private static func anyPattern<Base: Combinator>(
-    _ base: Base
-  ) -> AnyCombinator<ParserState, AnyPatternID>
+  private static func anyPattern<Base: Combinator>(_ base: Base) -> AnyCombinator<
+    ParserState, AnyPatternID
+  >
   where Base.Context == ParserState, Base.Element: PatternID {
     AnyCombinator(parse: { (state) in
       try base.parse(&state).map(AnyPatternID.init(_:))
@@ -2509,9 +2246,7 @@ public enum Parser {
 
   private static let _pattern =
     (oneOf([
-      anyPattern(bindingPattern),
-      anyPattern(exprPattern),
-      anyPattern(tuplePattern),
+      anyPattern(bindingPattern), anyPattern(exprPattern), anyPattern(tuplePattern),
       anyPattern(wildcardPattern),
     ]))
 
@@ -2521,18 +2256,14 @@ public enum Parser {
         inContext(
           .bindingPattern,
           apply: oneOf([
-            anyPattern(namePattern),
-            anyPattern(tuplePattern),
-            anyPattern(wildcardPattern),
+            anyPattern(namePattern), anyPattern(tuplePattern), anyPattern(wildcardPattern),
           ]))
       )
       .and(maybe(take(.colon).and(expr)))
       .map({ (state, tree) -> NodeID<BindingPattern> in
         try state.ast.insert(
           wellFormed: BindingPattern(
-            introducer: tree.0.0,
-            subpattern: tree.0.1,
-            annotation: tree.1?.1,
+            introducer: tree.0.0, subpattern: tree.0.1, annotation: tree.1?.1,
             origin: tree.0.0.origin!.extended(upTo: state.currentIndex)))
       }))
 
@@ -2564,8 +2295,7 @@ public enum Parser {
       }
 
       return SourceRepresentable(
-        value: introducer,
-        range: head.origin.extended(upTo: state.currentIndex))
+        value: introducer, range: head.origin.extended(upTo: state.currentIndex))
     }))
 
   static let exprPattern =
@@ -2585,9 +2315,7 @@ public enum Parser {
       // Default to an expression.
       guard let exprID = try expr.parse(&state) else { return nil }
       let id = try state.ast.insert(
-        wellFormed: ExprPattern(
-          expr: exprID,
-          origin: state.ast[exprID].origin))
+        wellFormed: ExprPattern(expr: exprID, origin: state.ast[exprID].origin))
       return AnyPatternID(id)
     }))
 
@@ -2595,8 +2323,8 @@ public enum Parser {
     (take(.name)
       .map({ (state, token) -> NodeID<NamePattern> in
         let declID = try state.ast.insert(
-          wellFormed: VarDecl(
-            identifier: SourceRepresentable(token: token, in: state.lexer.source)))
+          wellFormed: VarDecl(identifier: SourceRepresentable(token: token, in: state.lexer.source))
+        )
         return try state.ast.insert(wellFormed: NamePattern(decl: declID, origin: token.origin))
       }))
 
@@ -2622,8 +2350,7 @@ public enum Parser {
         if state.take(.colon) != nil {
           if let value = try pattern.parse(&state) {
             return TuplePattern.Element(
-              label: SourceRepresentable(token: label, in: state.lexer.source),
-              pattern: value)
+              label: SourceRepresentable(token: label, in: state.lexer.source), pattern: value)
           }
         }
       }
@@ -2645,9 +2372,9 @@ public enum Parser {
 
   // MARK: Statements
 
-  private static func anyStmt<Base: Combinator>(
-    _ base: Base
-  ) -> AnyCombinator<ParserState, AnyStmtID>
+  private static func anyStmt<Base: Combinator>(_ base: Base) -> AnyCombinator<
+    ParserState, AnyStmtID
+  >
   where Base.Context == ParserState, Base.Element: StmtID {
     AnyCombinator(parse: { (state) in
       try base.parse(&state).map(AnyStmtID.init(_:))
@@ -2658,18 +2385,9 @@ public enum Parser {
 
   static let _stmt =
     (oneOf([
-      anyStmt(braceStmt),
-      anyStmt(discardStmt),
-      anyStmt(doWhileStmt),
-      anyStmt(whileStmt),
-      anyStmt(forStmt),
-      anyStmt(returnStmt),
-      anyStmt(yieldStmt),
-      anyStmt(breakStmt),
-      anyStmt(continueStmt),
-      anyStmt(bindingStmt),
-      anyStmt(declStmt),
-      anyStmt(exprStmt),
+      anyStmt(braceStmt), anyStmt(discardStmt), anyStmt(doWhileStmt), anyStmt(whileStmt),
+      anyStmt(forStmt), anyStmt(returnStmt), anyStmt(yieldStmt), anyStmt(breakStmt),
+      anyStmt(continueStmt), anyStmt(bindingStmt), anyStmt(declStmt), anyStmt(exprStmt),
     ]))
 
   static let braceStmt =
@@ -2680,8 +2398,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<BraceStmt> in
         try state.ast.insert(
           wellFormed: BraceStmt(
-            stmts: tree.0.1,
-            origin: tree.0.0.0.origin.extended(upTo: state.currentIndex)))
+            stmts: tree.0.1, origin: tree.0.0.0.origin.extended(upTo: state.currentIndex)))
       }))
 
   static let discardStmt =
@@ -2689,8 +2406,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<DiscardStmt> in
         try state.ast.insert(
           wellFormed: DiscardStmt(
-            expr: tree.1,
-            origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
+            expr: tree.1, origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
       }))
 
   static let doWhileStmt =
@@ -2698,8 +2414,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<DoWhileStmt> in
         try state.ast.insert(
           wellFormed: DoWhileStmt(
-            body: tree.0.0.1,
-            condition: tree.1,
+            body: tree.0.0.1, condition: tree.1,
             origin: tree.0.0.0.origin.extended(upTo: state.currentIndex)))
       }))
 
@@ -2708,8 +2423,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<WhileStmt> in
         try state.ast.insert(
           wellFormed: WhileStmt(
-            condition: tree.0.1,
-            body: tree.1,
+            condition: tree.0.1, body: tree.1,
             origin: tree.0.0.origin.extended(upTo: state.currentIndex)))
       }))
 
@@ -2718,15 +2432,10 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<ForStmt> in
         let decl = try state.ast.insert(
           wellFormed: BindingDecl(
-            pattern: tree.0.0.0.1,
-            initializer: nil,
-            origin: state.ast[tree.0.0.0.1].origin))
+            pattern: tree.0.0.0.1, initializer: nil, origin: state.ast[tree.0.0.0.1].origin))
         return try state.ast.insert(
           wellFormed: ForStmt(
-            binding: decl,
-            domain: tree.0.0.1,
-            filter: tree.0.1,
-            body: tree.1,
+            binding: decl, domain: tree.0.0.1, filter: tree.0.1, body: tree.1,
             origin: tree.0.0.0.0.origin.extended(upTo: state.currentIndex)))
       }))
 
@@ -2741,8 +2450,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<ReturnStmt> in
         try state.ast.insert(
           wellFormed: ReturnStmt(
-            value: tree.1,
-            origin: tree.0.origin.extended(upTo: state.currentIndex)))
+            value: tree.1, origin: tree.0.origin.extended(upTo: state.currentIndex)))
       }))
 
   static let yieldStmt =
@@ -2750,8 +2458,7 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<YieldStmt> in
         try state.ast.insert(
           wellFormed: YieldStmt(
-            value: tree.1,
-            origin: tree.0.origin.extended(upTo: state.currentIndex)))
+            value: tree.1, origin: tree.0.origin.extended(upTo: state.currentIndex)))
       }))
 
   static let breakStmt =
@@ -2776,9 +2483,7 @@ public enum Parser {
 
       if let decl = try bindingDecl.parse(&state) {
         let id = try state.ast.insert(
-          wellFormed: DeclStmt(
-            decl: AnyDeclID(decl),
-            origin: state.ast[decl].origin))
+          wellFormed: DeclStmt(decl: AnyDeclID(decl), origin: state.ast[decl].origin))
         return AnyStmtID(id)
       } else {
         return nil
@@ -2799,8 +2504,7 @@ public enum Parser {
 
         return try state.ast.insert(
           wellFormed: CondBindingStmt(
-            binding: tree.0.0,
-            fallback: tree.1,
+            binding: tree.0.0, fallback: tree.1,
             origin: bindingRange.extended(upTo: state.currentIndex)))
       }))
 
@@ -2811,13 +2515,8 @@ public enum Parser {
     (expr.map({ (_, id) -> CondBindingStmt.Fallback in .expr(id) }))
 
   static let conditionalBindingFallbackStmt =
-    (oneOf([
-      anyStmt(breakStmt),
-      anyStmt(continueStmt),
-      anyStmt(returnStmt),
-      anyStmt(braceStmt),
-    ])
-    .map({ (_, id) -> CondBindingStmt.Fallback in .exit(id) }))
+    (oneOf([anyStmt(breakStmt), anyStmt(continueStmt), anyStmt(returnStmt), anyStmt(braceStmt)])
+      .map({ (_, id) -> CondBindingStmt.Fallback in .exit(id) }))
 
   static let declStmt =
     (Apply(parseDecl)
@@ -2845,9 +2544,7 @@ public enum Parser {
 
     let stmt = try state.ast.insert(
       wellFormed: AssignStmt(
-        left: lhs,
-        right: rhs,
-        origin: state.range(from: state.ast[lhs].origin!.lowerBound)))
+        left: lhs, right: rhs, origin: state.range(from: state.ast[lhs].origin!.lowerBound)))
     return AnyStmtID(stmt)
   }
 
@@ -2855,9 +2552,9 @@ public enum Parser {
 
   private static let nameTypeExpr = Apply(parseNameExpr(in:))
 
-  private static func parseLambdaParameter(
-    in state: inout ParserState
-  ) throws -> LambdaTypeExpr.Parameter? {
+  private static func parseLambdaParameter(in state: inout ParserState) throws -> LambdaTypeExpr
+    .Parameter?
+  {
     let backup = state.backup()
 
     // Parse a labeled parameter.
@@ -2865,8 +2562,7 @@ public enum Parser {
       if state.take(.colon) != nil {
         if let type = try parameterTypeExpr.parse(&state) {
           return LambdaTypeExpr.Parameter(
-            label: SourceRepresentable(token: label, in: state.lexer.source),
-            type: type)
+            label: SourceRepresentable(token: label, in: state.lexer.source), type: type)
         }
       }
     }
@@ -2880,10 +2576,7 @@ public enum Parser {
     return nil
   }
 
-  static let receiverEffect = translate([
-    .inout: ReceiverEffect.inout,
-    .sink: ReceiverEffect.sink,
-  ])
+  static let receiverEffect = translate([.inout: ReceiverEffect.inout, .sink: ReceiverEffect.sink])
 
   static let parameterTypeExpr =
     (maybe(passingConvention)
@@ -2891,18 +2584,14 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<ParameterTypeExpr> in
         try state.ast.insert(
           wellFormed: ParameterTypeExpr(
-            convention: tree.0 ?? SourceRepresentable(value: .let),
-            bareType: tree.1,
+            convention: tree.0 ?? SourceRepresentable(value: .let), bareType: tree.1,
             origin: state.range(
               from: tree.0?.origin!.lowerBound ?? state.ast[tree.1].origin!.lowerBound)))
       }))
 
   static let passingConvention = translate([
-    .let: PassingConvention.let,
-    .inout: PassingConvention.inout,
-    .set: PassingConvention.set,
-    .sink: PassingConvention.sink,
-    .yielded: PassingConvention.yielded,
+    .let: PassingConvention.let, .inout: PassingConvention.inout, .set: PassingConvention.set,
+    .sink: PassingConvention.sink, .yielded: PassingConvention.yielded,
   ])
 
   static let whereClause =
@@ -2948,8 +2637,7 @@ public enum Parser {
     (valueAttribute.and(expr)
       .map({ (state, tree) -> SourceRepresentable<WhereClause.ConstraintExpr> in
         SourceRepresentable(
-          value: .value(tree.1),
-          range: tree.0.origin.extended(upTo: state.currentIndex))
+          value: .value(tree.1), range: tree.0.origin.extended(upTo: state.currentIndex))
       }))
 
   static let traitComposition =
@@ -2958,22 +2646,21 @@ public enum Parser {
 
   // MARK: Attributes
 
-  static func parseDeclAttribute(
-    in state: inout ParserState
-  ) throws -> SourceRepresentable<Attribute>? {
+  static func parseDeclAttribute(in state: inout ParserState) throws -> SourceRepresentable<
+    Attribute
+  >? {
     guard let introducer = state.take(.attribute) else { return nil }
     let arguments = try parseAttributeArgumentList(in: &state) ?? []
 
     return SourceRepresentable(
       value: Attribute(
-        name: SourceRepresentable(token: introducer, in: state.lexer.source),
-        arguments: arguments),
+        name: SourceRepresentable(token: introducer, in: state.lexer.source), arguments: arguments),
       range: state.range(from: introducer.origin.lowerBound))
   }
 
-  private static func parseAttributeArgument(
-    in state: inout ParserState
-  ) throws -> Attribute.Argument? {
+  private static func parseAttributeArgument(in state: inout ParserState) throws -> Attribute
+    .Argument?
+  {
     if let token = state.take(.int) {
       if let value = Int(state.lexer.source[token.origin]) {
         return .integer(SourceRepresentable(value: value, range: token.origin))
@@ -3257,8 +2944,7 @@ struct DelimitedCommaSeparatedList<E: Combinator>: Combinator where E.Context ==
       // unless we reached EOF. Otherwise, diagnose a missing expression and exit.
       if trailingSeparator == nil {
         if let head = state.peek() {
-          state.diagnostics.append(
-            .diagnose(expected: "',' separator", at: head.origin.first()))
+          state.diagnostics.append(.diagnose(expected: "',' separator", at: head.origin.first()))
           continue
         } else {
           state.diagnostics.append(
@@ -3266,17 +2952,13 @@ struct DelimitedCommaSeparatedList<E: Combinator>: Combinator where E.Context ==
           break
         }
       } else {
-        state.diagnostics.append(
-          .diagnose(expected: "expression", at: state.currentLocation))
+        state.diagnostics.append(.diagnose(expected: "expression", at: state.currentLocation))
         break
       }
     }
 
     return Element(
-      opener: opener,
-      closer: closer,
-      trailingSeparator: trailingSeparator,
-      elements: elements)
+      opener: opener, closer: closer, trailingSeparator: trailingSeparator, elements: elements)
   }
 
 }
@@ -3297,9 +2979,7 @@ private func attribute(_ name: String) -> Apply<ParserState, Token> {
 }
 
 /// Creates a combinator that translates token kinds to instances of type.
-private func translate<T>(
-  _ table: [Token.Kind: T]
-) -> Apply<ParserState, SourceRepresentable<T>> {
+private func translate<T>(_ table: [Token.Kind: T]) -> Apply<ParserState, SourceRepresentable<T>> {
   Apply({ (state) in
     guard let head = state.peek() else { return nil }
     if let translation = table[head.kind] {
@@ -3313,25 +2993,22 @@ private func translate<T>(
 
 /// Creates a combinator that pushes `context` to the parser state before applying, and pops
 /// that context afterward.
-private func inContext<Base: Combinator>(
-  _ context: ParserState.Context,
-  apply base: Base
-) -> WrapInContext<Base> {
+private func inContext<Base: Combinator>(_ context: ParserState.Context, apply base: Base)
+  -> WrapInContext<Base>
+{
   WrapInContext(context: context, base: base)
 }
 
 /// Creates a combinator that applies `base` only if its input is not preceeded by whitespaces.
-private func withoutLeadingWhitespace<Base: Combinator>(
-  _ base: Base
-) -> Apply<ParserState, Base.Element>
+private func withoutLeadingWhitespace<Base: Combinator>(_ base: Base) -> Apply<
+  ParserState, Base.Element
+>
 where Base.Context == ParserState {
   Apply({ (state) in try state.hasLeadingWhitespace ? nil : base.parse(&state) })
 }
 
 /// Creates a combinator that applies `base` only if its input is not preceeded by newlines.
-private func onSameLine<Base: Combinator>(
-  _ base: Base
-) -> Apply<ParserState, Base.Element>
+private func onSameLine<Base: Combinator>(_ base: Base) -> Apply<ParserState, Base.Element>
 where Base.Context == ParserState {
   Apply({ (state) in
     if let t = state.peek() {

--- a/Sources/Compiler/Parse/ParserState.swift
+++ b/Sources/Compiler/Parse/ParserState.swift
@@ -95,8 +95,7 @@ struct ParserState {
 
   /// Returns whether there are whitespaces before *and* after `token`.
   mutating func hasLeadingAndTrailingWhitespaces(_ token: Token) -> Bool {
-    guard
-      let a = lexer.source.contents.prefix(upTo: token.origin.lowerBound).last,
+    guard let a = lexer.source.contents.prefix(upTo: token.origin.lowerBound).last,
       let b = lexer.source.contents.suffix(from: token.origin.upperBound).first
     else { return false }
     return a.isWhitespace && b.isWhitespace
@@ -104,8 +103,7 @@ struct ParserState {
 
   /// Returns whether there is a new line in the character stream before `bound`.
   mutating func hasNewline(before bound: Token) -> Bool {
-    lexer.source.contents[currentIndex..<bound.origin.lowerBound]
-      .contains(where: { $0.isNewline })
+    lexer.source.contents[currentIndex..<bound.origin.lowerBound].contains(where: { $0.isNewline })
   }
 
   /// Returns a source range from `startIndex` to `self.currentIndex`.
@@ -125,9 +123,7 @@ struct ParserState {
   /// Returns the next token without consuming it, if any.
   mutating func peek() -> Token? {
     // Return the token in the lookahead buffer, if available.
-    if let token = lookahead.first {
-      return token
-    }
+    if let token = lookahead.first { return token }
 
     // Attempt to pull a new element from the lexer.
     guard let token = lexer.next() else { return nil }
@@ -136,17 +132,11 @@ struct ParserState {
   }
 
   /// Returns whether a token of the given `kind` is next in the input.
-  mutating func isNext(_ kind: Token.Kind) -> Bool {
-    peek()?.kind == kind
-  }
+  mutating func isNext(_ kind: Token.Kind) -> Bool { peek()?.kind == kind }
 
   /// Returns whether a token satisfying `predicate` is next in the input.
   mutating func isNext(satisfying predicate: (Token) -> Bool) -> Bool {
-    if let token = peek() {
-      return predicate(token)
-    } else {
-      return false
-    }
+    if let token = peek() { return predicate(token) } else { return false }
   }
 
   /// Consumes and returns the next token, if any.
@@ -194,9 +184,7 @@ struct ParserState {
 
   /// Consumes and returns a name token with the specified value.
   mutating func take(nameTokenWithValue value: String) -> Token? {
-    take(if: { [source = lexer.source] in
-      ($0.kind == .name) && (source[$0.origin] == value)
-    })
+    take(if: { [source = lexer.source] in ($0.kind == .name) && (source[$0.origin] == value) })
   }
 
   /// Consumes and returns an operator (excluding `=`) from the token stream.
@@ -225,8 +213,7 @@ struct ParserState {
       range.upperBound = upper
       return SourceRepresentable(value: String(lexer.source[range]), range: range)
 
-    default:
-      return nil
+    default: return nil
     }
   }
 
@@ -241,9 +228,7 @@ struct ParserState {
 
   /// Consumes and returns an attribute token with the specified name.
   mutating func take(attribute name: String) -> Token? {
-    take(if: { [source = lexer.source] in
-      ($0.kind == .attribute) && (source[$0.origin] == name)
-    })
+    take(if: { [source = lexer.source] in ($0.kind == .attribute) && (source[$0.origin] == name) })
   }
 
   /// Applies `parse`, propagating thrown errors, and returns non-`nil` results or throws an error
@@ -262,14 +247,10 @@ struct ParserState {
   /// an error diagnosing that we expected `expectedConstruct`.
   mutating func expect<C: Combinator>(_ expectedConstruct: String, using parser: C) throws
     -> C.Element where C.Context == Self
-  {
-    try expect(expectedConstruct, using: parser.parse(_:))
-  }
+  { try expect(expectedConstruct, using: parser.parse(_:)) }
 
   /// Consumes tokens as long as they satisfy `predicate`.
-  mutating func skip(while predicate: (Token) -> Bool) {
-    while take(if: predicate) != nil {}
-  }
+  mutating func skip(while predicate: (Token) -> Bool) { while take(if: predicate) != nil {} }
 
 }
 

--- a/Sources/Compiler/Parse/ParserState.swift
+++ b/Sources/Compiler/Parse/ParserState.swift
@@ -249,8 +249,7 @@ struct ParserState {
   /// Applies `parse`, propagating thrown errors, and returns non-`nil` results or throws an error
   /// diagnosing that we expected `expectedConstruct`.
   mutating func expect<T>(
-    _ expectedConstruct: String,
-    using parse: (inout ParserState) throws -> T?
+    _ expectedConstruct: String, using parse: (inout ParserState) throws -> T?
   ) throws -> T {
     if let element = try parse(&self) {
       return element
@@ -261,10 +260,9 @@ struct ParserState {
 
   /// Applies `parser.parse`, propagating thrown errors, and returns non-`nil` results or throws
   /// an error diagnosing that we expected `expectedConstruct`.
-  mutating func expect<C: Combinator>(
-    _ expectedConstruct: String,
-    using parser: C
-  ) throws -> C.Element where C.Context == Self {
+  mutating func expect<C: Combinator>(_ expectedConstruct: String, using parser: C) throws
+    -> C.Element where C.Context == Self
+  {
     try expect(expectedConstruct, using: parser.parse(_:))
   }
 

--- a/Sources/Compiler/Parse/SourceFile.swift
+++ b/Sources/Compiler/Parse/SourceFile.swift
@@ -36,11 +36,7 @@ public struct SourceFile {
     var lower = location.index
     while lower > contents.startIndex {
       let predecessor = contents.index(before: lower)
-      if contents[predecessor].isNewline {
-        break
-      } else {
-        lower = predecessor
-      }
+      if contents[predecessor].isNewline { break } else { lower = predecessor }
     }
 
     var upper = location.index
@@ -61,9 +57,7 @@ public struct SourceFile {
     }
 
     var lineIndex = 1
-    for c in contents.prefix(upTo: location.index) where c.isNewline {
-      lineIndex += 1
-    }
+    for c in contents.prefix(upTo: location.index) where c.isNewline { lineIndex += 1 }
 
     let buffer = contents.prefix(upTo: location.index)
     var columnIndex = 1
@@ -79,21 +73,15 @@ public struct SourceFile {
 
 extension SourceFile: Hashable {
 
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(url)
-  }
+  public func hash(into hasher: inout Hasher) { hasher.combine(url) }
 
-  public static func == (lhs: SourceFile, rhs: SourceFile) -> Bool {
-    return lhs.url == rhs.url
-  }
+  public static func == (lhs: SourceFile, rhs: SourceFile) -> Bool { return lhs.url == rhs.url }
 
 }
 
 extension SourceFile: ExpressibleByStringLiteral {
 
-  public init(stringLiteral value: String) {
-    self.init(contents: value)
-  }
+  public init(stringLiteral value: String) { self.init(contents: value) }
 
 }
 

--- a/Sources/Compiler/Parse/SourceLocation.swift
+++ b/Sources/Compiler/Parse/SourceLocation.swift
@@ -44,8 +44,7 @@ extension SourceLocation: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     source = try container.decode(SourceFile.self, forKey: .source)
     index = String.Index(
-      utf16Offset: try container.decode(Int.self, forKey: .index),
-      in: source.contents)
+      utf16Offset: try container.decode(Int.self, forKey: .index), in: source.contents)
   }
 
   public func encode(to encoder: Encoder) throws {
@@ -60,13 +59,7 @@ extension SourceLocation: CustomReflectable {
 
   public var customMirror: Mirror {
     let (line, column) = source.lineAndColumnIndices(at: self)
-    return Mirror(
-      self,
-      children: [
-        "sourceURL": source.url,
-        "line": line,
-        "column": column,
-      ])
+    return Mirror(self, children: ["sourceURL": source.url, "line": line, "column": column])
   }
 
 }

--- a/Sources/Compiler/Parse/SourceRange.swift
+++ b/Sources/Compiler/Parse/SourceRange.swift
@@ -5,14 +5,10 @@ public struct SourceRange: Hashable {
   public let source: SourceFile
 
   /// The start index of the range.
-  public var lowerBound: String.Index {
-    didSet { precondition(lowerBound <= upperBound) }
-  }
+  public var lowerBound: String.Index { didSet { precondition(lowerBound <= upperBound) } }
 
   /// The end index of the range.
-  public var upperBound: String.Index {
-    didSet { precondition(lowerBound <= upperBound) }
-  }
+  public var upperBound: String.Index { didSet { precondition(lowerBound <= upperBound) } }
 
   /// Creates a range in `source` from `lowerBound` to `upperBound`.
   ///
@@ -25,15 +21,12 @@ public struct SourceRange: Hashable {
   }
 
   /// Returns the first source location in this range.
-  public func first() -> SourceLocation {
-    SourceLocation(source: source, index: lowerBound)
-  }
+  public func first() -> SourceLocation { SourceLocation(source: source, index: lowerBound) }
 
   /// Returns the last source location in this range, unless the range is empty.
   public func last() -> SourceLocation? {
     lowerBound < upperBound
-      ? SourceLocation(source: source, index: source.contents.index(before: upperBound))
-      : nil
+      ? SourceLocation(source: source, index: source.contents.index(before: upperBound)) : nil
   }
 
   /// Returns a copy of `self` with the upper bound set to `newUpperBound`.

--- a/Sources/Compiler/Parse/SourceRange.swift
+++ b/Sources/Compiler/Parse/SourceRange.swift
@@ -45,8 +45,7 @@ public struct SourceRange: Hashable {
   public func extended(toCover other: SourceRange) -> SourceRange {
     precondition(source == other.source, "incompatible ranges")
     return SourceRange(
-      in: source,
-      from: Swift.min(lowerBound, other.lowerBound),
+      in: source, from: Swift.min(lowerBound, other.lowerBound),
       to: Swift.max(upperBound, other.upperBound))
   }
 
@@ -69,11 +68,9 @@ extension SourceRange: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     source = try container.decode(SourceFile.self, forKey: .source)
     lowerBound = String.Index(
-      utf16Offset: try container.decode(Int.self, forKey: .lowerBound),
-      in: source.contents)
+      utf16Offset: try container.decode(Int.self, forKey: .lowerBound), in: source.contents)
     upperBound = String.Index(
-      utf16Offset: try container.decode(Int.self, forKey: .upperBound),
-      in: source.contents)
+      utf16Offset: try container.decode(Int.self, forKey: .upperBound), in: source.contents)
   }
 
   public func encode(to encoder: Encoder) throws {

--- a/Sources/Compiler/Parse/Token.swift
+++ b/Sources/Compiler/Parse/Token.swift
@@ -101,14 +101,10 @@ public struct Token {
   public internal(set) var origin: SourceRange
 
   /// Indicates whether `self` is a keyword.
-  public var isKeyword: Bool {
-    (Kind.any.rawValue..<Kind.any.rawValue + 999) ~= kind.rawValue
-  }
+  public var isKeyword: Bool { (Kind.any.rawValue..<Kind.any.rawValue + 999) ~= kind.rawValue }
 
   /// Indicates whether `self` is a suitable as a label.
-  public var isLabel: Bool {
-    (kind == .name) || isKeyword
-  }
+  public var isLabel: Bool { (kind == .name) || isKeyword }
 
   /// Indicates whether `self` may be in an operator
   ///
@@ -123,22 +119,16 @@ public struct Token {
   ///
   /// - Note: `&` may not be at the start of a prefix operator. An expression prefixed by `&` is
   ///   parsed as an in-place expression.
-  public var isPrefixOperatorHead: Bool {
-    isOf(kind: [.oper, .equal, .pipe, .rAngle])
-  }
+  public var isPrefixOperatorHead: Bool { isOf(kind: [.oper, .equal, .pipe, .rAngle]) }
 
   /// Indicates whether `self` is a suitable postfix operator head.
-  public var isPostfixOperatorHead: Bool {
-    isOf(kind: [.oper, .ampersand, .equal, .pipe])
-  }
+  public var isPostfixOperatorHead: Bool { isOf(kind: [.oper, .ampersand, .equal, .pipe]) }
 
   /// Indicates whether `self` is a declaration modifier.
   public var isDeclModifier: Bool {
     switch kind {
-    case .public, .static:
-      return true
-    default:
-      return false
+    case .public, .static: return true
+    default: return false
     }
   }
 
@@ -150,18 +140,15 @@ public struct Token {
       .`trait`, .`type`, .`typealias`, .`var`:
       return true
 
-    default:
-      return isDeclModifier
+    default: return isDeclModifier
     }
   }
 
   /// Indicates whether `self` may be at the begining of a control statement.
   public var mayBeginCtrlStmt: Bool {
     switch kind {
-    case .break, .continue, .for, .if, .lBrace, .return, .while:
-      return true
-    default:
-      return false
+    case .break, .continue, .for, .if, .lBrace, .return, .while: return true
+    default: return false
     }
   }
 

--- a/Sources/Compiler/Parse/Token.swift
+++ b/Sources/Compiler/Parse/Token.swift
@@ -145,25 +145,9 @@ public struct Token {
   /// Indicates whether `self` may be at the begining of a declaration.
   public var mayBeginDecl: Bool {
     switch kind {
-    case .`conformance`,
-      .`extension`,
-      .`fun`,
-      .`import`,
-      .`infix`,
-      .`init`,
-      .`inout`,
-      .`let`,
-      .`namespace`,
-      .`operator`,
-      .`postfix`,
-      .`prefix`,
-      .`property`,
-      .`sink`,
-      .`subscript`,
-      .`trait`,
-      .`type`,
-      .`typealias`,
-      .`var`:
+    case .`conformance`, .`extension`, .`fun`, .`import`, .`infix`, .`init`, .`inout`, .`let`,
+      .`namespace`, .`operator`, .`postfix`, .`prefix`, .`property`, .`sink`, .`subscript`,
+      .`trait`, .`type`, .`typealias`, .`var`:
       return true
 
     default:

--- a/Sources/Compiler/Program.swift
+++ b/Sources/Compiler/Program.swift
@@ -28,10 +28,7 @@ extension Program {
   /// - `isContained(parent[child], ancestor)`.
   ///
   /// - Requires: `child` is the identifier of a scope in this hierarchy.
-  public func isContained<T: NodeIDProtocol, U: ScopeID>(
-    _ child: T,
-    in ancestor: U
-  ) -> Bool {
+  public func isContained<T: NodeIDProtocol, U: ScopeID>(_ child: T, in ancestor: U) -> Bool {
     var current = AnyNodeID(child)
     while true {
       if ancestor.rawValue == current.rawValue {
@@ -53,13 +50,8 @@ extension Program {
   /// - it is introduced with `init` or `memberwise init`.
   public func isGlobal<T: DeclID>(_ decl: T) -> Bool {
     switch decl.kind {
-    case AssociatedTypeDecl.self,
-      ImportDecl.self,
-      ModuleDecl.self,
-      NamespaceDecl.self,
-      ProductTypeDecl.self,
-      TraitDecl.self,
-      TypeAliasDecl.self:
+    case AssociatedTypeDecl.self, ImportDecl.self, ModuleDecl.self, NamespaceDecl.self,
+      ProductTypeDecl.self, TraitDecl.self, TypeAliasDecl.self:
       // Type declarations are global.
       return true
 
@@ -104,10 +96,7 @@ extension Program {
   public func isMember<T: DeclID>(_ decl: T) -> Bool {
     guard let parent = declToScope[decl] else { return false }
     switch parent.kind {
-    case ConformanceDecl.self,
-      ExtensionDecl.self,
-      ProductTypeDecl.self,
-      TraitDecl.self,
+    case ConformanceDecl.self, ExtensionDecl.self, ProductTypeDecl.self, TraitDecl.self,
       TypeAliasDecl.self:
       return true
 

--- a/Sources/Compiler/Program.swift
+++ b/Sources/Compiler/Program.swift
@@ -59,36 +59,29 @@ extension Program {
       // Generic parameters are global.
       return true
 
-    default:
-      break
+    default: break
     }
 
     // Declarations at global scope are global.
     switch declToScope[decl]!.kind {
-    case TopLevelDeclSet.self, NamespaceDecl.self:
-      return true
+    case TopLevelDeclSet.self, NamespaceDecl.self: return true
 
-    default:
-      break
+    default: break
     }
 
     // Static member declarations and initializers are global.
     switch decl.kind {
-    case BindingDecl.self:
-      return ast[NodeID<BindingDecl>(rawValue: decl.rawValue)].isStatic
+    case BindingDecl.self: return ast[NodeID<BindingDecl>(rawValue: decl.rawValue)].isStatic
 
     case FunctionDecl.self:
       let i = NodeID<FunctionDecl>(rawValue: decl.rawValue)
       return ast[i].isStatic
 
-    case InitializerDecl.self:
-      return true
+    case InitializerDecl.self: return true
 
-    case SubscriptDecl.self:
-      return ast[NodeID<SubscriptDecl>(rawValue: decl.rawValue)].isStatic
+    case SubscriptDecl.self: return ast[NodeID<SubscriptDecl>(rawValue: decl.rawValue)].isStatic
 
-    default:
-      return false
+    default: return false
     }
   }
 
@@ -100,15 +93,12 @@ extension Program {
       TypeAliasDecl.self:
       return true
 
-    default:
-      return false
+    default: return false
     }
   }
 
   /// Returns whether `decl` is a non-static member of a type declaration.
-  public func isNonStaticMember<T: DeclID>(_ decl: T) -> Bool {
-    !isGlobal(decl) && isMember(decl)
-  }
+  public func isNonStaticMember<T: DeclID>(_ decl: T) -> Bool { !isGlobal(decl) && isMember(decl) }
 
   /// Returns whether `decl` is a non-static member of a type declaration.
   public func isNonStaticMember(_ decl: NodeID<FunctionDecl>) -> Bool {
@@ -121,9 +111,7 @@ extension Program {
   }
 
   /// Returns whether `decl` is local in `ast`.
-  public func isLocal<T: DeclID>(_ decl: T) -> Bool {
-    !isGlobal(decl) && !isMember(decl)
-  }
+  public func isLocal<T: DeclID>(_ decl: T) -> Bool { !isGlobal(decl) && !isMember(decl) }
 
   /// Returns whether `decl` is a requirement.
   public func isRequirement<T: DeclID>(_ decl: T) -> Bool {
@@ -134,8 +122,7 @@ extension Program {
       return isRequirement(NodeID<MethodDecl>(rawValue: declToScope[decl]!.rawValue))
     case SubscriptImplDecl.self:
       return isRequirement(NodeID<SubscriptDecl>(rawValue: declToScope[decl]!.rawValue))
-    default:
-      return false
+    default: return false
     }
   }
 
@@ -147,9 +134,7 @@ extension Program {
   /// Returns the module containing `scope`.
   public func module<S: ScopeID>(containing scope: S) -> NodeID<ModuleDecl>? {
     var last = AnyScopeID(scope)
-    while let parent = scopeToParent[last] {
-      last = parent
-    }
+    while let parent = scopeToParent[last] { last = parent }
     return NodeID(last)
   }
 

--- a/Sources/Compiler/ScopedProgram.swift
+++ b/Sources/Compiler/ScopedProgram.swift
@@ -68,8 +68,7 @@ extension ScopedProgram {
   /// Sets `scope` as the parent of the current innermost lexical scope and calls `action` with a
   /// a mutable projection of `self` and `state` where `scope` is the innermost lexical scope.
   private mutating func nesting<T: ScopeID>(
-    in scope: T,
-    withState state: inout VisitorState,
+    in scope: T, withState state: inout VisitorState,
     _ action: (inout ScopedProgram, inout VisitorState) -> Void
   ) {
     let currentInnermost = state.innermost
@@ -136,8 +135,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    associatedTypeDecl decl: NodeID<AssociatedTypeDecl>,
-    withState state: inout VisitorState
+    associatedTypeDecl decl: NodeID<AssociatedTypeDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -153,8 +151,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    associatedValueDecl decl: NodeID<AssociatedValueDecl>,
-    withState state: inout VisitorState
+    associatedValueDecl decl: NodeID<AssociatedValueDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -167,8 +164,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    bindingDecl decl: NodeID<BindingDecl>,
-    withState state: inout VisitorState
+    bindingDecl decl: NodeID<BindingDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -184,8 +180,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    conformanceDecl decl: NodeID<ConformanceDecl>,
-    withState state: inout VisitorState
+    conformanceDecl decl: NodeID<ConformanceDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -203,8 +198,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    extensionDecl decl: NodeID<ExtensionDecl>,
-    withState state: inout VisitorState
+    extensionDecl decl: NodeID<ExtensionDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -222,8 +216,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    functionDecl decl: NodeID<FunctionDecl>,
-    withState state: inout VisitorState
+    functionDecl decl: NodeID<FunctionDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -260,8 +253,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    genericParameterDecl decl: NodeID<GenericParameterDecl>,
-    withState state: inout VisitorState
+    genericParameterDecl decl: NodeID<GenericParameterDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -274,15 +266,13 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    importDecl decl: NodeID<ImportDecl>,
-    withState state: inout VisitorState
+    importDecl decl: NodeID<ImportDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
   }
 
   private mutating func visit(
-    initializerDecl decl: NodeID<InitializerDecl>,
-    withState state: inout VisitorState
+    initializerDecl decl: NodeID<InitializerDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -303,8 +293,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    methodDecl decl: NodeID<MethodDecl>,
-    withState state: inout VisitorState
+    methodDecl decl: NodeID<MethodDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -327,8 +316,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    methodImplDecl decl: NodeID<MethodImplDecl>,
-    withState state: inout VisitorState
+    methodImplDecl decl: NodeID<MethodImplDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -351,8 +339,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    moduleDecl decl: NodeID<ModuleDecl>,
-    withState state: inout VisitorState
+    moduleDecl decl: NodeID<ModuleDecl>, withState state: inout VisitorState
   ) {
     precondition(state.innermost == decl)
     for source in ast[decl].sources {
@@ -361,8 +348,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    namespaceDecl decl: NodeID<NamespaceDecl>,
-    withState state: inout VisitorState
+    namespaceDecl decl: NodeID<NamespaceDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -376,15 +362,13 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    operatorDecl decl: NodeID<OperatorDecl>,
-    withState state: inout VisitorState
+    operatorDecl decl: NodeID<OperatorDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
   }
 
   private mutating func visit(
-    parameterDecl decl: NodeID<ParameterDecl>,
-    withState state: inout VisitorState
+    parameterDecl decl: NodeID<ParameterDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -397,8 +381,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    productTypeDecl decl: NodeID<ProductTypeDecl>,
-    withState state: inout VisitorState
+    productTypeDecl decl: NodeID<ProductTypeDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -418,8 +401,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    subscriptDecl decl: NodeID<SubscriptDecl>,
-    withState state: inout VisitorState
+    subscriptDecl decl: NodeID<SubscriptDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -443,8 +425,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    subscriptImplDecl decl: NodeID<SubscriptImplDecl>,
-    withState state: inout VisitorState
+    subscriptImplDecl decl: NodeID<SubscriptImplDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -469,8 +450,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    traitDecl decl: NodeID<TraitDecl>,
-    withState state: inout VisitorState
+    traitDecl decl: NodeID<TraitDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -487,8 +467,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    typeAliasDecl decl: NodeID<TypeAliasDecl>,
-    withState state: inout VisitorState
+    typeAliasDecl decl: NodeID<TypeAliasDecl>, withState state: inout VisitorState
   ) {
     insert(decl: decl, into: state.innermost)
 
@@ -510,17 +489,13 @@ extension ScopedProgram {
       })
   }
 
-  private mutating func visit(
-    varDecl decl: NodeID<VarDecl>,
-    withState state: inout VisitorState
-  ) {
+  private mutating func visit(varDecl decl: NodeID<VarDecl>, withState state: inout VisitorState) {
     insert(decl: decl, into: state.innermost)
     varToBinding[decl] = state.bindingDeclBeingVisited
   }
 
   private mutating func visit(
-    topLevelDeclSet: NodeID<TopLevelDeclSet>,
-    withState state: inout VisitorState
+    topLevelDeclSet: NodeID<TopLevelDeclSet>, withState state: inout VisitorState
   ) {
     nesting(
       in: topLevelDeclSet, withState: &state,
@@ -599,26 +574,21 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    bufferLiteralExpr expr: NodeID<BufferLiteralExpr>,
-    withState state: inout VisitorState
+    bufferLiteralExpr expr: NodeID<BufferLiteralExpr>, withState state: inout VisitorState
   ) {
     for element in ast[expr].elements {
       visit(expr: element, withState: &state)
     }
   }
 
-  private mutating func visit(
-    castExpr expr: NodeID<CastExpr>,
-    withState state: inout VisitorState
-  ) {
+  private mutating func visit(castExpr expr: NodeID<CastExpr>, withState state: inout VisitorState)
+  {
     visit(expr: ast[expr].left, withState: &state)
     visit(expr: ast[expr].right, withState: &state)
   }
 
-  private mutating func visit(
-    condExpr expr: NodeID<CondExpr>,
-    withState state: inout VisitorState
-  ) {
+  private mutating func visit(condExpr expr: NodeID<CondExpr>, withState state: inout VisitorState)
+  {
     nesting(
       in: expr, withState: &state,
       { (this, state) in
@@ -658,8 +628,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    existentialTypeExpr expr: NodeID<ExistentialTypeExpr>,
-    withState state: inout VisitorState
+    existentialTypeExpr expr: NodeID<ExistentialTypeExpr>, withState state: inout VisitorState
   ) {
     for trait in ast[expr].traits {
       visit(nameExpr: trait, withState: &state)
@@ -670,8 +639,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    funCallExpr expr: NodeID<FunCallExpr>,
-    withState state: inout VisitorState
+    funCallExpr expr: NodeID<FunCallExpr>, withState state: inout VisitorState
   ) {
     visit(expr: ast[expr].callee, withState: &state)
     for argument in ast[expr].arguments {
@@ -680,22 +648,19 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    inoutExpr expr: NodeID<InoutExpr>,
-    withState state: inout VisitorState
+    inoutExpr expr: NodeID<InoutExpr>, withState state: inout VisitorState
   ) {
     visit(expr: ast[expr].subject, withState: &state)
   }
 
   private mutating func visit(
-    lambdaExpr expr: NodeID<LambdaExpr>,
-    withState state: inout VisitorState
+    lambdaExpr expr: NodeID<LambdaExpr>, withState state: inout VisitorState
   ) {
     visit(functionDecl: ast[expr].decl, withState: &state)
   }
 
   private mutating func visit(
-    lambdaTypeExpr expr: NodeID<LambdaTypeExpr>,
-    withState state: inout VisitorState
+    lambdaTypeExpr expr: NodeID<LambdaTypeExpr>, withState state: inout VisitorState
   ) {
     if let environment = ast[expr].environment {
       visit(expr: environment, withState: &state)
@@ -707,8 +672,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    mapLiteralExpr expr: NodeID<MapLiteralExpr>,
-    withState state: inout VisitorState
+    mapLiteralExpr expr: NodeID<MapLiteralExpr>, withState state: inout VisitorState
   ) {
     for element in ast[expr].elements {
       visit(expr: element.key, withState: &state)
@@ -717,8 +681,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    matchExpr expr: NodeID<MatchExpr>,
-    withState state: inout VisitorState
+    matchExpr expr: NodeID<MatchExpr>, withState state: inout VisitorState
   ) {
     visit(expr: ast[expr].subject, withState: &state)
     for case_ in ast[expr].cases {
@@ -740,10 +703,8 @@ extension ScopedProgram {
     }
   }
 
-  private mutating func visit(
-    nameExpr expr: NodeID<NameExpr>,
-    withState state: inout VisitorState
-  ) {
+  private mutating func visit(nameExpr expr: NodeID<NameExpr>, withState state: inout VisitorState)
+  {
     if case let .expr(domain) = ast[expr].domain {
       visit(expr: domain, withState: &state)
     }
@@ -753,22 +714,19 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    parameterTypeExpr expr: NodeID<ParameterTypeExpr>,
-    withState state: inout VisitorState
+    parameterTypeExpr expr: NodeID<ParameterTypeExpr>, withState state: inout VisitorState
   ) {
     visit(expr: ast[expr].bareType, withState: &state)
   }
 
   private mutating func visit(
-    storedProjectionTypeExpr expr: NodeID<RemoteTypeExpr>,
-    withState state: inout VisitorState
+    storedProjectionTypeExpr expr: NodeID<RemoteTypeExpr>, withState state: inout VisitorState
   ) {
     visit(expr: ast[expr].operand, withState: &state)
   }
 
   private mutating func visit(
-    sequenceExpr expr: NodeID<SequenceExpr>,
-    withState state: inout VisitorState
+    sequenceExpr expr: NodeID<SequenceExpr>, withState state: inout VisitorState
   ) {
     visit(expr: ast[expr].head, withState: &state)
     for element in ast[expr].tail {
@@ -778,15 +736,13 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    spawnExpr expr: NodeID<SpawnExpr>,
-    withState state: inout VisitorState
+    spawnExpr expr: NodeID<SpawnExpr>, withState state: inout VisitorState
   ) {
     visit(functionDecl: ast[expr].decl, withState: &state)
   }
 
   private mutating func visit(
-    subscriptCallExpr expr: NodeID<SubscriptCallExpr>,
-    withState state: inout VisitorState
+    subscriptCallExpr expr: NodeID<SubscriptCallExpr>, withState state: inout VisitorState
   ) {
     visit(expr: ast[expr].callee, withState: &state)
     for argument in ast[expr].arguments {
@@ -795,8 +751,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    tupleExpr expr: NodeID<TupleExpr>,
-    withState state: inout VisitorState
+    tupleExpr expr: NodeID<TupleExpr>, withState state: inout VisitorState
   ) {
     for element in ast[expr].elements {
       visit(expr: element.value, withState: &state)
@@ -804,15 +759,13 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    tupleMemberExpr expr: NodeID<TupleMemberExpr>,
-    withState state: inout VisitorState
+    tupleMemberExpr expr: NodeID<TupleMemberExpr>, withState state: inout VisitorState
   ) {
     visit(expr: ast[expr].tuple, withState: &state)
   }
 
   private mutating func visit(
-    tupleTypeExpr expr: NodeID<TupleTypeExpr>,
-    withState state: inout VisitorState
+    tupleTypeExpr expr: NodeID<TupleTypeExpr>, withState state: inout VisitorState
   ) {
     for element in ast[expr].elements {
       visit(expr: element.type, withState: &state)
@@ -820,8 +773,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    unionTypeExpr expr: NodeID<UnionTypeExpr>,
-    withState state: inout VisitorState
+    unionTypeExpr expr: NodeID<UnionTypeExpr>, withState state: inout VisitorState
   ) {
     for element in ast[expr].elements {
       visit(expr: element, withState: &state)
@@ -848,8 +800,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    bindingPattern pattern: NodeID<BindingPattern>,
-    withState state: inout VisitorState
+    bindingPattern pattern: NodeID<BindingPattern>, withState state: inout VisitorState
   ) {
     visit(pattern: ast[pattern].subpattern, withState: &state)
     if let annotation = ast[pattern].annotation {
@@ -858,22 +809,19 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    exprPattern pattern: NodeID<ExprPattern>,
-    withState state: inout VisitorState
+    exprPattern pattern: NodeID<ExprPattern>, withState state: inout VisitorState
   ) {
     visit(expr: ast[pattern].expr, withState: &state)
   }
 
   private mutating func visit(
-    namePattern pattern: NodeID<NamePattern>,
-    withState state: inout VisitorState
+    namePattern pattern: NodeID<NamePattern>, withState state: inout VisitorState
   ) {
     visit(varDecl: ast[pattern].decl, withState: &state)
   }
 
   private mutating func visit(
-    tuplePattern pattern: NodeID<TuplePattern>,
-    withState state: inout VisitorState
+    tuplePattern pattern: NodeID<TuplePattern>, withState state: inout VisitorState
   ) {
     for element in ast[pattern].elements {
       visit(pattern: element.pattern, withState: &state)
@@ -916,16 +864,14 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    assignStmt stmt: NodeID<AssignStmt>,
-    withState state: inout VisitorState
+    assignStmt stmt: NodeID<AssignStmt>, withState state: inout VisitorState
   ) {
     visit(expr: ast[stmt].left, withState: &state)
     visit(expr: ast[stmt].right, withState: &state)
   }
 
   private mutating func visit(
-    braceStmt stmt: NodeID<BraceStmt>,
-    withState state: inout VisitorState
+    braceStmt stmt: NodeID<BraceStmt>, withState state: inout VisitorState
   ) {
     nesting(
       in: stmt, withState: &state,
@@ -937,8 +883,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    condBindingStmt stmt: NodeID<CondBindingStmt>,
-    withState state: inout VisitorState
+    condBindingStmt stmt: NodeID<CondBindingStmt>, withState state: inout VisitorState
   ) {
     visit(bindingDecl: ast[stmt].binding, withState: &state)
     switch ast[stmt].fallback {
@@ -949,23 +894,19 @@ extension ScopedProgram {
     }
   }
 
-  private mutating func visit(
-    declStmt stmt: NodeID<DeclStmt>,
-    withState state: inout VisitorState
-  ) {
+  private mutating func visit(declStmt stmt: NodeID<DeclStmt>, withState state: inout VisitorState)
+  {
     visit(decl: ast[stmt].decl, withState: &state)
   }
 
   private mutating func visit(
-    discardStmt stmt: NodeID<DiscardStmt>,
-    withState state: inout VisitorState
+    discardStmt stmt: NodeID<DiscardStmt>, withState state: inout VisitorState
   ) {
     visit(expr: ast[stmt].expr, withState: &state)
   }
 
   private mutating func visit(
-    doWhileStmt stmt: NodeID<DoWhileStmt>,
-    withState state: inout VisitorState
+    doWhileStmt stmt: NodeID<DoWhileStmt>, withState state: inout VisitorState
   ) {
     visit(braceStmt: ast[stmt].body, withState: &state)
 
@@ -976,17 +917,12 @@ extension ScopedProgram {
     state.innermost = currentInnermost
   }
 
-  private mutating func visit(
-    exprStmt stmt: NodeID<ExprStmt>,
-    withState state: inout VisitorState
-  ) {
+  private mutating func visit(exprStmt stmt: NodeID<ExprStmt>, withState state: inout VisitorState)
+  {
     visit(expr: ast[stmt].expr, withState: &state)
   }
 
-  private mutating func visit(
-    forStmt stmt: NodeID<ForStmt>,
-    withState state: inout VisitorState
-  ) {
+  private mutating func visit(forStmt stmt: NodeID<ForStmt>, withState state: inout VisitorState) {
     nesting(
       in: stmt, withState: &state,
       { (this, state) in
@@ -999,8 +935,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    returnStmt stmt: NodeID<ReturnStmt>,
-    withState state: inout VisitorState
+    returnStmt stmt: NodeID<ReturnStmt>, withState state: inout VisitorState
   ) {
     if let value = ast[stmt].value {
       visit(expr: value, withState: &state)
@@ -1008,8 +943,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    whileStmt stmt: NodeID<WhileStmt>,
-    withState state: inout VisitorState
+    whileStmt stmt: NodeID<WhileStmt>, withState state: inout VisitorState
   ) {
     nesting(
       in: stmt, withState: &state,
@@ -1028,8 +962,7 @@ extension ScopedProgram {
   }
 
   private mutating func visit(
-    yieldStmt stmt: NodeID<YieldStmt>,
-    withState state: inout VisitorState
+    yieldStmt stmt: NodeID<YieldStmt>, withState state: inout VisitorState
   ) {
     visit(expr: ast[stmt].value, withState: &state)
   }
@@ -1037,8 +970,7 @@ extension ScopedProgram {
   // MARK: Others
 
   private mutating func visit(
-    genericClause clause: GenericClause,
-    withState state: inout VisitorState
+    genericClause clause: GenericClause, withState state: inout VisitorState
   ) {
     for parameter in clause.parameters {
       visit(genericParameterDecl: parameter, withState: &state)
@@ -1048,10 +980,8 @@ extension ScopedProgram {
     }
   }
 
-  private mutating func visit(
-    whereClause clause: WhereClause,
-    withState state: inout VisitorState
-  ) {
+  private mutating func visit(whereClause clause: WhereClause, withState state: inout VisitorState)
+  {
     for constraint in clause.constraints {
       switch constraint.value {
       case .conformance(let lhs, let traits):

--- a/Sources/Compiler/ScopedProgram.swift
+++ b/Sources/Compiler/ScopedProgram.swift
@@ -89,32 +89,25 @@ extension ScopedProgram {
       visit(associatedTypeDecl: NodeID(rawValue: decl.rawValue), withState: &state)
     case AssociatedValueDecl.self:
       visit(associatedValueDecl: NodeID(rawValue: decl.rawValue), withState: &state)
-    case BindingDecl.self:
-      visit(bindingDecl: NodeID(rawValue: decl.rawValue), withState: &state)
-    case BuiltinDecl.self:
-      break
+    case BindingDecl.self: visit(bindingDecl: NodeID(rawValue: decl.rawValue), withState: &state)
+    case BuiltinDecl.self: break
     case ConformanceDecl.self:
       visit(conformanceDecl: NodeID(rawValue: decl.rawValue), withState: &state)
     case ExtensionDecl.self:
       visit(extensionDecl: NodeID(rawValue: decl.rawValue), withState: &state)
-    case FunctionDecl.self:
-      visit(functionDecl: NodeID(rawValue: decl.rawValue), withState: &state)
+    case FunctionDecl.self: visit(functionDecl: NodeID(rawValue: decl.rawValue), withState: &state)
     case GenericParameterDecl.self:
       visit(genericParameterDecl: NodeID(rawValue: decl.rawValue), withState: &state)
-    case ImportDecl.self:
-      visit(importDecl: NodeID(rawValue: decl.rawValue), withState: &state)
+    case ImportDecl.self: visit(importDecl: NodeID(rawValue: decl.rawValue), withState: &state)
     case InitializerDecl.self:
       visit(initializerDecl: NodeID(rawValue: decl.rawValue), withState: &state)
-    case MethodDecl.self:
-      visit(methodDecl: NodeID(rawValue: decl.rawValue), withState: &state)
+    case MethodDecl.self: visit(methodDecl: NodeID(rawValue: decl.rawValue), withState: &state)
     case MethodImplDecl.self:
       visit(methodImplDecl: NodeID(rawValue: decl.rawValue), withState: &state)
-    case ModuleDecl.self:
-      visit(moduleDecl: NodeID(rawValue: decl.rawValue), withState: &state)
+    case ModuleDecl.self: visit(moduleDecl: NodeID(rawValue: decl.rawValue), withState: &state)
     case NamespaceDecl.self:
       visit(namespaceDecl: NodeID(rawValue: decl.rawValue), withState: &state)
-    case OperatorDecl.self:
-      visit(operatorDecl: NodeID(rawValue: decl.rawValue), withState: &state)
+    case OperatorDecl.self: visit(operatorDecl: NodeID(rawValue: decl.rawValue), withState: &state)
     case ParameterDecl.self:
       visit(parameterDecl: NodeID(rawValue: decl.rawValue), withState: &state)
     case ProductTypeDecl.self:
@@ -123,14 +116,11 @@ extension ScopedProgram {
       visit(subscriptDecl: NodeID(rawValue: decl.rawValue), withState: &state)
     case SubscriptImplDecl.self:
       visit(subscriptImplDecl: NodeID(rawValue: decl.rawValue), withState: &state)
-    case TraitDecl.self:
-      visit(traitDecl: NodeID(rawValue: decl.rawValue), withState: &state)
+    case TraitDecl.self: visit(traitDecl: NodeID(rawValue: decl.rawValue), withState: &state)
     case TypeAliasDecl.self:
       visit(typeAliasDecl: NodeID(rawValue: decl.rawValue), withState: &state)
-    case VarDecl.self:
-      visit(varDecl: NodeID(rawValue: decl.rawValue), withState: &state)
-    default:
-      unreachable("unexpected declaration")
+    case VarDecl.self: visit(varDecl: NodeID(rawValue: decl.rawValue), withState: &state)
+    default: unreachable("unexpected declaration")
     }
   }
 
@@ -139,15 +129,9 @@ extension ScopedProgram {
   ) {
     insert(decl: decl, into: state.innermost)
 
-    for conformance in ast[decl].conformances {
-      visit(nameExpr: conformance, withState: &state)
-    }
-    if let defaultValue = ast[decl].defaultValue {
-      visit(expr: defaultValue, withState: &state)
-    }
-    if let clause = ast[decl].whereClause?.value {
-      visit(whereClause: clause, withState: &state)
-    }
+    for conformance in ast[decl].conformances { visit(nameExpr: conformance, withState: &state) }
+    if let defaultValue = ast[decl].defaultValue { visit(expr: defaultValue, withState: &state) }
+    if let clause = ast[decl].whereClause?.value { visit(whereClause: clause, withState: &state) }
   }
 
   private mutating func visit(
@@ -155,12 +139,8 @@ extension ScopedProgram {
   ) {
     insert(decl: decl, into: state.innermost)
 
-    if let defaultValue = ast[decl].defaultValue {
-      visit(expr: defaultValue, withState: &state)
-    }
-    if let clause = ast[decl].whereClause?.value {
-      visit(whereClause: clause, withState: &state)
-    }
+    if let defaultValue = ast[decl].defaultValue { visit(expr: defaultValue, withState: &state) }
+    if let clause = ast[decl].whereClause?.value { visit(whereClause: clause, withState: &state) }
   }
 
   private mutating func visit(
@@ -172,9 +152,7 @@ extension ScopedProgram {
     state.bindingDeclBeingVisited = decl
 
     visit(bindingPattern: ast[decl].pattern, withState: &state)
-    if let initializer = ast[decl].initializer {
-      visit(expr: initializer, withState: &state)
-    }
+    if let initializer = ast[decl].initializer { visit(expr: initializer, withState: &state) }
 
     state.bindingDeclBeingVisited = currentBindingDeclBeingVisited
   }
@@ -186,14 +164,11 @@ extension ScopedProgram {
 
     nesting(
       in: decl, withState: &state,
-      { (this, state) in
-        this.visit(expr: this.ast[decl].subject, withState: &state)
+      { (this, state) in this.visit(expr: this.ast[decl].subject, withState: &state)
         if let clause = this.ast[decl].whereClause?.value {
           this.visit(whereClause: clause, withState: &state)
         }
-        for member in this.ast[decl].members {
-          this.visit(decl: member, withState: &state)
-        }
+        for member in this.ast[decl].members { this.visit(decl: member, withState: &state) }
       })
   }
 
@@ -204,14 +179,11 @@ extension ScopedProgram {
 
     nesting(
       in: decl, withState: &state,
-      { (this, state) in
-        this.visit(expr: this.ast[decl].subject, withState: &state)
+      { (this, state) in this.visit(expr: this.ast[decl].subject, withState: &state)
         if let clause = this.ast[decl].whereClause?.value {
           this.visit(whereClause: clause, withState: &state)
         }
-        for member in this.ast[decl].members {
-          this.visit(decl: member, withState: &state)
-        }
+        for member in this.ast[decl].members { this.visit(decl: member, withState: &state) }
       })
   }
 
@@ -235,19 +207,14 @@ extension ScopedProgram {
         if let receiver = this.ast[decl].receiver {
           this.visit(parameterDecl: receiver, withState: &state)
         }
-        if let output = this.ast[decl].output {
-          this.visit(expr: output, withState: &state)
-        }
+        if let output = this.ast[decl].output { this.visit(expr: output, withState: &state) }
 
         switch this.ast[decl].body {
-        case let .expr(expr):
-          this.visit(expr: expr, withState: &state)
+        case let .expr(expr): this.visit(expr: expr, withState: &state)
 
-        case let .block(stmt):
-          this.visit(braceStmt: stmt, withState: &state)
+        case let .block(stmt): this.visit(braceStmt: stmt, withState: &state)
 
-        case nil:
-          break
+        case nil: break
         }
       })
   }
@@ -257,19 +224,13 @@ extension ScopedProgram {
   ) {
     insert(decl: decl, into: state.innermost)
 
-    for conformance in ast[decl].conformances {
-      visit(nameExpr: conformance, withState: &state)
-    }
-    if let defaultValue = ast[decl].defaultValue {
-      visit(expr: defaultValue, withState: &state)
-    }
+    for conformance in ast[decl].conformances { visit(nameExpr: conformance, withState: &state) }
+    if let defaultValue = ast[decl].defaultValue { visit(expr: defaultValue, withState: &state) }
   }
 
   private mutating func visit(
     importDecl decl: NodeID<ImportDecl>, withState state: inout VisitorState
-  ) {
-    insert(decl: decl, into: state.innermost)
-  }
+  ) { insert(decl: decl, into: state.innermost) }
 
   private mutating func visit(
     initializerDecl decl: NodeID<InitializerDecl>, withState state: inout VisitorState
@@ -286,9 +247,7 @@ extension ScopedProgram {
           this.visit(parameterDecl: parameter, withState: &state)
         }
         this.visit(parameterDecl: this.ast[decl].receiver, withState: &state)
-        if let body = this.ast[decl].body {
-          this.visit(braceStmt: body, withState: &state)
-        }
+        if let body = this.ast[decl].body { this.visit(braceStmt: body, withState: &state) }
       })
   }
 
@@ -306,12 +265,8 @@ extension ScopedProgram {
         for parameter in this.ast[decl].parameters {
           this.visit(parameterDecl: parameter, withState: &state)
         }
-        if let output = this.ast[decl].output {
-          this.visit(expr: output, withState: &state)
-        }
-        for impl in this.ast[decl].impls {
-          this.visit(methodImplDecl: impl, withState: &state)
-        }
+        if let output = this.ast[decl].output { this.visit(expr: output, withState: &state) }
+        for impl in this.ast[decl].impls { this.visit(methodImplDecl: impl, withState: &state) }
       })
   }
 
@@ -322,18 +277,14 @@ extension ScopedProgram {
 
     nesting(
       in: decl, withState: &state,
-      { (this, state) in
-        this.visit(parameterDecl: this.ast[decl].receiver, withState: &state)
+      { (this, state) in this.visit(parameterDecl: this.ast[decl].receiver, withState: &state)
 
         switch this.ast[decl].body {
-        case let .expr(expr):
-          this.visit(expr: expr, withState: &state)
+        case let .expr(expr): this.visit(expr: expr, withState: &state)
 
-        case let .block(stmt):
-          this.visit(braceStmt: stmt, withState: &state)
+        case let .block(stmt): this.visit(braceStmt: stmt, withState: &state)
 
-        case nil:
-          break
+        case nil: break
         }
       })
   }
@@ -342,9 +293,7 @@ extension ScopedProgram {
     moduleDecl decl: NodeID<ModuleDecl>, withState state: inout VisitorState
   ) {
     precondition(state.innermost == decl)
-    for source in ast[decl].sources {
-      visit(topLevelDeclSet: source, withState: &state)
-    }
+    for source in ast[decl].sources { visit(topLevelDeclSet: source, withState: &state) }
   }
 
   private mutating func visit(
@@ -355,17 +304,13 @@ extension ScopedProgram {
     nesting(
       in: decl, withState: &state,
       { (this, state) in
-        for member in this.ast[decl].members {
-          this.visit(decl: member, withState: &state)
-        }
+        for member in this.ast[decl].members { this.visit(decl: member, withState: &state) }
       })
   }
 
   private mutating func visit(
     operatorDecl decl: NodeID<OperatorDecl>, withState state: inout VisitorState
-  ) {
-    insert(decl: decl, into: state.innermost)
-  }
+  ) { insert(decl: decl, into: state.innermost) }
 
   private mutating func visit(
     parameterDecl decl: NodeID<ParameterDecl>, withState state: inout VisitorState
@@ -375,9 +320,7 @@ extension ScopedProgram {
     if let annotation = ast[decl].annotation {
       visit(parameterTypeExpr: annotation, withState: &state)
     }
-    if let defaultValue = ast[decl].defaultValue {
-      visit(expr: defaultValue, withState: &state)
-    }
+    if let defaultValue = ast[decl].defaultValue { visit(expr: defaultValue, withState: &state) }
   }
 
   private mutating func visit(
@@ -394,9 +337,7 @@ extension ScopedProgram {
         for conformance in this.ast[decl].conformances {
           this.visit(nameExpr: conformance, withState: &state)
         }
-        for member in this.ast[decl].members {
-          this.visit(decl: member, withState: &state)
-        }
+        for member in this.ast[decl].members { this.visit(decl: member, withState: &state) }
       })
   }
 
@@ -418,9 +359,7 @@ extension ScopedProgram {
           this.visit(parameterDecl: parameter, withState: &state)
         }
         this.visit(expr: this.ast[decl].output, withState: &state)
-        for impl in this.ast[decl].impls {
-          this.visit(subscriptImplDecl: impl, withState: &state)
-        }
+        for impl in this.ast[decl].impls { this.visit(subscriptImplDecl: impl, withState: &state) }
       })
   }
 
@@ -437,14 +376,11 @@ extension ScopedProgram {
         }
 
         switch this.ast[decl].body {
-        case let .expr(expr):
-          this.visit(expr: expr, withState: &state)
+        case let .expr(expr): this.visit(expr: expr, withState: &state)
 
-        case let .block(stmt):
-          this.visit(braceStmt: stmt, withState: &state)
+        case let .block(stmt): this.visit(braceStmt: stmt, withState: &state)
 
-        case nil:
-          break
+        case nil: break
         }
       })
   }
@@ -460,9 +396,7 @@ extension ScopedProgram {
         for refinement in this.ast[decl].refinements {
           this.visit(nameExpr: refinement, withState: &state)
         }
-        for member in this.ast[decl].members {
-          this.visit(decl: member, withState: &state)
-        }
+        for member in this.ast[decl].members { this.visit(decl: member, withState: &state) }
       })
   }
 
@@ -478,13 +412,10 @@ extension ScopedProgram {
           this.visit(genericClause: clause, withState: &state)
         }
         switch this.ast[decl].body {
-        case .typeExpr(let expr):
-          this.visit(expr: expr, withState: &state)
+        case .typeExpr(let expr): this.visit(expr: expr, withState: &state)
 
         case .union(let union):
-          for element in union {
-            this.visit(productTypeDecl: element, withState: &state)
-          }
+          for element in union { this.visit(productTypeDecl: element, withState: &state) }
         }
       })
   }
@@ -510,76 +441,53 @@ extension ScopedProgram {
 
   private mutating func visit(expr: AnyExprID, withState state: inout VisitorState) {
     switch expr.kind {
-    case BooleanLiteralExpr.self:
-      break
+    case BooleanLiteralExpr.self: break
     case BufferLiteralExpr.self:
       visit(bufferLiteralExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case CastExpr.self:
-      visit(castExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case CondExpr.self:
-      visit(condExpr: NodeID(rawValue: expr.rawValue), withState: &state)
+    case CastExpr.self: visit(castExpr: NodeID(rawValue: expr.rawValue), withState: &state)
+    case CondExpr.self: visit(condExpr: NodeID(rawValue: expr.rawValue), withState: &state)
     case ConformanceLensTypeExpr.self:
       visit(conformanceLensTypeExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case ErrorExpr.self:
-      break
+    case ErrorExpr.self: break
     case ExistentialTypeExpr.self:
       visit(existentialTypeExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case FloatLiteralExpr.self:
-      break
-    case FunCallExpr.self:
-      visit(funCallExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case InoutExpr.self:
-      visit(inoutExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case IntegerLiteralExpr.self:
-      break
-    case LambdaExpr.self:
-      visit(lambdaExpr: NodeID(rawValue: expr.rawValue), withState: &state)
+    case FloatLiteralExpr.self: break
+    case FunCallExpr.self: visit(funCallExpr: NodeID(rawValue: expr.rawValue), withState: &state)
+    case InoutExpr.self: visit(inoutExpr: NodeID(rawValue: expr.rawValue), withState: &state)
+    case IntegerLiteralExpr.self: break
+    case LambdaExpr.self: visit(lambdaExpr: NodeID(rawValue: expr.rawValue), withState: &state)
     case LambdaTypeExpr.self:
       visit(lambdaTypeExpr: NodeID(rawValue: expr.rawValue), withState: &state)
     case MapLiteralExpr.self:
       visit(mapLiteralExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case MatchExpr.self:
-      visit(matchExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case NameExpr.self:
-      visit(nameExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case NilLiteralExpr.self:
-      break
+    case MatchExpr.self: visit(matchExpr: NodeID(rawValue: expr.rawValue), withState: &state)
+    case NameExpr.self: visit(nameExpr: NodeID(rawValue: expr.rawValue), withState: &state)
+    case NilLiteralExpr.self: break
     case ParameterTypeExpr.self:
       visit(parameterTypeExpr: NodeID(rawValue: expr.rawValue), withState: &state)
     case RemoteTypeExpr.self:
       visit(storedProjectionTypeExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case SequenceExpr.self:
-      visit(sequenceExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case SpawnExpr.self:
-      visit(spawnExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case StringLiteralExpr.self:
-      break
+    case SequenceExpr.self: visit(sequenceExpr: NodeID(rawValue: expr.rawValue), withState: &state)
+    case SpawnExpr.self: visit(spawnExpr: NodeID(rawValue: expr.rawValue), withState: &state)
+    case StringLiteralExpr.self: break
     case SubscriptCallExpr.self:
       visit(subscriptCallExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case TupleExpr.self:
-      visit(tupleExpr: NodeID(rawValue: expr.rawValue), withState: &state)
+    case TupleExpr.self: visit(tupleExpr: NodeID(rawValue: expr.rawValue), withState: &state)
     case TupleMemberExpr.self:
       visit(tupleMemberExpr: NodeID(rawValue: expr.rawValue), withState: &state)
     case TupleTypeExpr.self:
       visit(tupleTypeExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case UnicodeScalarLiteralExpr.self:
-      break
+    case UnicodeScalarLiteralExpr.self: break
     case UnionTypeExpr.self:
       visit(unionTypeExpr: NodeID(rawValue: expr.rawValue), withState: &state)
-    case WildcardExpr.self:
-      break
-    default:
-      unreachable("unexpected expression")
+    case WildcardExpr.self: break
+    default: unreachable("unexpected expression")
     }
   }
 
   private mutating func visit(
     bufferLiteralExpr expr: NodeID<BufferLiteralExpr>, withState state: inout VisitorState
-  ) {
-    for element in ast[expr].elements {
-      visit(expr: element, withState: &state)
-    }
-  }
+  ) { for element in ast[expr].elements { visit(expr: element, withState: &state) } }
 
   private mutating func visit(castExpr expr: NodeID<CastExpr>, withState state: inout VisitorState)
   {
@@ -594,27 +502,20 @@ extension ScopedProgram {
       { (this, state) in
         for item in this.ast[expr].condition {
           switch item {
-          case let .expr(i):
-            this.visit(expr: i, withState: &state)
-          case let .decl(i):
-            this.visit(bindingDecl: i, withState: &state)
+          case let .expr(i): this.visit(expr: i, withState: &state)
+          case let .decl(i): this.visit(bindingDecl: i, withState: &state)
           }
         }
 
         switch this.ast[expr].success {
-        case let .expr(i):
-          this.visit(expr: i, withState: &state)
-        case let .block(i):
-          this.visit(braceStmt: i, withState: &state)
+        case let .expr(i): this.visit(expr: i, withState: &state)
+        case let .block(i): this.visit(braceStmt: i, withState: &state)
         }
 
         switch this.ast[expr].failure {
-        case let .expr(i):
-          this.visit(expr: i, withState: &state)
-        case let .block(i):
-          this.visit(braceStmt: i, withState: &state)
-        case nil:
-          break
+        case let .expr(i): this.visit(expr: i, withState: &state)
+        case let .block(i): this.visit(braceStmt: i, withState: &state)
+        case nil: break
         }
       })
   }
@@ -630,41 +531,29 @@ extension ScopedProgram {
   private mutating func visit(
     existentialTypeExpr expr: NodeID<ExistentialTypeExpr>, withState state: inout VisitorState
   ) {
-    for trait in ast[expr].traits {
-      visit(nameExpr: trait, withState: &state)
-    }
-    if let clause = ast[expr].whereClause?.value {
-      visit(whereClause: clause, withState: &state)
-    }
+    for trait in ast[expr].traits { visit(nameExpr: trait, withState: &state) }
+    if let clause = ast[expr].whereClause?.value { visit(whereClause: clause, withState: &state) }
   }
 
   private mutating func visit(
     funCallExpr expr: NodeID<FunCallExpr>, withState state: inout VisitorState
   ) {
     visit(expr: ast[expr].callee, withState: &state)
-    for argument in ast[expr].arguments {
-      visit(expr: argument.value, withState: &state)
-    }
+    for argument in ast[expr].arguments { visit(expr: argument.value, withState: &state) }
   }
 
   private mutating func visit(
     inoutExpr expr: NodeID<InoutExpr>, withState state: inout VisitorState
-  ) {
-    visit(expr: ast[expr].subject, withState: &state)
-  }
+  ) { visit(expr: ast[expr].subject, withState: &state) }
 
   private mutating func visit(
     lambdaExpr expr: NodeID<LambdaExpr>, withState state: inout VisitorState
-  ) {
-    visit(functionDecl: ast[expr].decl, withState: &state)
-  }
+  ) { visit(functionDecl: ast[expr].decl, withState: &state) }
 
   private mutating func visit(
     lambdaTypeExpr expr: NodeID<LambdaTypeExpr>, withState state: inout VisitorState
   ) {
-    if let environment = ast[expr].environment {
-      visit(expr: environment, withState: &state)
-    }
+    if let environment = ast[expr].environment { visit(expr: environment, withState: &state) }
     for parameter in ast[expr].parameters {
       visit(parameterTypeExpr: parameter.type, withState: &state)
     }
@@ -687,17 +576,14 @@ extension ScopedProgram {
     for case_ in ast[expr].cases {
       nesting(
         in: case_, withState: &state,
-        { (this, state) in
-          this.visit(pattern: this.ast[case_].pattern, withState: &state)
+        { (this, state) in this.visit(pattern: this.ast[case_].pattern, withState: &state)
           if let condition = this.ast[case_].condition {
             this.visit(expr: condition, withState: &state)
           }
 
           switch this.ast[case_].body {
-          case let .expr(i):
-            this.visit(expr: i, withState: &state)
-          case let .block(i):
-            this.visit(braceStmt: i, withState: &state)
+          case let .expr(i): this.visit(expr: i, withState: &state)
+          case let .block(i): this.visit(braceStmt: i, withState: &state)
           }
         })
     }
@@ -705,25 +591,17 @@ extension ScopedProgram {
 
   private mutating func visit(nameExpr expr: NodeID<NameExpr>, withState state: inout VisitorState)
   {
-    if case let .expr(domain) = ast[expr].domain {
-      visit(expr: domain, withState: &state)
-    }
-    for argument in ast[expr].arguments {
-      visit(expr: argument.value, withState: &state)
-    }
+    if case let .expr(domain) = ast[expr].domain { visit(expr: domain, withState: &state) }
+    for argument in ast[expr].arguments { visit(expr: argument.value, withState: &state) }
   }
 
   private mutating func visit(
     parameterTypeExpr expr: NodeID<ParameterTypeExpr>, withState state: inout VisitorState
-  ) {
-    visit(expr: ast[expr].bareType, withState: &state)
-  }
+  ) { visit(expr: ast[expr].bareType, withState: &state) }
 
   private mutating func visit(
     storedProjectionTypeExpr expr: NodeID<RemoteTypeExpr>, withState state: inout VisitorState
-  ) {
-    visit(expr: ast[expr].operand, withState: &state)
-  }
+  ) { visit(expr: ast[expr].operand, withState: &state) }
 
   private mutating func visit(
     sequenceExpr expr: NodeID<SequenceExpr>, withState state: inout VisitorState
@@ -737,48 +615,30 @@ extension ScopedProgram {
 
   private mutating func visit(
     spawnExpr expr: NodeID<SpawnExpr>, withState state: inout VisitorState
-  ) {
-    visit(functionDecl: ast[expr].decl, withState: &state)
-  }
+  ) { visit(functionDecl: ast[expr].decl, withState: &state) }
 
   private mutating func visit(
     subscriptCallExpr expr: NodeID<SubscriptCallExpr>, withState state: inout VisitorState
   ) {
     visit(expr: ast[expr].callee, withState: &state)
-    for argument in ast[expr].arguments {
-      visit(expr: argument.value, withState: &state)
-    }
+    for argument in ast[expr].arguments { visit(expr: argument.value, withState: &state) }
   }
 
   private mutating func visit(
     tupleExpr expr: NodeID<TupleExpr>, withState state: inout VisitorState
-  ) {
-    for element in ast[expr].elements {
-      visit(expr: element.value, withState: &state)
-    }
-  }
+  ) { for element in ast[expr].elements { visit(expr: element.value, withState: &state) } }
 
   private mutating func visit(
     tupleMemberExpr expr: NodeID<TupleMemberExpr>, withState state: inout VisitorState
-  ) {
-    visit(expr: ast[expr].tuple, withState: &state)
-  }
+  ) { visit(expr: ast[expr].tuple, withState: &state) }
 
   private mutating func visit(
     tupleTypeExpr expr: NodeID<TupleTypeExpr>, withState state: inout VisitorState
-  ) {
-    for element in ast[expr].elements {
-      visit(expr: element.type, withState: &state)
-    }
-  }
+  ) { for element in ast[expr].elements { visit(expr: element.type, withState: &state) } }
 
   private mutating func visit(
     unionTypeExpr expr: NodeID<UnionTypeExpr>, withState state: inout VisitorState
-  ) {
-    for element in ast[expr].elements {
-      visit(expr: element, withState: &state)
-    }
-  }
+  ) { for element in ast[expr].elements { visit(expr: element, withState: &state) } }
 
   // MARK: Patterns
 
@@ -786,16 +646,12 @@ extension ScopedProgram {
     switch pattern.kind {
     case BindingPattern.self:
       visit(bindingPattern: NodeID(rawValue: pattern.rawValue), withState: &state)
-    case ExprPattern.self:
-      visit(exprPattern: NodeID(rawValue: pattern.rawValue), withState: &state)
-    case NamePattern.self:
-      visit(namePattern: NodeID(rawValue: pattern.rawValue), withState: &state)
+    case ExprPattern.self: visit(exprPattern: NodeID(rawValue: pattern.rawValue), withState: &state)
+    case NamePattern.self: visit(namePattern: NodeID(rawValue: pattern.rawValue), withState: &state)
     case TuplePattern.self:
       visit(tuplePattern: NodeID(rawValue: pattern.rawValue), withState: &state)
-    case WildcardPattern.self:
-      break
-    default:
-      unreachable("unexpected pattern")
+    case WildcardPattern.self: break
+    default: unreachable("unexpected pattern")
     }
   }
 
@@ -803,63 +659,40 @@ extension ScopedProgram {
     bindingPattern pattern: NodeID<BindingPattern>, withState state: inout VisitorState
   ) {
     visit(pattern: ast[pattern].subpattern, withState: &state)
-    if let annotation = ast[pattern].annotation {
-      visit(expr: annotation, withState: &state)
-    }
+    if let annotation = ast[pattern].annotation { visit(expr: annotation, withState: &state) }
   }
 
   private mutating func visit(
     exprPattern pattern: NodeID<ExprPattern>, withState state: inout VisitorState
-  ) {
-    visit(expr: ast[pattern].expr, withState: &state)
-  }
+  ) { visit(expr: ast[pattern].expr, withState: &state) }
 
   private mutating func visit(
     namePattern pattern: NodeID<NamePattern>, withState state: inout VisitorState
-  ) {
-    visit(varDecl: ast[pattern].decl, withState: &state)
-  }
+  ) { visit(varDecl: ast[pattern].decl, withState: &state) }
 
   private mutating func visit(
     tuplePattern pattern: NodeID<TuplePattern>, withState state: inout VisitorState
-  ) {
-    for element in ast[pattern].elements {
-      visit(pattern: element.pattern, withState: &state)
-    }
-  }
+  ) { for element in ast[pattern].elements { visit(pattern: element.pattern, withState: &state) } }
 
   // MARK: Statements
 
   private mutating func visit(stmt: AnyStmtID, withState state: inout VisitorState) {
     switch stmt.kind {
-    case AssignStmt.self:
-      visit(assignStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
-    case BraceStmt.self:
-      visit(braceStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
-    case BraceStmt.self:
-      break
+    case AssignStmt.self: visit(assignStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
+    case BraceStmt.self: visit(braceStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
+    case BraceStmt.self: break
     case CondBindingStmt.self:
       visit(condBindingStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
-    case ContinueStmt.self:
-      break
-    case DeclStmt.self:
-      visit(declStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
-    case DiscardStmt.self:
-      visit(discardStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
-    case DoWhileStmt.self:
-      visit(doWhileStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
-    case ExprStmt.self:
-      visit(exprStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
-    case ForStmt.self:
-      visit(forStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
-    case ReturnStmt.self:
-      visit(returnStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
-    case WhileStmt.self:
-      visit(whileStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
-    case YieldStmt.self:
-      visit(yieldStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
-    default:
-      unreachable("unexpected statement")
+    case ContinueStmt.self: break
+    case DeclStmt.self: visit(declStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
+    case DiscardStmt.self: visit(discardStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
+    case DoWhileStmt.self: visit(doWhileStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
+    case ExprStmt.self: visit(exprStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
+    case ForStmt.self: visit(forStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
+    case ReturnStmt.self: visit(returnStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
+    case WhileStmt.self: visit(whileStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
+    case YieldStmt.self: visit(yieldStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
+    default: unreachable("unexpected statement")
     }
   }
 
@@ -875,11 +708,7 @@ extension ScopedProgram {
   ) {
     nesting(
       in: stmt, withState: &state,
-      { (this, state) in
-        for i in this.ast[stmt].stmts {
-          this.visit(stmt: i, withState: &state)
-        }
-      })
+      { (this, state) in for i in this.ast[stmt].stmts { this.visit(stmt: i, withState: &state) } })
   }
 
   private mutating func visit(
@@ -887,23 +716,17 @@ extension ScopedProgram {
   ) {
     visit(bindingDecl: ast[stmt].binding, withState: &state)
     switch ast[stmt].fallback {
-    case .expr(let i):
-      visit(expr: i, withState: &state)
-    case .exit(let i):
-      visit(stmt: i, withState: &state)
+    case .expr(let i): visit(expr: i, withState: &state)
+    case .exit(let i): visit(stmt: i, withState: &state)
     }
   }
 
   private mutating func visit(declStmt stmt: NodeID<DeclStmt>, withState state: inout VisitorState)
-  {
-    visit(decl: ast[stmt].decl, withState: &state)
-  }
+  { visit(decl: ast[stmt].decl, withState: &state) }
 
   private mutating func visit(
     discardStmt stmt: NodeID<DiscardStmt>, withState state: inout VisitorState
-  ) {
-    visit(expr: ast[stmt].expr, withState: &state)
-  }
+  ) { visit(expr: ast[stmt].expr, withState: &state) }
 
   private mutating func visit(
     doWhileStmt stmt: NodeID<DoWhileStmt>, withState state: inout VisitorState
@@ -918,29 +741,20 @@ extension ScopedProgram {
   }
 
   private mutating func visit(exprStmt stmt: NodeID<ExprStmt>, withState state: inout VisitorState)
-  {
-    visit(expr: ast[stmt].expr, withState: &state)
-  }
+  { visit(expr: ast[stmt].expr, withState: &state) }
 
   private mutating func visit(forStmt stmt: NodeID<ForStmt>, withState state: inout VisitorState) {
     nesting(
       in: stmt, withState: &state,
-      { (this, state) in
-        this.visit(bindingDecl: this.ast[stmt].binding, withState: &state)
-        if let filter = this.ast[stmt].filter {
-          this.visit(expr: filter, withState: &state)
-        }
+      { (this, state) in this.visit(bindingDecl: this.ast[stmt].binding, withState: &state)
+        if let filter = this.ast[stmt].filter { this.visit(expr: filter, withState: &state) }
         this.visit(braceStmt: this.ast[stmt].body, withState: &state)
       })
   }
 
   private mutating func visit(
     returnStmt stmt: NodeID<ReturnStmt>, withState state: inout VisitorState
-  ) {
-    if let value = ast[stmt].value {
-      visit(expr: value, withState: &state)
-    }
-  }
+  ) { if let value = ast[stmt].value { visit(expr: value, withState: &state) } }
 
   private mutating func visit(
     whileStmt stmt: NodeID<WhileStmt>, withState state: inout VisitorState
@@ -950,10 +764,8 @@ extension ScopedProgram {
       { (this, state) in
         for item in this.ast[stmt].condition {
           switch item {
-          case let .expr(i):
-            this.visit(expr: i, withState: &state)
-          case let .decl(i):
-            this.visit(bindingDecl: i, withState: &state)
+          case let .expr(i): this.visit(expr: i, withState: &state)
+          case let .decl(i): this.visit(bindingDecl: i, withState: &state)
           }
         }
 
@@ -963,18 +775,14 @@ extension ScopedProgram {
 
   private mutating func visit(
     yieldStmt stmt: NodeID<YieldStmt>, withState state: inout VisitorState
-  ) {
-    visit(expr: ast[stmt].value, withState: &state)
-  }
+  ) { visit(expr: ast[stmt].value, withState: &state) }
 
   // MARK: Others
 
   private mutating func visit(
     genericClause clause: GenericClause, withState state: inout VisitorState
   ) {
-    for parameter in clause.parameters {
-      visit(genericParameterDecl: parameter, withState: &state)
-    }
+    for parameter in clause.parameters { visit(genericParameterDecl: parameter, withState: &state) }
     if let whereClause = clause.whereClause?.value {
       visit(whereClause: whereClause, withState: &state)
     }
@@ -986,16 +794,13 @@ extension ScopedProgram {
       switch constraint.value {
       case .conformance(let lhs, let traits):
         visit(nameExpr: lhs, withState: &state)
-        for trait in traits {
-          visit(nameExpr: trait, withState: &state)
-        }
+        for trait in traits { visit(nameExpr: trait, withState: &state) }
 
       case .equality(let lhs, let rhs):
         visit(nameExpr: lhs, withState: &state)
         visit(expr: rhs, withState: &state)
 
-      case .value(let expr):
-        visit(expr: expr, withState: &state)
+      case .value(let expr): visit(expr: expr, withState: &state)
       }
     }
   }

--- a/Sources/Compiler/SuccessOrDiagnostics.swift
+++ b/Sources/Compiler/SuccessOrDiagnostics.swift
@@ -9,11 +9,7 @@ public enum SuccessOrDiagnostics {
 
   /// The diagnostics in the payload of `.failure`. Otherwise, an empty array.
   public var diagnostics: [Diagnostic] {
-    if case .failure(let ds) = self {
-      return ds
-    } else {
-      return []
-    }
+    if case .failure(let ds) = self { return ds } else { return [] }
   }
 
 }

--- a/Sources/Compiler/TypeChecking/CaptureCollector.swift
+++ b/Sources/Compiler/TypeChecking/CaptureCollector.swift
@@ -31,11 +31,9 @@ struct CaptureCollector {
       let d = NodeID<FunctionDecl>(rawValue: id.rawValue)
       collectCaptures(ofFunction: d, includingExplicitCaptures: true, into: &captures)
 
-    case SubscriptDecl.self:
-      fatalError("not implemented")
+    case SubscriptDecl.self: fatalError("not implemented")
 
-    default:
-      unreachable()
+    default: unreachable()
     }
 
     return captures
@@ -54,11 +52,8 @@ struct CaptureCollector {
     if !boundNames.contains(where: { $0.contains(name) }) {
       modifying(
         &captures[name, default: ([], .let)],
-        { entry in
-          entry.occurences.append(occurrence)
-          if capability == .inout {
-            entry.capability = capability
-          }
+        { entry in entry.occurences.append(occurrence)
+          if capability == .inout { entry.capability = capability }
         })
     }
   }
@@ -72,8 +67,7 @@ struct CaptureCollector {
       collectCaptures(
         ofFunction: NodeID(rawValue: id.rawValue), includingExplicitCaptures: false, into: &captures
       )
-    default:
-      unreachable("unexpected declaration")
+    default: unreachable("unexpected declaration")
     }
   }
 
@@ -147,12 +141,9 @@ struct CaptureCollector {
     // Visit the function's body.
     boundNames.append(newNames)
     switch ast[id].body {
-    case .expr(let expr):
-      collectCaptures(ofExpr: expr, into: &captures, inMutatingContext: false)
-    case .block(let stmt):
-      collectCaptures(ofBrace: stmt, into: &captures)
-    default:
-      break
+    case .expr(let expr): collectCaptures(ofExpr: expr, into: &captures, inMutatingContext: false)
+    case .block(let stmt): collectCaptures(ofBrace: stmt, into: &captures)
+    default: break
     }
     boundNames.removeLast()
   }
@@ -206,8 +197,7 @@ struct CaptureCollector {
       FloatLiteralExpr.self, IntegerLiteralExpr.self, NilLiteralExpr.self, StringLiteralExpr.self:
       break
 
-    default:
-      unreachable("unexpected expression")
+    default: unreachable("unexpected expression")
     }
   }
 
@@ -220,17 +210,14 @@ struct CaptureCollector {
     // Visit the condition.
     for item in ast[id].condition {
       switch item {
-      case .expr(let expr):
-        collectCaptures(ofExpr: expr, into: &captures, inMutatingContext: false)
-      case .decl(let decl):
-        collectCaptures(ofBinding: decl, into: &captures)
+      case .expr(let expr): collectCaptures(ofExpr: expr, into: &captures, inMutatingContext: false)
+      case .decl(let decl): collectCaptures(ofBinding: decl, into: &captures)
       }
     }
 
     // Visit the then branch.
     switch ast[id].success {
-    case .block(let stmt):
-      collectCaptures(ofBrace: stmt, into: &captures)
+    case .block(let stmt): collectCaptures(ofBrace: stmt, into: &captures)
     case .expr(let expr):
       collectCaptures(ofExpr: expr, into: &captures, inMutatingContext: isContextMutating)
     }
@@ -240,12 +227,10 @@ struct CaptureCollector {
 
     // Visit the else branch, if any.
     switch ast[id].failure {
-    case .block(let stmt):
-      collectCaptures(ofBrace: stmt, into: &captures)
+    case .block(let stmt): collectCaptures(ofBrace: stmt, into: &captures)
     case .expr(let expr):
       collectCaptures(ofExpr: expr, into: &captures, inMutatingContext: isContextMutating)
-    case nil:
-      break
+    case nil: break
     }
   }
 
@@ -292,9 +277,7 @@ struct CaptureCollector {
   private mutating func collectCaptures(
     ofInout id: NodeID<InoutExpr>, into captures: inout FreeSet,
     inMutatingContext isContextMutating: Bool
-  ) {
-    collectCaptures(ofExpr: ast[id].subject, into: &captures, inMutatingContext: true)
-  }
+  ) { collectCaptures(ofExpr: ast[id].subject, into: &captures, inMutatingContext: true) }
 
   /// Collects the names occurring free in the specified expression.
   ///
@@ -313,8 +296,7 @@ struct CaptureCollector {
     case .expr(let domain):
       collectCaptures(ofExpr: domain, into: &captures, inMutatingContext: isContextMutating)
 
-    default:
-      break
+    default: break
     }
 
     for argument in ast[id].arguments {
@@ -345,9 +327,7 @@ struct CaptureCollector {
   private mutating func collectCaptures(
     ofTupleMember id: NodeID<TupleMemberExpr>, into captures: inout FreeSet,
     inMutatingContext isContextMutating: Bool
-  ) {
-    collectCaptures(ofExpr: ast[id].tuple, into: &captures, inMutatingContext: false)
-  }
+  ) { collectCaptures(ofExpr: ast[id].tuple, into: &captures, inMutatingContext: false) }
 
   private mutating func collectCaptures<T: PatternID>(ofPattern id: T, into captures: inout FreeSet)
   {
@@ -361,10 +341,8 @@ struct CaptureCollector {
     case ExprPattern.self:
       let expr = ast[NodeID<ExprPattern>(rawValue: id.rawValue)].expr
       collectCaptures(ofExpr: expr, into: &captures, inMutatingContext: false)
-    case WildcardPattern.self:
-      break
-    default:
-      unreachable("unexpected pattern")
+    case WildcardPattern.self: break
+    default: unreachable("unexpected pattern")
     }
   }
 
@@ -387,36 +365,27 @@ struct CaptureCollector {
   private mutating func collectCaptures(
     ofTuplePattern id: NodeID<TuplePattern>, into captures: inout FreeSet
   ) {
-    for element in ast[id].elements {
-      collectCaptures(ofPattern: element.pattern, into: &captures)
-    }
+    for element in ast[id].elements { collectCaptures(ofPattern: element.pattern, into: &captures) }
   }
 
   /// Collects the names occurring free in the specified statement.
   private mutating func collectCaptures<T: StmtID>(ofStmt id: T, into captures: inout FreeSet) {
     switch id.kind {
-    case AssignStmt.self:
-      collectCaptures(ofAssign: NodeID(rawValue: id.rawValue), into: &captures)
-    case BraceStmt.self:
-      collectCaptures(ofBrace: NodeID(rawValue: id.rawValue), into: &captures)
+    case AssignStmt.self: collectCaptures(ofAssign: NodeID(rawValue: id.rawValue), into: &captures)
+    case BraceStmt.self: collectCaptures(ofBrace: NodeID(rawValue: id.rawValue), into: &captures)
     case DoWhileStmt.self:
       collectCaptures(ofDoWhile: NodeID(rawValue: id.rawValue), into: &captures)
-    case ReturnStmt.self:
-      collectCaptures(ofReturn: NodeID(rawValue: id.rawValue), into: &captures)
-    case WhileStmt.self:
-      collectCaptures(ofWhile: NodeID(rawValue: id.rawValue), into: &captures)
-    case YieldStmt.self:
-      collectCaptures(ofYield: NodeID(rawValue: id.rawValue), into: &captures)
+    case ReturnStmt.self: collectCaptures(ofReturn: NodeID(rawValue: id.rawValue), into: &captures)
+    case WhileStmt.self: collectCaptures(ofWhile: NodeID(rawValue: id.rawValue), into: &captures)
+    case YieldStmt.self: collectCaptures(ofYield: NodeID(rawValue: id.rawValue), into: &captures)
     case DeclStmt.self:
       let decl = ast[NodeID<DeclStmt>(rawValue: id.rawValue)].decl
       collectCaptures(ofDecl: decl, into: &captures)
     case ExprStmt.self:
       let expr = ast[NodeID<ExprStmt>(rawValue: id.rawValue)].expr
       collectCaptures(ofExpr: expr, into: &captures, inMutatingContext: false)
-    case BreakStmt.self, ContinueStmt.self:
-      break
-    default:
-      unreachable("unexpected statement")
+    case BreakStmt.self, ContinueStmt.self: break
+    default: unreachable("unexpected statement")
     }
   }
 
@@ -430,9 +399,7 @@ struct CaptureCollector {
   private mutating func collectCaptures(ofBrace id: NodeID<BraceStmt>, into captures: inout FreeSet)
   {
     boundNames.append([])
-    for stmt in ast[id].stmts {
-      collectCaptures(ofStmt: stmt, into: &captures)
-    }
+    for stmt in ast[id].stmts { collectCaptures(ofStmt: stmt, into: &captures) }
     boundNames.removeLast()
   }
 
@@ -440,9 +407,7 @@ struct CaptureCollector {
     ofDoWhile id: NodeID<DoWhileStmt>, into captures: inout FreeSet
   ) {
     boundNames.append([])
-    for stmt in ast[ast[id].body].stmts {
-      collectCaptures(ofStmt: stmt, into: &captures)
-    }
+    for stmt in ast[ast[id].body].stmts { collectCaptures(ofStmt: stmt, into: &captures) }
     collectCaptures(ofExpr: ast[id].condition, into: &captures, inMutatingContext: false)
     boundNames.removeLast()
   }
@@ -462,10 +427,8 @@ struct CaptureCollector {
     // Visit the condition.
     for item in ast[id].condition {
       switch item {
-      case .expr(let expr):
-        collectCaptures(ofExpr: expr, into: &captures, inMutatingContext: false)
-      case .decl(let decl):
-        collectCaptures(ofBinding: decl, into: &captures)
+      case .expr(let expr): collectCaptures(ofExpr: expr, into: &captures, inMutatingContext: false)
+      case .decl(let decl): collectCaptures(ofBinding: decl, into: &captures)
       }
     }
 
@@ -476,22 +439,18 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(ofYield id: NodeID<YieldStmt>, into captures: inout FreeSet)
-  {
-    collectCaptures(ofExpr: ast[id].value, into: &captures, inMutatingContext: isYieldMutating)
-  }
+  { collectCaptures(ofExpr: ast[id].value, into: &captures, inMutatingContext: isYieldMutating) }
 
   private mutating func collectCaptures<T: TypeExprID>(
     ofTypeExpr id: T, into captures: inout FreeSet
   ) {
     switch id.kind {
-    case NameExpr.self:
-      collectCaptures(ofNameType: NodeID(rawValue: id.rawValue), into: &captures)
+    case NameExpr.self: collectCaptures(ofNameType: NodeID(rawValue: id.rawValue), into: &captures)
     case ParameterTypeExpr.self:
       collectCaptures(ofParameter: NodeID(rawValue: id.rawValue), into: &captures)
     case TupleTypeExpr.self:
       collectCaptures(ofTupleType: NodeID(rawValue: id.rawValue), into: &captures)
-    default:
-      unreachable("unexpected type expression")
+    default: unreachable("unexpected type expression")
     }
   }
 
@@ -499,8 +458,7 @@ struct CaptureCollector {
     ofNameType id: NodeID<NameExpr>, into captures: inout FreeSet
   ) {
     switch ast[id].domain {
-    case .none, .implicit:
-      break
+    case .none, .implicit: break
     case .expr(let domain):
       collectCaptures(ofExpr: domain, into: &captures, inMutatingContext: false)
     }
@@ -512,16 +470,12 @@ struct CaptureCollector {
 
   private mutating func collectCaptures(
     ofParameter id: NodeID<ParameterTypeExpr>, into captures: inout FreeSet
-  ) {
-    collectCaptures(ofTypeExpr: ast[id].bareType, into: &captures)
-  }
+  ) { collectCaptures(ofTypeExpr: ast[id].bareType, into: &captures) }
 
   private mutating func collectCaptures(
     ofTupleType id: NodeID<TupleTypeExpr>, into captures: inout FreeSet
   ) {
-    for element in ast[id].elements {
-      collectCaptures(ofTypeExpr: element.type, into: &captures)
-    }
+    for element in ast[id].elements { collectCaptures(ofTypeExpr: element.type, into: &captures) }
   }
 
 }

--- a/Sources/Compiler/TypeChecking/CaptureCollector.swift
+++ b/Sources/Compiler/TypeChecking/CaptureCollector.swift
@@ -47,10 +47,8 @@ struct CaptureCollector {
   /// - Parameters:
   ///   - capability: The capability of the use; must be either `let` or `inout`.
   private mutating func record(
-    occurrence: NodeID<NameExpr>,
-    withCapability capability: RemoteType.Capability,
-    ifFree name: Name,
-    into captures: inout FreeSet
+    occurrence: NodeID<NameExpr>, withCapability capability: RemoteType.Capability,
+    ifFree name: Name, into captures: inout FreeSet
   ) {
     precondition(capability == .let || capability == .inout)
     if !boundNames.contains(where: { $0.contains(name) }) {
@@ -66,34 +64,28 @@ struct CaptureCollector {
   }
 
   /// Collects the names occurring free in the specified declaration.
-  private mutating func collectCaptures<T: DeclID>(
-    ofDecl id: T,
-    into captures: inout FreeSet
-  ) {
+  private mutating func collectCaptures<T: DeclID>(ofDecl id: T, into captures: inout FreeSet) {
     switch id.kind {
     case BindingDecl.self:
       collectCaptures(ofBinding: NodeID(rawValue: id.rawValue), into: &captures)
     case FunctionDecl.self:
       collectCaptures(
-        ofFunction: NodeID(rawValue: id.rawValue),
-        includingExplicitCaptures: false,
-        into: &captures)
+        ofFunction: NodeID(rawValue: id.rawValue), includingExplicitCaptures: false, into: &captures
+      )
     default:
       unreachable("unexpected declaration")
     }
   }
 
   private mutating func collectCaptures(
-    ofBinding id: NodeID<BindingDecl>,
-    into captures: inout FreeSet
+    ofBinding id: NodeID<BindingDecl>, into captures: inout FreeSet
   ) {
     // Note: the names introduced by that declaration are not yet available in the pattern and
     // initializer of the declaration.
     collectCaptures(ofBindingPattern: ast[id].pattern, into: &captures)
     if let initializer = ast[id].initializer {
       collectCaptures(
-        ofExpr: initializer,
-        into: &captures,
+        ofExpr: initializer, into: &captures,
         inMutatingContext: ast[ast[id].pattern].introducer.value == .inout)
     }
 
@@ -105,8 +97,7 @@ struct CaptureCollector {
 
   private mutating func collectCaptures(
     ofFunction id: NodeID<FunctionDecl>,
-    includingExplicitCaptures areExplicitCapturesIncluded: Bool,
-    into captures: inout FreeSet
+    includingExplicitCaptures areExplicitCapturesIncluded: Bool, into captures: inout FreeSet
   ) {
     var newNames: Set<Name> = []
 
@@ -168,66 +159,51 @@ struct CaptureCollector {
 
   /// Collects the names occurring free in the specified expression.
   private mutating func collectCaptures<T: ExprID>(
-    ofExpr id: T,
-    into captures: inout FreeSet,
-    inMutatingContext isContextMutating: Bool
+    ofExpr id: T, into captures: inout FreeSet, inMutatingContext isContextMutating: Bool
   ) {
     switch id.kind {
     case CastExpr.self:
       collectCaptures(
-        ofCast: NodeID(rawValue: id.rawValue),
-        into: &captures,
-        inMutatingContext: isContextMutating)
+        ofCast: NodeID(rawValue: id.rawValue), into: &captures, inMutatingContext: isContextMutating
+      )
 
     case CondExpr.self:
       collectCaptures(
-        ofCond: NodeID(rawValue: id.rawValue),
-        into: &captures,
-        inMutatingContext: isContextMutating)
+        ofCond: NodeID(rawValue: id.rawValue), into: &captures, inMutatingContext: isContextMutating
+      )
 
     case FunCallExpr.self:
       collectCaptures(
-        ofFunCall: NodeID(rawValue: id.rawValue),
-        into: &captures,
+        ofFunCall: NodeID(rawValue: id.rawValue), into: &captures,
         inMutatingContext: isContextMutating)
 
     case InoutExpr.self:
       collectCaptures(
-        ofInout: NodeID(rawValue: id.rawValue),
-        into: &captures,
+        ofInout: NodeID(rawValue: id.rawValue), into: &captures,
         inMutatingContext: isContextMutating)
 
     case NameExpr.self:
       collectCaptures(
-        ofName: NodeID(rawValue: id.rawValue),
-        into: &captures,
-        inMutatingContext: isContextMutating)
+        ofName: NodeID(rawValue: id.rawValue), into: &captures, inMutatingContext: isContextMutating
+      )
 
     case SequenceExpr.self:
       collectCaptures(
-        ofSequence: NodeID(rawValue: id.rawValue),
-        into: &captures,
+        ofSequence: NodeID(rawValue: id.rawValue), into: &captures,
         inMutatingContext: isContextMutating)
 
     case TupleExpr.self:
       collectCaptures(
-        ofTuple: NodeID(rawValue: id.rawValue),
-        into: &captures,
+        ofTuple: NodeID(rawValue: id.rawValue), into: &captures,
         inMutatingContext: isContextMutating)
 
     case TupleMemberExpr.self:
       collectCaptures(
-        ofTupleMember: NodeID(rawValue: id.rawValue),
-        into: &captures,
+        ofTupleMember: NodeID(rawValue: id.rawValue), into: &captures,
         inMutatingContext: isContextMutating)
 
-    case BooleanLiteralExpr.self,
-      UnicodeScalarLiteralExpr.self,
-      ErrorExpr.self,
-      FloatLiteralExpr.self,
-      IntegerLiteralExpr.self,
-      NilLiteralExpr.self,
-      StringLiteralExpr.self:
+    case BooleanLiteralExpr.self, UnicodeScalarLiteralExpr.self, ErrorExpr.self,
+      FloatLiteralExpr.self, IntegerLiteralExpr.self, NilLiteralExpr.self, StringLiteralExpr.self:
       break
 
     default:
@@ -236,8 +212,7 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofCond id: NodeID<CondExpr>,
-    into captures: inout FreeSet,
+    ofCond id: NodeID<CondExpr>, into captures: inout FreeSet,
     inMutatingContext isContextMutating: Bool
   ) {
     boundNames.append([])
@@ -275,8 +250,7 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofCast id: NodeID<CastExpr>,
-    into captures: inout FreeSet,
+    ofCast id: NodeID<CastExpr>, into captures: inout FreeSet,
     inMutatingContext isContextMutating: Bool
   ) {
     collectCaptures(ofExpr: ast[id].left, into: &captures, inMutatingContext: isContextMutating)
@@ -284,8 +258,7 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofFunCall id: NodeID<FunCallExpr>,
-    into captures: inout FreeSet,
+    ofFunCall id: NodeID<FunCallExpr>, into captures: inout FreeSet,
     inMutatingContext isContextMutating: Bool
   ) {
     if ast[id].callee.kind == NameExpr.self {
@@ -295,8 +268,7 @@ struct CaptureCollector {
         let baseName: Name
         if (ast[callee].name.value.notation == nil) && ast[callee].name.value.labels.isEmpty {
           baseName = Name(
-            stem: ast[callee].name.value.stem,
-            labels: ast[id].arguments.map({ $0.label?.value }))
+            stem: ast[callee].name.value.stem, labels: ast[id].arguments.map({ $0.label?.value }))
         } else {
           baseName = ast[callee].name.value
         }
@@ -318,8 +290,7 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofInout id: NodeID<InoutExpr>,
-    into captures: inout FreeSet,
+    ofInout id: NodeID<InoutExpr>, into captures: inout FreeSet,
     inMutatingContext isContextMutating: Bool
   ) {
     collectCaptures(ofExpr: ast[id].subject, into: &captures, inMutatingContext: true)
@@ -330,18 +301,14 @@ struct CaptureCollector {
   /// - Parameter ignoreBaseName: Assign this parameter to `true` to prevent the method from
   ///   inserting the base name of the expression even when it isn't bound.
   private mutating func collectCaptures(
-    ofName id: NodeID<NameExpr>,
-    into captures: inout FreeSet,
-    inMutatingContext isContextMutating: Bool,
-    ignoringBaseName ignoreBaseName: Bool = false
+    ofName id: NodeID<NameExpr>, into captures: inout FreeSet,
+    inMutatingContext isContextMutating: Bool, ignoringBaseName ignoreBaseName: Bool = false
   ) {
     switch ast[id].domain {
     case .none where !ignoreBaseName:
       record(
-        occurrence: id,
-        withCapability: isContextMutating ? .inout : .let,
-        ifFree: ast[id].name.value,
-        into: &captures)
+        occurrence: id, withCapability: isContextMutating ? .inout : .let,
+        ifFree: ast[id].name.value, into: &captures)
 
     case .expr(let domain):
       collectCaptures(ofExpr: domain, into: &captures, inMutatingContext: isContextMutating)
@@ -356,8 +323,7 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofSequence id: NodeID<SequenceExpr>,
-    into captures: inout FreeSet,
+    ofSequence id: NodeID<SequenceExpr>, into captures: inout FreeSet,
     inMutatingContext isContextMutating: Bool
   ) {
     collectCaptures(ofExpr: ast[id].head, into: &captures, inMutatingContext: false)
@@ -368,8 +334,7 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofTuple id: NodeID<TupleExpr>,
-    into captures: inout FreeSet,
+    ofTuple id: NodeID<TupleExpr>, into captures: inout FreeSet,
     inMutatingContext isContextMutating: Bool
   ) {
     for element in ast[id].elements {
@@ -378,17 +343,14 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofTupleMember id: NodeID<TupleMemberExpr>,
-    into captures: inout FreeSet,
+    ofTupleMember id: NodeID<TupleMemberExpr>, into captures: inout FreeSet,
     inMutatingContext isContextMutating: Bool
   ) {
     collectCaptures(ofExpr: ast[id].tuple, into: &captures, inMutatingContext: false)
   }
 
-  private mutating func collectCaptures<T: PatternID>(
-    ofPattern id: T,
-    into captures: inout FreeSet
-  ) {
+  private mutating func collectCaptures<T: PatternID>(ofPattern id: T, into captures: inout FreeSet)
+  {
     switch id.kind {
     case BindingPattern.self:
       collectCaptures(ofBindingPattern: NodeID(rawValue: id.rawValue), into: &captures)
@@ -407,8 +369,7 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofBindingPattern id: NodeID<BindingPattern>,
-    into captures: inout FreeSet
+    ofBindingPattern id: NodeID<BindingPattern>, into captures: inout FreeSet
   ) {
     collectCaptures(ofPattern: ast[id].subpattern, into: &captures)
     if let annotation = ast[id].annotation {
@@ -417,16 +378,14 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofNamePattern id: NodeID<NamePattern>,
-    into captures: inout FreeSet
+    ofNamePattern id: NodeID<NamePattern>, into captures: inout FreeSet
   ) {
     let name = Name(stem: ast[ast[id].decl].name)
     boundNames[boundNames.count - 1].insert(name)
   }
 
   private mutating func collectCaptures(
-    ofTuplePattern id: NodeID<TuplePattern>,
-    into captures: inout FreeSet
+    ofTuplePattern id: NodeID<TuplePattern>, into captures: inout FreeSet
   ) {
     for element in ast[id].elements {
       collectCaptures(ofPattern: element.pattern, into: &captures)
@@ -434,10 +393,7 @@ struct CaptureCollector {
   }
 
   /// Collects the names occurring free in the specified statement.
-  private mutating func collectCaptures<T: StmtID>(
-    ofStmt id: T,
-    into captures: inout FreeSet
-  ) {
+  private mutating func collectCaptures<T: StmtID>(ofStmt id: T, into captures: inout FreeSet) {
     switch id.kind {
     case AssignStmt.self:
       collectCaptures(ofAssign: NodeID(rawValue: id.rawValue), into: &captures)
@@ -465,17 +421,14 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofAssign id: NodeID<AssignStmt>,
-    into captures: inout FreeSet
+    ofAssign id: NodeID<AssignStmt>, into captures: inout FreeSet
   ) {
     collectCaptures(ofExpr: ast[id].left, into: &captures, inMutatingContext: true)
     collectCaptures(ofExpr: ast[id].right, into: &captures, inMutatingContext: false)
   }
 
-  private mutating func collectCaptures(
-    ofBrace id: NodeID<BraceStmt>,
-    into captures: inout FreeSet
-  ) {
+  private mutating func collectCaptures(ofBrace id: NodeID<BraceStmt>, into captures: inout FreeSet)
+  {
     boundNames.append([])
     for stmt in ast[id].stmts {
       collectCaptures(ofStmt: stmt, into: &captures)
@@ -484,8 +437,7 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofDoWhile id: NodeID<DoWhileStmt>,
-    into captures: inout FreeSet
+    ofDoWhile id: NodeID<DoWhileStmt>, into captures: inout FreeSet
   ) {
     boundNames.append([])
     for stmt in ast[ast[id].body].stmts {
@@ -496,18 +448,15 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofReturn id: NodeID<ReturnStmt>,
-    into captures: inout FreeSet
+    ofReturn id: NodeID<ReturnStmt>, into captures: inout FreeSet
   ) {
     if let value = ast[id].value {
       collectCaptures(ofExpr: value, into: &captures, inMutatingContext: false)
     }
   }
 
-  private mutating func collectCaptures(
-    ofWhile id: NodeID<WhileStmt>,
-    into captures: inout FreeSet
-  ) {
+  private mutating func collectCaptures(ofWhile id: NodeID<WhileStmt>, into captures: inout FreeSet)
+  {
     boundNames.append([])
 
     // Visit the condition.
@@ -526,16 +475,13 @@ struct CaptureCollector {
     boundNames.removeLast()
   }
 
-  private mutating func collectCaptures(
-    ofYield id: NodeID<YieldStmt>,
-    into captures: inout FreeSet
-  ) {
+  private mutating func collectCaptures(ofYield id: NodeID<YieldStmt>, into captures: inout FreeSet)
+  {
     collectCaptures(ofExpr: ast[id].value, into: &captures, inMutatingContext: isYieldMutating)
   }
 
   private mutating func collectCaptures<T: TypeExprID>(
-    ofTypeExpr id: T,
-    into captures: inout FreeSet
+    ofTypeExpr id: T, into captures: inout FreeSet
   ) {
     switch id.kind {
     case NameExpr.self:
@@ -550,8 +496,7 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofNameType id: NodeID<NameExpr>,
-    into captures: inout FreeSet
+    ofNameType id: NodeID<NameExpr>, into captures: inout FreeSet
   ) {
     switch ast[id].domain {
     case .none, .implicit:
@@ -566,15 +511,13 @@ struct CaptureCollector {
   }
 
   private mutating func collectCaptures(
-    ofParameter id: NodeID<ParameterTypeExpr>,
-    into captures: inout FreeSet
+    ofParameter id: NodeID<ParameterTypeExpr>, into captures: inout FreeSet
   ) {
     collectCaptures(ofTypeExpr: ast[id].bareType, into: &captures)
   }
 
   private mutating func collectCaptures(
-    ofTupleType id: NodeID<TupleTypeExpr>,
-    into captures: inout FreeSet
+    ofTupleType id: NodeID<TupleTypeExpr>, into captures: inout FreeSet
   ) {
     for element in ast[id].elements {
       collectCaptures(ofTypeExpr: element.type, into: &captures)

--- a/Sources/Compiler/TypeChecking/ConstraintGenerator.swift
+++ b/Sources/Compiler/TypeChecking/ConstraintGenerator.swift
@@ -55,44 +55,32 @@ struct ConstraintGenerator {
     switch expr.kind {
     case BooleanLiteralExpr.self:
       return visit(booleanLiteral: NodeID(rawValue: expr.rawValue), using: &checker)
-    case CastExpr.self:
-      return visit(cast: NodeID(rawValue: expr.rawValue), using: &checker)
-    case CondExpr.self:
-      return visit(cond: NodeID(rawValue: expr.rawValue), using: &checker)
+    case CastExpr.self: return visit(cast: NodeID(rawValue: expr.rawValue), using: &checker)
+    case CondExpr.self: return visit(cond: NodeID(rawValue: expr.rawValue), using: &checker)
     case FloatLiteralExpr.self:
       return visit(floatLiteral: NodeID(rawValue: expr.rawValue), using: &checker)
-    case FunCallExpr.self:
-      return visit(funCall: NodeID(rawValue: expr.rawValue), using: &checker)
-    case InoutExpr.self:
-      return visit(`inout`: NodeID(rawValue: expr.rawValue), using: &checker)
+    case FunCallExpr.self: return visit(funCall: NodeID(rawValue: expr.rawValue), using: &checker)
+    case InoutExpr.self: return visit(`inout`: NodeID(rawValue: expr.rawValue), using: &checker)
     case IntegerLiteralExpr.self:
       return visit(integerLiteral: NodeID(rawValue: expr.rawValue), using: &checker)
-    case LambdaExpr.self:
-      return visit(lambda: NodeID(rawValue: expr.rawValue), using: &checker)
+    case LambdaExpr.self: return visit(lambda: NodeID(rawValue: expr.rawValue), using: &checker)
     case MapLiteralExpr.self:
       return visit(mapLiteral: NodeID(rawValue: expr.rawValue), using: &checker)
-    case MatchExpr.self:
-      return visit(match: NodeID(rawValue: expr.rawValue), using: &checker)
-    case NameExpr.self:
-      return visit(name: NodeID(rawValue: expr.rawValue), using: &checker)
-    case NilLiteralExpr.self:
-      return visit(nil: NodeID(rawValue: expr.rawValue), using: &checker)
-    case SequenceExpr.self:
-      return visit(sequence: NodeID(rawValue: expr.rawValue), using: &checker)
-    case SpawnExpr.self:
-      return visit(spawn: NodeID(rawValue: expr.rawValue), using: &checker)
+    case MatchExpr.self: return visit(match: NodeID(rawValue: expr.rawValue), using: &checker)
+    case NameExpr.self: return visit(name: NodeID(rawValue: expr.rawValue), using: &checker)
+    case NilLiteralExpr.self: return visit(nil: NodeID(rawValue: expr.rawValue), using: &checker)
+    case SequenceExpr.self: return visit(sequence: NodeID(rawValue: expr.rawValue), using: &checker)
+    case SpawnExpr.self: return visit(spawn: NodeID(rawValue: expr.rawValue), using: &checker)
     case StringLiteralExpr.self:
       return visit(stringLiteral: NodeID(rawValue: expr.rawValue), using: &checker)
     case SubscriptCallExpr.self:
       return visit(subscriptCall: NodeID(rawValue: expr.rawValue), using: &checker)
-    case TupleExpr.self:
-      return visit(tuple: NodeID(rawValue: expr.rawValue), using: &checker)
+    case TupleExpr.self: return visit(tuple: NodeID(rawValue: expr.rawValue), using: &checker)
     case TupleMemberExpr.self:
       return visit(tupleMember: NodeID(rawValue: expr.rawValue), using: &checker)
     case UnicodeScalarLiteralExpr.self:
       return visit(unicodeScalarLiteral: NodeID(rawValue: expr.rawValue), using: &checker)
-    default:
-      unreachable()
+    default: unreachable()
     }
   }
 
@@ -105,9 +93,7 @@ struct ConstraintGenerator {
 
   private mutating func visit(
     bufferLiteral id: NodeID<BufferLiteralExpr>, using checker: inout TypeChecker
-  ) {
-    fatalError("not implemented")
-  }
+  ) { fatalError("not implemented") }
 
   private mutating func visit(cast id: NodeID<CastExpr>, using checker: inout TypeChecker) {
     let node = checker.program.ast[id]
@@ -163,8 +149,7 @@ struct ConstraintGenerator {
         inferredTypes[expr] = ^boolType
         visit(expr: expr, using: &checker)
 
-      case .decl(let binding):
-        _ = checker.check(binding: binding)
+      case .decl(let binding): _ = checker.check(binding: binding)
       }
     }
 
@@ -194,8 +179,7 @@ struct ConstraintGenerator {
       assume(typeOf: id, equals: AnyType.void, at: checker.program.ast[id].origin)
       _ = checker.check(brace: thenBlock)
 
-    case nil:
-      assume(typeOf: id, equals: AnyType.void, at: checker.program.ast[id].origin)
+    case nil: assume(typeOf: id, equals: AnyType.void, at: checker.program.ast[id].origin)
     }
   }
 
@@ -205,9 +189,7 @@ struct ConstraintGenerator {
 
   private mutating func visit(
     floatLiteral id: NodeID<FloatLiteralExpr>, using checker: inout TypeChecker
-  ) {
-    fatalError("not implemented")
-  }
+  ) { fatalError("not implemented") }
 
   private mutating func visit(funCall id: NodeID<FunCallExpr>, using checker: inout TypeChecker) {
     defer { assert(inferredTypes[id] != nil) }
@@ -286,11 +268,9 @@ struct ConstraintGenerator {
           .diagnose(cannotConstructTrait: trait, at: checker.program.ast[callee].origin))
         assignToError(id)
 
-      case TypeAliasDecl.self:
-        fatalError("not implemented")
+      case TypeAliasDecl.self: fatalError("not implemented")
 
-      default:
-        unreachable("unexpected declaration")
+      default: unreachable("unexpected declaration")
       }
 
       return
@@ -432,9 +412,7 @@ struct ConstraintGenerator {
 
   private mutating func visit(
     mapLiteral i: NodeID<MapLiteralExpr>, using checker: inout TypeChecker
-  ) {
-    fatalError("not implemented")
-  }
+  ) { fatalError("not implemented") }
 
   private mutating func visit(match i: NodeID<MatchExpr>, using checker: inout TypeChecker) {
     fatalError("not implemented")
@@ -537,8 +515,7 @@ struct ConstraintGenerator {
             ofType: inferredType, because: cause))
       }
 
-    case .implicit:
-      fatalError("not implemented")
+    case .implicit: fatalError("not implemented")
     }
   }
 
@@ -567,14 +544,10 @@ struct ConstraintGenerator {
     case .infix(let callee, let lhs, let rhs):
       // Infer the types of the operands.
       let lhsType = visit(foldedSequence: lhs, expectingRootType: nil, using: &checker)
-      if lhsType.isError {
-        return .error
-      }
+      if lhsType.isError { return .error }
 
       let rhsType = visit(foldedSequence: rhs, expectingRootType: nil, using: &checker)
-      if rhsType.isError {
-        return .error
-      }
+      if rhsType.isError { return .error }
 
       // Infer the type of the callee.
       let parameterType = ^TypeVariable()
@@ -612,15 +585,11 @@ struct ConstraintGenerator {
 
   private mutating func visit(
     stringLiteral i: NodeID<StringLiteralExpr>, using checker: inout TypeChecker
-  ) {
-    fatalError("not implemented")
-  }
+  ) { fatalError("not implemented") }
 
   private mutating func visit(
     subscriptCall i: NodeID<SubscriptCallExpr>, using checker: inout TypeChecker
-  ) {
-    fatalError("not implemented")
-  }
+  ) { fatalError("not implemented") }
 
   private mutating func visit(tuple id: NodeID<TupleExpr>, using checker: inout TypeChecker) {
     defer { assert(inferredTypes[id] != nil) }
@@ -655,15 +624,11 @@ struct ConstraintGenerator {
 
   private mutating func visit(
     tupleMember id: NodeID<TupleMemberExpr>, using checker: inout TypeChecker
-  ) {
-    fatalError("not implemented")
-  }
+  ) { fatalError("not implemented") }
 
   private mutating func visit(
     unicodeScalarLiteral id: NodeID<UnicodeScalarLiteralExpr>, using checker: inout TypeChecker
-  ) {
-    fatalError("not implemented")
-  }
+  ) { fatalError("not implemented") }
 
   private mutating func propagateDown(
     callee: AnyExprID, calleeType: LambdaType, calleeTypeConstraints: ConstraintSet,
@@ -701,9 +666,7 @@ struct ConstraintGenerator {
           argumentType, parameterType,
           because: ConstraintCause(.argument, at: checker.program.ast[argumentExpr].origin)))
 
-      if let type = ParameterType(parameterType) {
-        expectedTypes[argumentExpr] = type.bareType
-      }
+      if let type = ParameterType(parameterType) { expectedTypes[argumentExpr] = type.bareType }
       visit(expr: argumentExpr, using: &checker)
     }
 
@@ -766,8 +729,6 @@ struct ConstraintGenerator {
     }
   }
 
-  private mutating func assignToError<ID: ExprID>(_ id: ID) {
-    inferredTypes[id] = .error
-  }
+  private mutating func assignToError<ID: ExprID>(_ id: ID) { inferredTypes[id] = .error }
 
 }

--- a/Sources/Compiler/TypeChecking/ConstraintSolver.swift
+++ b/Sources/Compiler/TypeChecking/ConstraintSolver.swift
@@ -41,9 +41,7 @@ struct ConstraintSolver {
   }
 
   /// Applies `self` to solve its constraints using `checker` to resolve names and realize types.
-  mutating func apply(using checker: inout TypeChecker) -> Solution {
-    solve(using: &checker)!
-  }
+  mutating func apply(using checker: inout TypeChecker) -> Solution { solve(using: &checker)! }
 
   /// Solves the constraints and returns the best solution, or `nil` if a better solution has
   /// already been computed.
@@ -53,24 +51,15 @@ struct ConstraintSolver {
       if score > best { return nil }
 
       switch constraint {
-      case let c as ConformanceConstraint:
-        solve(conformance: c, using: &checker)
-      case let c as EqualityConstraint:
-        solve(equality: c)
-      case let c as SubtypingConstraint:
-        solve(subtyping: c)
-      case let c as ParameterConstraint:
-        solve(parameter: c)
-      case let c as BoundMemberConstraint:
-        solve(boundMember: c, using: &checker)
-      case let c as UnboundMemberConstraint:
-        solve(unboundMember: c, using: &checker)
-      case let c as DisjunctionConstraint:
-        return solve(disjunction: c, using: &checker)
-      case let c as OverloadConstraint:
-        return solve(overload: c, using: &checker)
-      default:
-        unreachable()
+      case let c as ConformanceConstraint: solve(conformance: c, using: &checker)
+      case let c as EqualityConstraint: solve(equality: c)
+      case let c as SubtypingConstraint: solve(subtyping: c)
+      case let c as ParameterConstraint: solve(parameter: c)
+      case let c as BoundMemberConstraint: solve(boundMember: c, using: &checker)
+      case let c as UnboundMemberConstraint: solve(unboundMember: c, using: &checker)
+      case let c as DisjunctionConstraint: return solve(disjunction: c, using: &checker)
+      case let c as OverloadConstraint: return solve(overload: c, using: &checker)
+      default: unreachable()
       }
     }
 
@@ -100,8 +89,7 @@ struct ConstraintSolver {
         }
       }
 
-    default:
-      fatalError("not implemented")
+    default: fatalError("not implemented")
     }
   }
 
@@ -132,8 +120,7 @@ struct ConstraintSolver {
           .diagnose(labels: found, incompatibleWith: expected, at: constraint.cause.origin))
         return
 
-      case .compatible:
-        break
+      case .compatible: break
       }
 
       // Break down the constraint.
@@ -152,8 +139,7 @@ struct ConstraintSolver {
           .diagnose(labels: found, incompatibleWith: expected, at: constraint.cause.origin))
         return
 
-      case .compatible:
-        break
+      case .compatible: break
       }
 
       // Break down the constraint.
@@ -247,14 +233,11 @@ struct ConstraintSolver {
       if r == .any { return }
       fatalError("not implemented")
 
-    case (_, _ as LambdaType):
-      fatalError("not implemented")
+    case (_, _ as LambdaType): fatalError("not implemented")
 
-    case (_, _ as UnionType):
-      fatalError("not implemented")
+    case (_, _ as UnionType): fatalError("not implemented")
 
-    default:
-      diagnostics.append(.diagnose(type: l, isNotSubtypeOf: r, at: constraint.cause.origin))
+    default: diagnostics.append(.diagnose(type: l, isNotSubtypeOf: r, at: constraint.cause.origin))
     }
   }
 
@@ -276,8 +259,7 @@ struct ConstraintSolver {
       // arguments passed mutably is verified after type inference.
       schedule(equalityOrSubtypingConstraint(l, p.bareType, because: constraint.cause))
 
-    default:
-      diagnostics.append(.diagnose(invalidParameterType: r, at: constraint.cause.origin))
+    default: diagnostics.append(.diagnose(invalidParameterType: r, at: constraint.cause.origin))
     }
   }
 
@@ -300,9 +282,7 @@ struct ConstraintSolver {
 
     // Search for non-static members with the specified name.
     let allMatches = checker.lookup(constraint.member.stem, memberOf: l, inScope: scope)
-    let nonStaticMatches = allMatches.filter({ decl in
-      checker.program.isNonStaticMember(decl)
-    })
+    let nonStaticMatches = allMatches.filter({ decl in checker.program.isNonStaticMember(decl) })
 
     // Catch uses of static members on instances.
     if nonStaticMatches.isEmpty && !allMatches.isEmpty {
@@ -335,9 +315,7 @@ struct ConstraintSolver {
     // If there's only one candidate, solve an equality constraint direcly.
     if candidates.count == 1 {
       solve(equality: .init(candidates[0].type, r, because: constraint.cause))
-      if let name = constraint.memberExpr {
-        bindingAssumptions[name] = candidates[0].reference
-      }
+      if let name = constraint.memberExpr { bindingAssumptions[name] = candidates[0].reference }
       return
     }
 
@@ -400,9 +378,7 @@ struct ConstraintSolver {
     // If there's only one candidate, solve an equality constraint direcly.
     if candidates.count == 1 {
       solve(equality: .init(candidates[0].type, r, because: constraint.cause))
-      if let name = constraint.memberExpr {
-        bindingAssumptions[name] = .direct(candidates[0].decl)
-      }
+      if let name = constraint.memberExpr { bindingAssumptions[name] = .direct(candidates[0].decl) }
     }
 
     // TODO: Create an overload constraint
@@ -458,8 +434,7 @@ struct ConstraintSolver {
   private mutating func explore<C: Collection>(
     _ choices: C, cause: ConstraintCause?, using checker: inout TypeChecker,
     insertingConstraintsWith insertConstraints: (inout ConstraintSolver, C.Element) -> Void
-  ) -> (choice: C.Element, solution: Solution)?
-  where C.Element: Choice {
+  ) -> (choice: C.Element, solution: Solution)? where C.Element: Choice {
     /// The results of the exploration.
     var results: [(choice: C.Element, solution: Solution)] = []
 
@@ -467,9 +442,7 @@ struct ConstraintSolver {
       // Don't bother if there's no chance to find a better solution.
       var underestimatedChoiceScore = score
       underestimatedChoiceScore.penalties += choice.penalties
-      if underestimatedChoiceScore > best {
-        continue
-      }
+      if underestimatedChoiceScore > best { continue }
 
       // Explore the result of this choice.
       var subsolver = self
@@ -487,11 +460,9 @@ struct ConstraintSolver {
     }
 
     switch results.count {
-    case 0:
-      return nil
+    case 0: return nil
 
-    case 1:
-      return results[0]
+    case 1: return results[0]
 
     default:
       // TODO: Merge remaining solutions
@@ -501,22 +472,16 @@ struct ConstraintSolver {
   }
 
   /// Schedules `constraint` to be solved.
-  private mutating func schedule(_ constraint: Constraint) {
-    fresh.append(constraint)
-  }
+  private mutating func schedule(_ constraint: Constraint) { fresh.append(constraint) }
 
   /// Schedules `constraint` to be solved once the solver has inferred more information about its
   /// type variables.
-  private mutating func postpone(_ constraint: Constraint) {
-    stale.append(constraint)
-  }
+  private mutating func postpone(_ constraint: Constraint) { stale.append(constraint) }
 
   /// Moves the stale constraints depending on the specified variables back to the fresh set.
   private mutating func refresh(constraintsDependingOn variable: TypeVariable) {
     for i in (0..<stale.count).reversed() {
-      if stale[i].depends(on: variable) {
-        fresh.append(stale.remove(at: i))
-      }
+      if stale[i].depends(on: variable) { fresh.append(stale.remove(at: i)) }
     }
   }
 
@@ -527,9 +492,7 @@ struct ConstraintSolver {
       typeAssumptions: typeAssumptions.asDictionary(), bindingAssumptions: bindingAssumptions,
       penalties: penalties, diagnostics: diagnostics)
 
-    for c in stale {
-      s.addDiagnostic(.diagnose(staleConstraint: c))
-    }
+    for c in stale { s.addDiagnostic(.diagnose(staleConstraint: c)) }
 
     return s
   }
@@ -563,9 +526,7 @@ extension LabeledCollection {
   func testLabelCompatibility<T: LabeledCollection>(with other: T) -> LabelCompatibility {
     let (ls, rs) = (self.labels, other.labels)
 
-    if ls.count != rs.count {
-      return .differentLengths
-    }
+    if ls.count != rs.count { return .differentLengths }
     for (l, r) in zip(ls, rs) {
       if l != r { return .differentLabels(found: Array(ls), expected: Array(rs)) }
     }

--- a/Sources/Compiler/TypeChecking/Constraints/BoundMemberConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/BoundMemberConstraint.swift
@@ -18,9 +18,7 @@ struct BoundMemberConstraint: Constraint, Hashable {
 
   /// Creates an instance with the given properties.
   init(
-    type left: AnyType,
-    hasMemberNamed member: Name,
-    ofType right: AnyType,
+    type left: AnyType, hasMemberNamed member: Name, ofType right: AnyType,
     because cause: ConstraintCause
   ) {
     self.left = left
@@ -32,11 +30,8 @@ struct BoundMemberConstraint: Constraint, Hashable {
 
   /// Creates an instance with the given properties.
   init(
-    type left: AnyType,
-    hasMemberExpressedBy memberExpr: NodeID<NameExpr>,
-    in ast: AST,
-    ofType right: AnyType,
-    because cause: ConstraintCause
+    type left: AnyType, hasMemberExpressedBy memberExpr: NodeID<NameExpr>, in ast: AST,
+    ofType right: AnyType, because cause: ConstraintCause
   ) {
     self.left = left
     self.right = right

--- a/Sources/Compiler/TypeChecking/Constraints/BoundMemberConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/BoundMemberConstraint.swift
@@ -45,9 +45,7 @@ struct BoundMemberConstraint: Constraint, Hashable {
     modify(&right)
   }
 
-  func depends(on variable: TypeVariable) -> Bool {
-    (left == variable) || (right == variable)
-  }
+  func depends(on variable: TypeVariable) -> Bool { (left == variable) || (right == variable) }
 
 }
 

--- a/Sources/Compiler/TypeChecking/Constraints/ConformanceConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/ConformanceConstraint.swift
@@ -10,11 +10,7 @@ struct ConformanceConstraint: Constraint, Hashable {
   var cause: ConstraintCause
 
   /// Creates an instance with the given properties.
-  init(
-    _ subject: AnyType,
-    traits: Set<TraitType>,
-    because cause: ConstraintCause
-  ) {
+  init(_ subject: AnyType, traits: Set<TraitType>, because cause: ConstraintCause) {
     self.subject = subject
     self.traits = traits
     self.cause = cause

--- a/Sources/Compiler/TypeChecking/Constraints/ConformanceConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/ConformanceConstraint.swift
@@ -16,13 +16,9 @@ struct ConformanceConstraint: Constraint, Hashable {
     self.cause = cause
   }
 
-  mutating func modifyTypes(_ modify: (inout AnyType) -> Void) {
-    modify(&subject)
-  }
+  mutating func modifyTypes(_ modify: (inout AnyType) -> Void) { modify(&subject) }
 
-  func depends(on variable: TypeVariable) -> Bool {
-    subject == variable
-  }
+  func depends(on variable: TypeVariable) -> Bool { subject == variable }
 
 }
 

--- a/Sources/Compiler/TypeChecking/Constraints/Constraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/Constraint.swift
@@ -26,11 +26,7 @@ extension Constraint where Self: Equatable {
 
   /// Returns whether `self` is equal to `other`.
   public func equals<Other: Constraint>(_ other: Other) -> Bool {
-    if let r = other as? Self {
-      return self == r
-    } else {
-      return false
-    }
+    if let r = other as? Self { return self == r } else { return false }
   }
 
 }

--- a/Sources/Compiler/TypeChecking/Constraints/Constraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/Constraint.swift
@@ -36,15 +36,12 @@ extension Constraint where Self: Equatable {
 }
 
 /// Creates a subtyping or equality constraint.
-func equalityOrSubtypingConstraint(
-  _ l: AnyType,
-  _ r: AnyType,
-  because cause: ConstraintCause
-) -> DisjunctionConstraint {
+func equalityOrSubtypingConstraint(_ l: AnyType, _ r: AnyType, because cause: ConstraintCause)
+  -> DisjunctionConstraint
+{
   DisjunctionConstraint(
     choices: [
       .init(constraints: [EqualityConstraint(l, r, because: cause)], penalties: 0),
       .init(constraints: [SubtypingConstraint(l, r, because: cause)], penalties: 1),
-    ],
-    because: cause)
+    ], because: cause)
 }

--- a/Sources/Compiler/TypeChecking/Constraints/DisjunctionConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/DisjunctionConstraint.swift
@@ -35,8 +35,7 @@ struct DisjunctionConstraint: Constraint, Hashable {
       choices[i] = Choice(
         constraints: choices[i].constraints.reduce(
           into: [],
-          { (cs, c) in
-            var newConstraint = c
+          { (cs, c) in var newConstraint = c
             newConstraint.modifyTypes(modify)
             cs.insert(newConstraint)
           }), penalties: choices[i].penalties)
@@ -44,11 +43,7 @@ struct DisjunctionConstraint: Constraint, Hashable {
   }
 
   func depends(on variable: TypeVariable) -> Bool {
-    for m in choices {
-      for c in m.constraints {
-        if c.depends(on: variable) { return true }
-      }
-    }
+    for m in choices { for c in m.constraints { if c.depends(on: variable) { return true } } }
     return false
   }
 
@@ -56,16 +51,12 @@ struct DisjunctionConstraint: Constraint, Hashable {
 
 extension DisjunctionConstraint: CustomStringConvertible {
 
-  var description: String {
-    choices.descriptions(joinedBy: " ∨ ")
-  }
+  var description: String { choices.descriptions(joinedBy: " ∨ ") }
 
 }
 
 extension DisjunctionConstraint.Choice: CustomStringConvertible {
 
-  var description: String {
-    "{\(constraints.descriptions(joinedBy: " ∧ "))}:\(penalties)"
-  }
+  var description: String { "{\(constraints.descriptions(joinedBy: " ∧ "))}:\(penalties)" }
 
 }

--- a/Sources/Compiler/TypeChecking/Constraints/DisjunctionConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/DisjunctionConstraint.swift
@@ -39,8 +39,7 @@ struct DisjunctionConstraint: Constraint, Hashable {
             var newConstraint = c
             newConstraint.modifyTypes(modify)
             cs.insert(newConstraint)
-          }),
-        penalties: choices[i].penalties)
+          }), penalties: choices[i].penalties)
     }
   }
 

--- a/Sources/Compiler/TypeChecking/Constraints/EqualityConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/EqualityConstraint.swift
@@ -30,9 +30,7 @@ struct EqualityConstraint: Constraint, Hashable {
     modify(&right)
   }
 
-  func depends(on variable: TypeVariable) -> Bool {
-    (left == variable) || (right == variable)
-  }
+  func depends(on variable: TypeVariable) -> Bool { (left == variable) || (right == variable) }
 
 }
 

--- a/Sources/Compiler/TypeChecking/Constraints/OverloadConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/OverloadConstraint.swift
@@ -57,17 +57,14 @@ struct OverloadConstraint: Constraint, Hashable {
         reference: choices[i].reference, type: newType,
         constraints: choices[i].constraints.reduce(
           into: [],
-          { (cs, c) in
-            var newConstraint = c
+          { (cs, c) in var newConstraint = c
             newConstraint.modifyTypes(modify)
             cs.insert(newConstraint)
           }), penalties: choices[i].penalties)
     }
   }
 
-  func depends(on variable: TypeVariable) -> Bool {
-    overloadedExprType == variable
-  }
+  func depends(on variable: TypeVariable) -> Bool { overloadedExprType == variable }
 
 }
 

--- a/Sources/Compiler/TypeChecking/Constraints/OverloadConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/OverloadConstraint.swift
@@ -36,9 +36,7 @@ struct OverloadConstraint: Constraint, Hashable {
   ///
   /// - Requires: `candidates.count >= 2`
   init(
-    _ expr: NodeID<NameExpr>,
-    withType type: AnyType,
-    refersToOneOf choices: [Candidate],
+    _ expr: NodeID<NameExpr>, withType type: AnyType, refersToOneOf choices: [Candidate],
     because cause: ConstraintCause
   ) {
     precondition(choices.count >= 2)
@@ -56,16 +54,14 @@ struct OverloadConstraint: Constraint, Hashable {
       modify(&newType)
 
       choices[i] = Candidate(
-        reference: choices[i].reference,
-        type: newType,
+        reference: choices[i].reference, type: newType,
         constraints: choices[i].constraints.reduce(
           into: [],
           { (cs, c) in
             var newConstraint = c
             newConstraint.modifyTypes(modify)
             cs.insert(newConstraint)
-          }),
-        penalties: choices[i].penalties)
+          }), penalties: choices[i].penalties)
     }
   }
 

--- a/Sources/Compiler/TypeChecking/Constraints/ParameterConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/ParameterConstraint.swift
@@ -25,9 +25,7 @@ struct ParameterConstraint: Constraint, Hashable {
     modify(&right)
   }
 
-  func depends(on variable: TypeVariable) -> Bool {
-    (left == variable) || (right == variable)
-  }
+  func depends(on variable: TypeVariable) -> Bool { (left == variable) || (right == variable) }
 
 }
 

--- a/Sources/Compiler/TypeChecking/Constraints/SubtypingConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/SubtypingConstraint.swift
@@ -21,9 +21,7 @@ struct SubtypingConstraint: Constraint, Hashable {
     modify(&right)
   }
 
-  func depends(on variable: TypeVariable) -> Bool {
-    (left == variable) || (right == variable)
-  }
+  func depends(on variable: TypeVariable) -> Bool { (left == variable) || (right == variable) }
 
 }
 

--- a/Sources/Compiler/TypeChecking/Constraints/UnboundMemberConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/UnboundMemberConstraint.swift
@@ -45,9 +45,7 @@ struct UnboundMemberConstraint: Constraint, Hashable {
     modify(&right)
   }
 
-  func depends(on variable: TypeVariable) -> Bool {
-    (left == variable) || (right == variable)
-  }
+  func depends(on variable: TypeVariable) -> Bool { (left == variable) || (right == variable) }
 
 }
 

--- a/Sources/Compiler/TypeChecking/Constraints/UnboundMemberConstraint.swift
+++ b/Sources/Compiler/TypeChecking/Constraints/UnboundMemberConstraint.swift
@@ -18,9 +18,7 @@ struct UnboundMemberConstraint: Constraint, Hashable {
 
   /// Creates an instance with the given properties.
   init(
-    type left: AnyType,
-    hasMemberNamed member: Name,
-    ofType right: AnyType,
+    type left: AnyType, hasMemberNamed member: Name, ofType right: AnyType,
     because cause: ConstraintCause
   ) {
     self.left = left
@@ -32,11 +30,8 @@ struct UnboundMemberConstraint: Constraint, Hashable {
 
   /// Creates an instance with the given properties.
   init(
-    type left: AnyType,
-    hasMemberExpressedBy memberExpr: NodeID<NameExpr>,
-    in ast: AST,
-    ofType right: AnyType,
-    because cause: ConstraintCause
+    type left: AnyType, hasMemberExpressedBy memberExpr: NodeID<NameExpr>, in ast: AST,
+    ofType right: AnyType, because cause: ConstraintCause
   ) {
     self.left = left
     self.right = right

--- a/Sources/Compiler/TypeChecking/GenericEnvironment.swift
+++ b/Sources/Compiler/TypeChecking/GenericEnvironment.swift
@@ -31,28 +31,21 @@ struct GenericEnvironment {
       case let conformance as ConformanceConstraint:
         var allTraits: Set<TraitType> = []
         for trait in conformance.traits {
-          guard let bases = checker.conformedTraits(of: ^trait, inScope: scope)
-          else { return nil }
+          guard let bases = checker.conformedTraits(of: ^trait, inScope: scope) else { return nil }
           allTraits.formUnion(bases)
         }
         registerConformance(l: conformance.subject, traits: allTraits)
 
-      case is PredicateConstraint:
-        break
+      case is PredicateConstraint: break
 
-      default:
-        unreachable()
+      default: unreachable()
       }
     }
   }
 
   /// Returns the set of traits to which `type` conforms in the environment.
   func conformedTraits(of type: AnyType) -> Set<TraitType> {
-    if let i = ledger[type] {
-      return entries[i].conformances
-    } else {
-      return []
-    }
+    if let i = ledger[type] { return entries[i].conformances } else { return [] }
   }
 
   private mutating func registerEquivalence(l: AnyType, r: AnyType) {

--- a/Sources/Compiler/TypeChecking/Solution.swift
+++ b/Sources/Compiler/TypeChecking/Solution.swift
@@ -35,9 +35,7 @@ struct Solution {
     static let worst = Score(errorCount: Int.max, penalties: Int.max)
 
     static func < (l: Self, r: Self) -> Bool {
-      l.errorCount == r.errorCount
-        ? l.penalties < r.penalties
-        : l.errorCount < r.errorCount
+      l.errorCount == r.errorCount ? l.penalties < r.penalties : l.errorCount < r.errorCount
     }
 
   }
@@ -67,10 +65,8 @@ struct Solution {
           return .stepInto(t)
         } else {
           switch substitutionPolicy {
-          case .substituteByError:
-            return .stepInto(.error)
-          case .keep:
-            return .stepOver(type)
+          case .substituteByError: return .stepInto(.error)
+          case .keep: return .stepOver(type)
           }
         }
       } else {
@@ -83,8 +79,6 @@ struct Solution {
   }
 
   /// Adds `d` to the list of diagnostics associated with this solution.
-  internal mutating func addDiagnostic(_ d: Diagnostic) {
-    diagnostics.append(d)
-  }
+  internal mutating func addDiagnostic(_ d: Diagnostic) { diagnostics.append(d) }
 
 }

--- a/Sources/Compiler/TypeChecking/Solution.swift
+++ b/Sources/Compiler/TypeChecking/Solution.swift
@@ -2,10 +2,8 @@
 struct Solution {
 
   init(
-    typeAssumptions: [TypeVariable: AnyType],
-    bindingAssumptions: [NodeID<NameExpr>: DeclRef],
-    penalties: Int,
-    diagnostics: [Diagnostic]
+    typeAssumptions: [TypeVariable: AnyType], bindingAssumptions: [NodeID<NameExpr>: DeclRef],
+    penalties: Int, diagnostics: [Diagnostic]
   ) {
     self.typeAssumptions = typeAssumptions
     self.bindingAssumptions = bindingAssumptions

--- a/Sources/Compiler/TypeChecking/SubstitutionMap.swift
+++ b/Sources/Compiler/TypeChecking/SubstitutionMap.swift
@@ -11,13 +11,7 @@ struct SubstitutionMap {
   /// map. Otherwise, returns `type`.
   subscript(type: AnyType) -> AnyType {
     var walked = type
-    while let a = TypeVariable(walked) {
-      if let b = storage[a] {
-        walked = b
-      } else {
-        break
-      }
-    }
+    while let a = TypeVariable(walked) { if let b = storage[a] { walked = b } else { break } }
     return walked
   }
 

--- a/Sources/Compiler/TypeChecking/SubstitutionMap.swift
+++ b/Sources/Compiler/TypeChecking/SubstitutionMap.swift
@@ -54,8 +54,7 @@ extension SubstitutionMap: CustomReflectable {
 
   var customMirror: Mirror {
     Mirror(
-      self,
-      children: storage.map({ (key, value) in (label: "\(key)", value: value) }),
+      self, children: storage.map({ (key, value) in (label: "\(key)", value: value) }),
       displayStyle: .collection)
   }
 

--- a/Sources/Compiler/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/Compiler/TypeChecking/TypeChecker+Diagnostics.swift
@@ -29,9 +29,7 @@ extension Diagnostic {
 
   static func diagnose(conformanceToNonTraitType type: AnyType, at range: SourceRange?)
     -> Diagnostic
-  {
-    .error("conformance to non-trait type '\(type)'", range: range)
-  }
+  { .error("conformance to non-trait type '\(type)'", range: range) }
 
   static func diagnose(declarationRequiresBodyAt range: SourceRange?) -> Diagnostic {
     .error("declaration requires a body", range: range)
@@ -65,9 +63,7 @@ extension Diagnostic {
 
   static func diagnose(
     illegalParameterConvention convention: PassingConvention, at range: SourceRange?
-  ) -> Diagnostic {
-    .error("'\(convention)' may only be used on parameters", range: range)
-  }
+  ) -> Diagnostic { .error("'\(convention)' may only be used on parameters", range: range) }
 
   static func diagnose(
     labels found: [String?], incompatibleWith expected: [String?], at range: SourceRange?
@@ -89,9 +85,7 @@ extension Diagnostic {
 
   static func diagnose(type l: AnyType, incompatibleWith r: AnyType, at range: SourceRange?)
     -> Diagnostic
-  {
-    .error("incompatible types '\(l)' and '\(r)'", range: range)
-  }
+  { .error("incompatible types '\(l)' and '\(r)'", range: range) }
 
   static func diagnose(invalidUseOfAssociatedType name: String, at range: SourceRange?)
     -> Diagnostic
@@ -118,9 +112,7 @@ extension Diagnostic {
 
   static func diagnose(invalidDestructuringOfType type: AnyType, at range: SourceRange?)
     -> Diagnostic
-  {
-    .error("invalid destructuring of type '\(type)'", range: range)
-  }
+  { .error("invalid destructuring of type '\(type)'", range: range) }
 
   static func diagnose(invalidReferenceToSelfTypeAt range: SourceRange?) -> Diagnostic {
     .error("reference to 'Self' outside of a type context", range: range)
@@ -173,15 +165,11 @@ extension Diagnostic {
 
   static func diagnose(notEnoughContextToResolveMember name: Name, at range: SourceRange?)
     -> Diagnostic
-  {
-    .error("not enough contextual information to resolve member '\(name)'", range: range)
-  }
+  { .error("not enough contextual information to resolve member '\(name)'", range: range) }
 
   static func diagnose(type l: AnyType, isNotSubtypeOf r: AnyType, at range: SourceRange?)
     -> Diagnostic
-  {
-    .error("'\(l)' is not subtype of '\(r)'", range: range)
-  }
+  { .error("'\(l)' is not subtype of '\(r)'", range: range) }
 
   static func diagnose(noType name: Name, in domain: AnyType? = nil, at range: SourceRange?)
     -> Diagnostic
@@ -220,9 +208,7 @@ extension Diagnostic {
   }
 
   static func diagnose(argumentToNonGenericType type: AnyType, at range: SourceRange?) -> Diagnostic
-  {
-    .error("non-generic type 'type' has no generic parameters", range: range)
-  }
+  { .error("non-generic type 'type' has no generic parameters", range: range) }
 
   static func diagnose(metatypeRequiresOneArgumentAt range: SourceRange?) -> Diagnostic {
     .error("reference to 'Metatype' requires exacly one static argument", range: range)
@@ -230,8 +216,6 @@ extension Diagnostic {
 
   static func diagnose(tooManyAnnotationsOnGenericValueParametersAt range: SourceRange?)
     -> Diagnostic
-  {
-    .error("only one annotation is allowed on generic value parameter declarations", range: range)
-  }
+  { .error("only one annotation is allowed on generic value parameter declarations", range: range) }
 
 }

--- a/Sources/Compiler/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/Compiler/TypeChecking/TypeChecker+Diagnostics.swift
@@ -1,270 +1,191 @@
 extension Diagnostic {
 
-  static func diagnose(
-    ambiguousDisjunctionAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(ambiguousDisjunctionAt range: SourceRange?) -> Diagnostic {
     .error("ambiguous disjunction", range: range)
   }
 
-  static func diagnose(
-    ambiguousUse expr: NodeID<NameExpr>,
-    in ast: AST
-  ) -> Diagnostic {
+  static func diagnose(ambiguousUse expr: NodeID<NameExpr>, in ast: AST) -> Diagnostic {
     .error("ambiguous use of '\(ast[expr].name.value)'", range: ast[expr].origin)
   }
 
-  static func diagnose(
-    circularRefinementAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(circularRefinementAt range: SourceRange?) -> Diagnostic {
     .error("circular trait refinement", range: range)
   }
 
-  static func diagnose(
-    circularDependencyAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(circularDependencyAt range: SourceRange?) -> Diagnostic {
     .error("circular dependency", range: range)
   }
 
-  static func diagnose(
-    cannotConstructTrait trait: TraitType,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(cannotConstructTrait trait: TraitType, at range: SourceRange?) -> Diagnostic
+  {
     .error(
-      "cannot construct an instance of trait '\(trait)'; did you mean 'any \(trait)'?",
-      range: range)
+      "cannot construct an instance of trait '\(trait)'; did you mean 'any \(trait)'?", range: range
+    )
   }
 
-  static func diagnose(
-    cannotInferComplexReturnTypeAt range: SourceRange?
-  ) -> Diagnostic {
-    .error(
-      "cannot infer complex return type; add an explicit return type annotation",
-      range: range)
+  static func diagnose(cannotInferComplexReturnTypeAt range: SourceRange?) -> Diagnostic {
+    .error("cannot infer complex return type; add an explicit return type annotation", range: range)
   }
 
-  static func diagnose(
-    conformanceToNonTraitType type: AnyType,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(conformanceToNonTraitType type: AnyType, at range: SourceRange?)
+    -> Diagnostic
+  {
     .error("conformance to non-trait type '\(type)'", range: range)
   }
 
-  static func diagnose(
-    declarationRequiresBodyAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(declarationRequiresBodyAt range: SourceRange?) -> Diagnostic {
     .error("declaration requires a body", range: range)
   }
 
-  static func diagnose(
-    duplicateCaptureNamed name: String,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(duplicateCaptureNamed name: String, at range: SourceRange?) -> Diagnostic {
     .error("duplicate capture name '\(name)'", range: range)
   }
 
-  static func diagnose(
-    duplicateOperatorNamed name: String,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(duplicateOperatorNamed name: String, at range: SourceRange?) -> Diagnostic {
     .error("duplicate operator declaration '\(name)'", range: range)
   }
 
-  static func diganose(
-    duplicateParameterNamed name: String,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diganose(duplicateParameterNamed name: String, at range: SourceRange?) -> Diagnostic {
     .error("duplicate parameter name '\(name)'", range: range)
   }
 
-  static func diagnose(
-    nameRefersToValue expr: NodeID<NameExpr>,
-    in ast: AST
-  ) -> Diagnostic {
-    .error(
-      "expected type but '\(ast[expr].name.value)' refers to a value",
-      range: ast[expr].origin)
+  static func diagnose(nameRefersToValue expr: NodeID<NameExpr>, in ast: AST) -> Diagnostic {
+    .error("expected type but '\(ast[expr].name.value)' refers to a value", range: ast[expr].origin)
   }
 
-  static func diagnose(
-    genericDeclHasCapturesAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(genericDeclHasCapturesAt range: SourceRange?) -> Diagnostic {
     .error("generic declaration has captures", range: range)
   }
 
-  static func diagnose(
-    illegalMemberwiseInitAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(illegalMemberwiseInitAt range: SourceRange?) -> Diagnostic {
     .error(
-      "memberwise initializer declaration may only appear in product type declaration",
-      range: range)
+      "memberwise initializer declaration may only appear in product type declaration", range: range
+    )
   }
 
   static func diagnose(
-    illegalParameterConvention convention: PassingConvention,
-    at range: SourceRange?
+    illegalParameterConvention convention: PassingConvention, at range: SourceRange?
   ) -> Diagnostic {
     .error("'\(convention)' may only be used on parameters", range: range)
   }
 
   static func diagnose(
-    labels found: [String?],
-    incompatibleWith expected: [String?],
-    at range: SourceRange?
+    labels found: [String?], incompatibleWith expected: [String?], at range: SourceRange?
   ) -> Diagnostic {
     .error(
       """
       incompatible labels: found '(\(Name.describe(labels: found)))', \
       expected '(\(Name.describe(labels: expected)))'
-      """,
-      range: range)
+      """, range: range)
   }
 
-  static func diagnose(
-    incompatibleParameterCountAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(incompatibleParameterCountAt range: SourceRange?) -> Diagnostic {
     .error("incompatible number of parameters", range: range)
   }
 
-  static func diagnose(
-    incompatibleTupleLengthsAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(incompatibleTupleLengthsAt range: SourceRange?) -> Diagnostic {
     .error("tuples have different lengths", range: range)
   }
 
-  static func diagnose(
-    type l: AnyType,
-    incompatibleWith r: AnyType,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(type l: AnyType, incompatibleWith r: AnyType, at range: SourceRange?)
+    -> Diagnostic
+  {
     .error("incompatible types '\(l)' and '\(r)'", range: range)
   }
 
-  static func diagnose(
-    invalidUseOfAssociatedType name: String,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(invalidUseOfAssociatedType name: String, at range: SourceRange?)
+    -> Diagnostic
+  {
     .error(
       "associated type '\(name)' can only be used with a concrete type or generic type parameter",
       range: range)
   }
 
-  static func diagnose(
-    expectedLambdaParameterCount: Int,
-    found: Int,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(expectedLambdaParameterCount: Int, found: Int, at range: SourceRange?)
+    -> Diagnostic
+  {
     .error(
       """
       contextual lambda type requires \(expectedLambdaParameterCount) argument(s), found \(found)
-      """,
-      range: range)
+      """, range: range)
   }
 
   static func diagnose(
-    inoutCapableMethodBundleMustReturn expectedReturnType: AnyType,
-    at range: SourceRange?
+    inoutCapableMethodBundleMustReturn expectedReturnType: AnyType, at range: SourceRange?
   ) -> Diagnostic {
     .error("inout-capable method bundle must return '\(expectedReturnType)'", range: range)
   }
 
-  static func diagnose(
-    invalidDestructuringOfType type: AnyType,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(invalidDestructuringOfType type: AnyType, at range: SourceRange?)
+    -> Diagnostic
+  {
     .error("invalid destructuring of type '\(type)'", range: range)
   }
 
-  static func diagnose(
-    invalidReferenceToSelfTypeAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(invalidReferenceToSelfTypeAt range: SourceRange?) -> Diagnostic {
     .error("reference to 'Self' outside of a type context", range: range)
   }
 
-  static func diagnose(
-    invalidParameterType type: AnyType,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(invalidParameterType type: AnyType, at range: SourceRange?) -> Diagnostic {
     .error("invalid parameter type '\(type)'", range: range)
   }
 
-  static func diagnose(
-    missingReturnValueAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(missingReturnValueAt range: SourceRange?) -> Diagnostic {
     .error("non-void function should return a value", range: range)
   }
 
-  static func diagnose(
-    notATrait type: AnyType,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(notATrait type: AnyType, at range: SourceRange?) -> Diagnostic {
     .error("type '\(type)' is not a trait", range: range)
   }
 
   static func diagnose(
-    _ type: AnyType,
-    doesNotConformTo trait: TraitType,
-    at range: SourceRange?,
+    _ type: AnyType, doesNotConformTo trait: TraitType, at range: SourceRange?,
     because children: [Diagnostic] = []
   ) -> Diagnostic {
-    .error(
-      "type '\(type)' does not conform to trait '\(trait)'",
-      range: range,
-      children: children)
+    .error("type '\(type)' does not conform to trait '\(trait)'", range: range, children: children)
   }
 
-  static func diagnose(
-    invalidConformanceConstraintTo type: AnyType,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(invalidConformanceConstraintTo type: AnyType, at range: SourceRange?)
+    -> Diagnostic
+  {
     .error(
       """
       type '\(type)' in conformance constraint does not refers to a generic parameter or \
       associated type
-      """,
-      range: range)
+      """, range: range)
   }
 
   static func diagnose(
-    invalidEqualityConstraintBetween l: AnyType,
-    and r: AnyType,
-    at range: SourceRange?
+    invalidEqualityConstraintBetween l: AnyType, and r: AnyType, at range: SourceRange?
   ) -> Diagnostic {
     .error(
       """
       neither type in equality constraint ('\(l)' or '\(r)') refers to a generic parameter or \
       associated type
-      """,
-      range: range)
+      """, range: range)
   }
 
-  static func diagnose(
-    notEnoughContextToInferArgumentsAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(notEnoughContextToInferArgumentsAt range: SourceRange?) -> Diagnostic {
     .error(
-      "not enough contextual information to infer the arguments to generic parameters",
-      range: range)
+      "not enough contextual information to infer the arguments to generic parameters", range: range
+    )
   }
 
-  static func diagnose(
-    notEnoughContextToResolveMember name: Name,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(notEnoughContextToResolveMember name: Name, at range: SourceRange?)
+    -> Diagnostic
+  {
     .error("not enough contextual information to resolve member '\(name)'", range: range)
   }
 
-  static func diagnose(
-    type l: AnyType,
-    isNotSubtypeOf r: AnyType,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(type l: AnyType, isNotSubtypeOf r: AnyType, at range: SourceRange?)
+    -> Diagnostic
+  {
     .error("'\(l)' is not subtype of '\(r)'", range: range)
   }
 
-  static func diagnose(
-    noType name: Name,
-    in domain: AnyType? = nil,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(noType name: Name, in domain: AnyType? = nil, at range: SourceRange?)
+    -> Diagnostic
+  {
     if let domain = domain {
       return .error("type '\(domain)' has no type member '\(name.stem)'", range: range)
     } else {
@@ -272,66 +193,44 @@ extension Diagnostic {
     }
   }
 
-  static func diagnose(
-    traitRequiresMethod name: Name,
-    withType type: AnyType
-  ) -> Diagnostic {
+  static func diagnose(traitRequiresMethod name: Name, withType type: AnyType) -> Diagnostic {
     .error("trait requires method '\(name)' with type '\(type)'")
   }
 
-  static func diagnose(
-    staleConstraint c: any Constraint
-  ) -> Diagnostic {
+  static func diagnose(staleConstraint c: any Constraint) -> Diagnostic {
     .error("stale constraint '\(c)'")
   }
 
   static func diagnose(
-    illegalUseOfStaticMember name: Name,
-    onInstanceOf: AnyType,
-    at range: SourceRange?
+    illegalUseOfStaticMember name: Name, onInstanceOf: AnyType, at range: SourceRange?
   ) -> Diagnostic {
-    .error(
-      "static member '\(name)' cannot be used on instance of '\(onInstanceOf)'",
-      range: range)
+    .error("static member '\(name)' cannot be used on instance of '\(onInstanceOf)'", range: range)
   }
 
-  static func diagnose(
-    undefinedName: String,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(undefinedName: String, at range: SourceRange?) -> Diagnostic {
     .error("undefined name '\(undefinedName)' in this scope", range: range)
   }
 
-  static func diagnose(
-    undefinedOperator name: String,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(undefinedOperator name: String, at range: SourceRange?) -> Diagnostic {
     .error("undefined operator '\(name)'", range: range)
   }
 
-  static func diagnose(
-    unusedResultOfType type: AnyType,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(unusedResultOfType type: AnyType, at range: SourceRange?) -> Diagnostic {
     .warning("unused result of type '\(type)'", range: range)
   }
 
-  static func diagnose(
-    argumentToNonGenericType type: AnyType,
-    at range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(argumentToNonGenericType type: AnyType, at range: SourceRange?) -> Diagnostic
+  {
     .error("non-generic type 'type' has no generic parameters", range: range)
   }
 
-  static func diagnose(
-    metatypeRequiresOneArgumentAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(metatypeRequiresOneArgumentAt range: SourceRange?) -> Diagnostic {
     .error("reference to 'Metatype' requires exacly one static argument", range: range)
   }
 
-  static func diagnose(
-    tooManyAnnotationsOnGenericValueParametersAt range: SourceRange?
-  ) -> Diagnostic {
+  static func diagnose(tooManyAnnotationsOnGenericValueParametersAt range: SourceRange?)
+    -> Diagnostic
+  {
     .error("only one annotation is allowed on generic value parameter declarations", range: range)
   }
 

--- a/Sources/Compiler/TypedNode.swift
+++ b/Sources/Compiler/TypedNode.swift
@@ -10,8 +10,7 @@ extension AST {
 
 /// A projection from a `TypedProgram` of an AST node along with all the non-syntax information
 /// related to that node.
-@dynamicMemberLookup
-public struct TypedNode<ID: NodeIDProtocol>: Hashable {
+@dynamicMemberLookup public struct TypedNode<ID: NodeIDProtocol>: Hashable {
 
   /// The whole program of which this node is a notional part.
   fileprivate let whole: TypedProgram
@@ -20,14 +19,10 @@ public struct TypedNode<ID: NodeIDProtocol>: Hashable {
   let id: ID
 
   /// Equality comparison; only check the node ID.
-  public static func == (lhs: TypedNode<ID>, rhs: TypedNode<ID>) -> Bool {
-    lhs.id == rhs.id
-  }
+  public static func == (lhs: TypedNode<ID>, rhs: TypedNode<ID>) -> Bool { lhs.id == rhs.id }
 
   /// Hashes the value of `id` into `hasher`.
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(id)
-  }
+  public func hash(into hasher: inout Hasher) { hasher.combine(id) }
 
 }
 
@@ -44,42 +39,31 @@ extension TypedProgram {
 extension TypedNode where ID: ConcreteNodeID {
 
   /// The corresponding AST node.
-  private var syntax: ID.Subject {
-    whole.ast[NodeID(id)!]
-  }
+  private var syntax: ID.Subject { whole.ast[NodeID(id)!] }
 
   /// Accesses the given member of the corresponding AST node.
-  subscript<Target>(dynamicMember m: KeyPath<ID.Subject, Target>) -> Target {
-    syntax[keyPath: m]
-  }
+  subscript<Target>(dynamicMember m: KeyPath<ID.Subject, Target>) -> Target { syntax[keyPath: m] }
 
   /// Accesses the given member of the corresponding AST node as a corresponding
   /// `TypedNode`
   subscript<TargetID: NodeIDProtocol>(dynamicMember m: KeyPath<ID.Subject, TargetID>) -> TypedNode<
     TargetID
-  > {
-    .init(whole: whole, id: syntax[keyPath: m])
-  }
+  > { .init(whole: whole, id: syntax[keyPath: m]) }
 
   /// Accesses the given member of the corresponding AST node as a corresponding lazy collection
   /// of `TypedNode`s.
   subscript<TargetID: NodeIDProtocol>(dynamicMember m: KeyPath<ID.Subject, [TargetID]>)
     -> LazyMapCollection<[TargetID], TypedNode<TargetID>>
-  {
-    syntax[keyPath: m].lazy.map { .init(whole: whole, id: $0) }
-  }
+  { syntax[keyPath: m].lazy.map { .init(whole: whole, id: $0) } }
 
   /// Accesses the given member of the corresponding AST node as a corresponding `TypedNode?`
   subscript<TargetID: NodeIDProtocol>(dynamicMember m: KeyPath<ID.Subject, TargetID?>) -> TypedNode<
     TargetID
-  >? {
-    syntax[keyPath: m].map { .init(whole: whole, id: $0) }
-  }
+  >? { syntax[keyPath: m].map { .init(whole: whole, id: $0) } }
 
   /// Creates an instance denoting the same node as `s`, or fails if `s` does not refer to a
   /// `Target` node.
-  init?<SourceID, Target>(_ s: TypedNode<SourceID>)
-  where ID == NodeID<Target> {
+  init?<SourceID, Target>(_ s: TypedNode<SourceID>) where ID == NodeID<Target> {
     guard let myID = NodeID<ID.Subject>(s.id) else { return nil }
     whole = s.whole
     id = .init(myID)
@@ -95,9 +79,7 @@ extension TypedNode {
 
 extension TypedNode where ID: ScopeID {
   /// The parent scope, if any
-  var parent: TypedNode<AnyScopeID>? {
-    whole.scopeToParent[id].map { .init(whole: whole, id: $0) }
-  }
+  var parent: TypedNode<AnyScopeID>? { whole.scopeToParent[id].map { .init(whole: whole, id: $0) } }
 
   /// The declarations in this immediate scope.
   var decls: LazyMapCollection<[AnyDeclID], TypedNode<AnyDeclID>> {
@@ -107,35 +89,25 @@ extension TypedNode where ID: ScopeID {
 
 extension TypedNode where ID: DeclID {
   /// The scope in which this declaration resides.
-  var scope: TypedNode<AnyScopeID> {
-    .init(whole: whole, id: whole.declToScope[id]!)
-  }
+  var scope: TypedNode<AnyScopeID> { .init(whole: whole, id: whole.declToScope[id]!) }
 
   /// The type of the declared entity.
-  var type: AnyType {
-    whole.declTypes[id]!
-  }
+  var type: AnyType { whole.declTypes[id]! }
 }
 
 extension TypedNode where ID == NodeID<VarDecl> {
   /// The binding decl containing this var.
-  var binding: Typed<BindingDecl> {
-    .init(whole: whole, id: whole.varToBinding[id]!)
-  }
+  var binding: Typed<BindingDecl> { .init(whole: whole, id: whole.varToBinding[id]!) }
 }
 
 extension TypedNode where ID: ExprID {
   /// The type of this expression
-  var type: AnyType {
-    whole.exprTypes[id]!
-  }
+  var type: AnyType { whole.exprTypes[id]! }
 }
 
 extension TypedNode where ID == NodeID<NameExpr> {
   /// The declaration of this name.
-  var decl: DeclRef {
-    whole.referredDecls[id]!
-  }
+  var decl: DeclRef { whole.referredDecls[id]! }
 }
 
 extension TypedNode where ID: PatternID {
@@ -148,17 +120,11 @@ extension TypedNode where ID: PatternID {
 extension TypedNode where ID == NodeID<ModuleDecl> {
   /// Collection of (typed) top-level declarations of the module.
   typealias TopLevelDecls = LazyMapSequence<
-    FlattenSequence<
-      LazyMapSequence<
-        [NodeID<TopLevelDeclSet>], [AnyDeclID]
-      >
-    >, TypedNode<AnyDeclID>
+    FlattenSequence<LazyMapSequence<[NodeID<TopLevelDeclSet>], [AnyDeclID]>>, TypedNode<AnyDeclID>
   >
 
   /// The top-level declarations in the module.
-  var topLevelDecls: TopLevelDecls {
-    whole.ast.topLevelDecls(id).map({ whole[$0] })
-  }
+  var topLevelDecls: TopLevelDecls { whole.ast.topLevelDecls(id).map({ whole[$0] }) }
 }
 
 extension TypedNode where ID == NodeID<FunctionDecl> {
@@ -176,14 +142,11 @@ extension TypedNode where ID == NodeID<FunctionDecl> {
   /// The body of the declaration, if any (in typed formed).
   var body: Body? {
     switch syntax.body {
-    case .expr(let expr):
-      return .expr(whole[expr])
+    case .expr(let expr): return .expr(whole[expr])
 
-    case .block(let stmt):
-      return .block(whole[stmt])
+    case .block(let stmt): return .block(whole[stmt])
 
-    case .none:
-      return .none
+    case .none: return .none
     }
   }
 }

--- a/Sources/Compiler/TypedNode.swift
+++ b/Sources/Compiler/TypedNode.swift
@@ -55,24 +55,24 @@ extension TypedNode where ID: ConcreteNodeID {
 
   /// Accesses the given member of the corresponding AST node as a corresponding
   /// `TypedNode`
-  subscript<TargetID: NodeIDProtocol>(
-    dynamicMember m: KeyPath<ID.Subject, TargetID>
-  ) -> TypedNode<TargetID> {
+  subscript<TargetID: NodeIDProtocol>(dynamicMember m: KeyPath<ID.Subject, TargetID>) -> TypedNode<
+    TargetID
+  > {
     .init(whole: whole, id: syntax[keyPath: m])
   }
 
   /// Accesses the given member of the corresponding AST node as a corresponding lazy collection
   /// of `TypedNode`s.
-  subscript<TargetID: NodeIDProtocol>(
-    dynamicMember m: KeyPath<ID.Subject, [TargetID]>
-  ) -> LazyMapCollection<[TargetID], TypedNode<TargetID>> {
+  subscript<TargetID: NodeIDProtocol>(dynamicMember m: KeyPath<ID.Subject, [TargetID]>)
+    -> LazyMapCollection<[TargetID], TypedNode<TargetID>>
+  {
     syntax[keyPath: m].lazy.map { .init(whole: whole, id: $0) }
   }
 
   /// Accesses the given member of the corresponding AST node as a corresponding `TypedNode?`
-  subscript<TargetID: NodeIDProtocol>(
-    dynamicMember m: KeyPath<ID.Subject, TargetID?>
-  ) -> TypedNode<TargetID>? {
+  subscript<TargetID: NodeIDProtocol>(dynamicMember m: KeyPath<ID.Subject, TargetID?>) -> TypedNode<
+    TargetID
+  >? {
     syntax[keyPath: m].map { .init(whole: whole, id: $0) }
   }
 
@@ -150,11 +150,9 @@ extension TypedNode where ID == NodeID<ModuleDecl> {
   typealias TopLevelDecls = LazyMapSequence<
     FlattenSequence<
       LazyMapSequence<
-        [NodeID<TopLevelDeclSet>],
-        [AnyDeclID]
+        [NodeID<TopLevelDeclSet>], [AnyDeclID]
       >
-    >,
-    TypedNode<AnyDeclID>
+    >, TypedNode<AnyDeclID>
   >
 
   /// The top-level declarations in the module.

--- a/Sources/Compiler/TypedProgram.swift
+++ b/Sources/Compiler/TypedProgram.swift
@@ -28,10 +28,8 @@ public struct TypedProgram: Program {
 
   /// Creates a typed program from a scoped program and property maps describing type annotations.
   public init(
-    annotating program: ScopedProgram,
-    declTypes: DeclProperty<AnyType>,
-    exprTypes: ExprProperty<AnyType>,
-    implicitCaptures: DeclProperty<[ImplicitCapture]>,
+    annotating program: ScopedProgram, declTypes: DeclProperty<AnyType>,
+    exprTypes: ExprProperty<AnyType>, implicitCaptures: DeclProperty<[ImplicitCapture]>,
     referredDecls: [NodeID<NameExpr>: DeclRef],
     foldedSequenceExprs: [NodeID<SequenceExpr>: FoldedSequenceExpr]
   ) {

--- a/Sources/Compiler/Types/AnyType.swift
+++ b/Sources/Compiler/Types/AnyType.swift
@@ -27,21 +27,13 @@ private struct ConcreteTypeBox<Base: TypeProtocol>: TypeBox {
   /// The value wrapped by this instance.
   let base: Base
 
-  func hash(into hasher: inout Hasher) {
-    base.hash(into: &hasher)
-  }
+  func hash(into hasher: inout Hasher) { base.hash(into: &hasher) }
 
-  func equals<Other: TypeBox>(_ other: Other) -> Bool {
-    base == other.unwrap(as: Base.self)
-  }
+  func equals<Other: TypeBox>(_ other: Other) -> Bool { base == other.unwrap(as: Base.self) }
 
-  func unwrap() -> any TypeProtocol {
-    base
-  }
+  func unwrap() -> any TypeProtocol { base }
 
-  func unwrap<T: TypeProtocol>(as: T.Type) -> T? {
-    base as? T
-  }
+  func unwrap<T: TypeProtocol>(as: T.Type) -> T? { base as? T }
 
   func transformParts(_ transformer: (AnyType) -> TypeTransformAction) -> any TypeProtocol {
     base.transformParts(transformer)
@@ -95,19 +87,14 @@ public struct AnyType: TypeProtocol {
   /// A leaf type is a type whose only subtypes are itself and `Never`.
   public var isLeaf: Bool {
     switch base {
-    case is ExistentialType, is LambdaType, is TypeVariable:
-      return false
-    case let type as UnionType:
-      return type.elements.isEmpty
-    default:
-      return true
+    case is ExistentialType, is LambdaType, is TypeVariable: return false
+    case let type as UnionType: return type.elements.isEmpty
+    default: return true
     }
   }
 
   /// Indicates whether `self` is the error type.
-  public var isError: Bool {
-    base is ErrorType
-  }
+  public var isError: Bool { base is ErrorType }
 
   /// Indicates whether `self` is a generic type parameter or associated type.
   public var isTypeParam: Bool {
@@ -117,12 +104,9 @@ public struct AnyType: TypeProtocol {
   /// Indicates whether `self` has a record layout.
   public var hasRecordLayout: Bool {
     switch base {
-    case is ProductType, is TupleType:
-      return true
-    case let type as BoundGenericType:
-      return type.base.hasRecordLayout
-    default:
-      return false
+    case is ProductType, is TupleType: return true
+    case let type as BoundGenericType: return type.base.hasRecordLayout
+    default: return false
     }
   }
 
@@ -139,9 +123,7 @@ public struct AnyType: TypeProtocol {
 extension AnyType: Equatable {
 
   /// Returns whether `l` is equal to `r`.
-  public static func == (l: Self, r: Self) -> Bool {
-    l.wrapped.equals(r.wrapped)
-  }
+  public static func == (l: Self, r: Self) -> Bool { l.wrapped.equals(r.wrapped) }
 
   /// Returns whether `l` is equal to `r`.
   public static func == <T: TypeProtocol>(l: Self, r: T) -> Bool {
@@ -149,9 +131,7 @@ extension AnyType: Equatable {
   }
 
   /// Returns whether `l` is not equal to `r`.
-  public static func != <T: TypeProtocol>(l: Self, r: T) -> Bool {
-    !(l == r)
-  }
+  public static func != <T: TypeProtocol>(l: Self, r: T) -> Bool { !(l == r) }
 
   /// Returns whether `l` is equal to `r`.
   public static func == <T: TypeProtocol>(l: T, r: Self) -> Bool {
@@ -159,9 +139,7 @@ extension AnyType: Equatable {
   }
 
   /// Returns whether `l` is not equal to `r`.
-  public static func != <T: TypeProtocol>(l: T, r: Self) -> Bool {
-    !(l == r)
-  }
+  public static func != <T: TypeProtocol>(l: T, r: Self) -> Bool { !(l == r) }
 
   /// Returns whether `subject` matches `pattern`.
   ///
@@ -178,17 +156,13 @@ extension AnyType: Equatable {
   ///         print("type is neither 'Any' nor 'Never'")
   ///       }
   ///     }
-  public static func ~= (pattern: Self, subject: any TypeProtocol) -> Bool {
-    pattern == subject
-  }
+  public static func ~= (pattern: Self, subject: any TypeProtocol) -> Bool { pattern == subject }
 
 }
 
 extension AnyType: Hashable {
 
-  public func hash(into hasher: inout Hasher) {
-    wrapped.hash(into: &hasher)
-  }
+  public func hash(into hasher: inout Hasher) { wrapped.hash(into: &hasher) }
 
 }
 
@@ -205,6 +179,4 @@ extension AnyType: CustomReflectable {
 }
 
 /// Creates a type-erased container wrapping the given instance.
-public prefix func ^ <T: TypeProtocol>(_ base: T) -> AnyType {
-  AnyType(base)
-}
+public prefix func ^ <T: TypeProtocol>(_ base: T) -> AnyType { AnyType(base) }

--- a/Sources/Compiler/Types/AssociatedTypeType.swift
+++ b/Sources/Compiler/Types/AssociatedTypeType.swift
@@ -21,8 +21,7 @@ public struct AssociatedTypeType: TypeProtocol {
     switch domain.base {
     case is AssociatedTypeType, is ConformanceLensType, is GenericTypeParameterType:
       self.domain = domain
-    default:
-      preconditionFailure("invalid associated type domain")
+    default: preconditionFailure("invalid associated type domain")
     }
 
     self.decl = decl
@@ -39,18 +38,15 @@ public struct AssociatedTypeType: TypeProtocol {
 
     while true {
       switch current.base {
-      case is GenericTypeParameterType:
-        return result
+      case is GenericTypeParameterType: return result
 
       case let type as AssociatedTypeType:
         current = type.domain
         result.append(type.domain)
 
-      case let type as ConformanceLensType:
-        current = type.subject
+      case let type as ConformanceLensType: current = type.subject
 
-      default:
-        unreachable()
+      default: unreachable()
       }
     }
   }

--- a/Sources/Compiler/Types/AssociatedValueType.swift
+++ b/Sources/Compiler/Types/AssociatedValueType.swift
@@ -21,8 +21,7 @@ public struct AssociatedValueType: TypeProtocol {
     switch domain.base {
     case is AssociatedTypeType, is ConformanceLensType, is GenericTypeParameterType:
       self.domain = domain
-    default:
-      preconditionFailure("invalid associated value domain")
+    default: preconditionFailure("invalid associated value domain")
     }
 
     self.decl = decl

--- a/Sources/Compiler/Types/BoundGenericType.swift
+++ b/Sources/Compiler/Types/BoundGenericType.swift
@@ -24,9 +24,7 @@ public struct BoundGenericType: TypeProtocol {
 
   /// Creates a bound generic type binding `base` to the given `arguments`.
   public init<T: TypeProtocol, S: Sequence>(_ instance: T, arguments: S)
-  where S.Element == Argument {
-    self.init(^instance, arguments: arguments)
-  }
+  where S.Element == Argument { self.init(^instance, arguments: arguments) }
 
   /// Creates a bound generic type binding `base` to the given `arguments`.
   public init<S: Sequence>(_ base: AnyType, arguments: S) where S.Element == Argument {
@@ -37,10 +35,8 @@ public struct BoundGenericType: TypeProtocol {
     for a in arguments {
       args.append(a)
       switch a {
-      case .type(let t):
-        flags.merge(t.flags)
-      case .value:
-        fatalError("not implemented")
+      case .type(let t): flags.merge(t.flags)
+      case .value: fatalError("not implemented")
       }
     }
 
@@ -76,10 +72,8 @@ extension BoundGenericType.Argument: CustomStringConvertible {
 
   public var description: String {
     switch self {
-    case .type(let a):
-      return String(describing: a)
-    case .value(let a):
-      return String(describing: a)
+    case .type(let a): return String(describing: a)
+    case .value(let a): return String(describing: a)
     }
   }
 

--- a/Sources/Compiler/Types/BoundGenericType.swift
+++ b/Sources/Compiler/Types/BoundGenericType.swift
@@ -23,10 +23,8 @@ public struct BoundGenericType: TypeProtocol {
   public let flags: TypeFlags
 
   /// Creates a bound generic type binding `base` to the given `arguments`.
-  public init<T: TypeProtocol, S: Sequence>(
-    _ instance: T,
-    arguments: S
-  ) where S.Element == Argument {
+  public init<T: TypeProtocol, S: Sequence>(_ instance: T, arguments: S)
+  where S.Element == Argument {
     self.init(^instance, arguments: arguments)
   }
 

--- a/Sources/Compiler/Types/BuiltinSymbols.swift
+++ b/Sources/Compiler/Types/BuiltinSymbols.swift
@@ -53,8 +53,7 @@ public enum BuiltinSymbols {
 
     case "f64_copy": return Self.f64_copy
 
-    default:
-      return nil
+    default: return nil
     }
   }
 

--- a/Sources/Compiler/Types/BuiltinSymbols.swift
+++ b/Sources/Compiler/Types/BuiltinSymbols.swift
@@ -2,58 +2,37 @@
 public enum BuiltinSymbols {
 
   /// Terminates the program abnormally.
-  public static let terminate = LambdaType(
-    to: .never)
+  public static let terminate = LambdaType(to: .never)
 
   /// 1-bit integer copy.
-  public static let i1_copy = LambdaType(
-    from: (.let, .i(1)),
-    to: .builtin(.i(1)))
+  public static let i1_copy = LambdaType(from: (.let, .i(1)), to: .builtin(.i(1)))
 
   /// 32-bit integer copy.
-  public static let i32_copy = LambdaType(
-    from: (.let, .i(32)),
-    to: .builtin(.i(32)))
+  public static let i32_copy = LambdaType(from: (.let, .i(32)), to: .builtin(.i(32)))
 
   /// 64-bit integer copy.
-  public static let i64_copy = LambdaType(
-    from: (.let, .i(64)),
-    to: .builtin(.i(64)))
+  public static let i64_copy = LambdaType(from: (.let, .i(64)), to: .builtin(.i(64)))
 
   /// 64-bit integer multiplication.
-  public static let i64_mul = LambdaType(
-    from: (.let, .i(64)), (.let, .i(64)),
-    to: .builtin(.i(64)))
+  public static let i64_mul = LambdaType(from: (.let, .i(64)), (.let, .i(64)), to: .builtin(.i(64)))
 
   /// 64-bit integer addition.
-  public static let i64_add = LambdaType(
-    from: (.let, .i(64)), (.let, .i(64)),
-    to: .builtin(.i(64)))
+  public static let i64_add = LambdaType(from: (.let, .i(64)), (.let, .i(64)), to: .builtin(.i(64)))
 
   /// 64-bit integer subtraction.
-  public static let i64_sub = LambdaType(
-    from: (.let, .i(64)), (.let, .i(64)),
-    to: .builtin(.i(64)))
+  public static let i64_sub = LambdaType(from: (.let, .i(64)), (.let, .i(64)), to: .builtin(.i(64)))
 
   /// 64-bit integer "less than" comparison.
-  public static let i64_lt = LambdaType(
-    from: (.let, .i(64)), (.let, .i(64)),
-    to: .builtin(.i(1)))
+  public static let i64_lt = LambdaType(from: (.let, .i(64)), (.let, .i(64)), to: .builtin(.i(1)))
 
   // 64-bit integer unchecked conversion to 32-bit.
-  public static let i64_trunc_to_i32 = LambdaType(
-    from: (.let, .i(64)),
-    to: .builtin(.i(32)))
+  public static let i64_trunc_to_i32 = LambdaType(from: (.let, .i(64)), to: .builtin(.i(32)))
 
   // 64-bit print.
-  public static let i64_print = LambdaType(
-    from: (.let, .i(64)),
-    to: .void)
+  public static let i64_print = LambdaType(from: (.let, .i(64)), to: .void)
 
   // Double-precision floating-point copy.
-  public static let f64_copy = LambdaType(
-    from: (.let, .f64),
-    to: .builtin(.f64))
+  public static let f64_copy = LambdaType(from: (.let, .f64), to: .builtin(.f64))
 
   /// Returns the type of the built-in function with the given name.
   public static subscript(_ name: String) -> LambdaType? {
@@ -87,8 +66,7 @@ extension LambdaType {
     self.init(
       inputs: inputs.map({ (convention, type) -> CallableTypeParameter in
         .init(type: ^ParameterType(convention: convention, bareType: .builtin(type)))
-      }),
-      output: output)
+      }), output: output)
   }
 
 }

--- a/Sources/Compiler/Types/BuiltinType.swift
+++ b/Sources/Compiler/Types/BuiltinType.swift
@@ -24,14 +24,10 @@ extension BuiltinType: CustomStringConvertible {
 
   public var description: String {
     switch self {
-    case .i(let bitWidth):
-      return "i\(bitWidth)"
-    case .f64:
-      return "f64"
-    case .pointer:
-      return "Pointer"
-    case .module:
-      return "Builtin"
+    case .i(let bitWidth): return "i\(bitWidth)"
+    case .f64: return "f64"
+    case .pointer: return "Pointer"
+    case .module: return "Builtin"
     }
   }
 
@@ -41,12 +37,9 @@ extension BuiltinType: LosslessStringConvertible {
 
   public init?(_ description: String) {
     switch description {
-    case "Builtin":
-      self = .module
-    case "f64":
-      self = .f64
-    case "Pointer":
-      self = .pointer
+    case "Builtin": self = .module
+    case "f64": self = .f64
+    case "Pointer": self = .pointer
 
     case _ where description.starts(with: "i"):
       if let bitWidth = Int(description.dropFirst()) {
@@ -56,8 +49,7 @@ extension BuiltinType: LosslessStringConvertible {
         return nil
       }
 
-    default:
-      return nil
+    default: return nil
     }
   }
 

--- a/Sources/Compiler/Types/CallableTypeParameter.swift
+++ b/Sources/Compiler/Types/CallableTypeParameter.swift
@@ -18,11 +18,7 @@ public struct CallableTypeParameter: Hashable {
 extension CallableTypeParameter: CustomStringConvertible {
 
   public var description: String {
-    if let label = label {
-      return "\(label): \(type)"
-    } else {
-      return "\(type)"
-    }
+    if let label = label { return "\(label): \(type)" } else { return "\(type)" }
   }
 
 }

--- a/Sources/Compiler/Types/GenericTypeParameterType.swift
+++ b/Sources/Compiler/Types/GenericTypeParameterType.swift
@@ -21,10 +21,8 @@ public struct GenericTypeParameterType: TypeProtocol {
     switch decl.kind {
     case AssociatedTypeDecl.self, GenericParameterDecl.self:
       name = Incidental((ast[decl] as! SingleEntityDecl).name)
-    case TraitDecl.self:
-      name = Incidental("Self")
-    default:
-      preconditionFailure("invalid declaration")
+    case TraitDecl.self: name = Incidental("Self")
+    default: preconditionFailure("invalid declaration")
     }
   }
 

--- a/Sources/Compiler/Types/GenericValueParameterType.swift
+++ b/Sources/Compiler/Types/GenericValueParameterType.swift
@@ -20,8 +20,7 @@ public struct GenericValueParameterType: TypeProtocol {
     switch decl.kind {
     case GenericParameterDecl.self, AssociatedValueDecl.self:
       name = Incidental((ast[decl] as! SingleEntityDecl).name)
-    default:
-      preconditionFailure("invalid declaration")
+    default: preconditionFailure("invalid declaration")
     }
   }
 

--- a/Sources/Compiler/Types/LambdaType.swift
+++ b/Sources/Compiler/Types/LambdaType.swift
@@ -27,10 +27,8 @@ public struct LambdaType: TypeProtocol {
     inputs: [CallableTypeParameter], output: AnyType
   ) {
     switch environment.base {
-    case is TupleType, is TypeVariable, is ErrorType:
-      break
-    default:
-      preconditionFailure("invalid environment type")
+    case is TupleType, is TypeVariable, is ErrorType: break
+    default: preconditionFailure("invalid environment type")
     }
 
     self.receiverEffect = receiverEffect

--- a/Sources/Compiler/Types/LambdaType.swift
+++ b/Sources/Compiler/Types/LambdaType.swift
@@ -23,10 +23,8 @@ public struct LambdaType: TypeProtocol {
 
   /// Creates an instance with the given properties.
   public init(
-    receiverEffect: ReceiverEffect? = nil,
-    environment: AnyType = .void,
-    inputs: [CallableTypeParameter],
-    output: AnyType
+    receiverEffect: ReceiverEffect? = nil, environment: AnyType = .void,
+    inputs: [CallableTypeParameter], output: AnyType
   ) {
     switch environment.base {
     case is TupleType, is TypeVariable, is ErrorType:
@@ -53,8 +51,7 @@ public struct LambdaType: TypeProtocol {
 
     let projectedReceiver = ^RemoteType(.let, method.receiver)
     self.init(
-      environment: ^TupleType(labelsAndTypes: [("self", projectedReceiver)]),
-      inputs: method.inputs,
+      environment: ^TupleType(labelsAndTypes: [("self", projectedReceiver)]), inputs: method.inputs,
       output: method.output)
   }
 
@@ -65,8 +62,7 @@ public struct LambdaType: TypeProtocol {
 
     let projectedReceiver = ^RemoteType(.inout, method.receiver)
     self.init(
-      environment: ^TupleType(labelsAndTypes: [("self", projectedReceiver)]),
-      inputs: method.inputs,
+      environment: ^TupleType(labelsAndTypes: [("self", projectedReceiver)]), inputs: method.inputs,
       output: method.output)
   }
 
@@ -76,18 +72,15 @@ public struct LambdaType: TypeProtocol {
     if !method.capabilities.contains(.inout) && !method.capabilities.contains(.sink) { return nil }
 
     self.init(
-      receiverEffect: .sink,
-      environment: ^TupleType(labelsAndTypes: [("self", method.receiver)]),
-      inputs: method.inputs,
-      output: method.output)
+      receiverEffect: .sink, environment: ^TupleType(labelsAndTypes: [("self", method.receiver)]),
+      inputs: method.inputs, output: method.output)
   }
 
   /// Transforms `self` into a constructor type if `self` has the shape of an initializer type.
   /// Otherwise, returns `nil`.
   public func ctor() -> LambdaType? {
     guard (receiverEffect == nil) && (environment == .void) && (output == .void),
-      let receiverType = ParameterType(inputs.first?.type),
-      receiverType.convention == .set
+      let receiverType = ParameterType(inputs.first?.type), receiverType.convention == .set
     else { return nil }
     return LambdaType(inputs: Array(inputs[1...]), output: receiverType.bareType)
   }
@@ -100,12 +93,10 @@ public struct LambdaType: TypeProtocol {
 
   public func transformParts(_ transformer: (AnyType) -> TypeTransformAction) -> Self {
     LambdaType(
-      receiverEffect: receiverEffect,
-      environment: environment.transform(transformer),
+      receiverEffect: receiverEffect, environment: environment.transform(transformer),
       inputs: inputs.map({ (p) -> CallableTypeParameter in
         .init(label: p.label, type: p.type.transform(transformer))
-      }),
-      output: output.transform(transformer))
+      }), output: output.transform(transformer))
   }
 
 }

--- a/Sources/Compiler/Types/MetatypeType.swift
+++ b/Sources/Compiler/Types/MetatypeType.swift
@@ -5,14 +5,10 @@ public struct MetatypeType: TypeProtocol {
   public let instance: AnyType
 
   /// Creates a type denoting the type of `instance`.
-  public init<T: TypeProtocol>(of instance: T) {
-    self.init(of: ^instance)
-  }
+  public init<T: TypeProtocol>(of instance: T) { self.init(of: ^instance) }
 
   /// Creates a type denoting the type of `instance`.
-  public init(of instance: AnyType) {
-    self.instance = instance
-  }
+  public init(of instance: AnyType) { self.instance = instance }
 
   public var flags: TypeFlags { instance.flags }
 
@@ -24,8 +20,6 @@ public struct MetatypeType: TypeProtocol {
 
 extension MetatypeType: CustomStringConvertible {
 
-  public var description: String {
-    "Metatype<\(instance)>"
-  }
+  public var description: String { "Metatype<\(instance)>" }
 
 }

--- a/Sources/Compiler/Types/MethodType.swift
+++ b/Sources/Compiler/Types/MethodType.swift
@@ -46,11 +46,7 @@ public struct MethodType: TypeProtocol {
 extension MethodType: CustomStringConvertible {
 
   public var description: String {
-    let cs =
-      capabilities
-      .map(String.init(describing:))
-      .sorted()
-      .joined(separator: " ")
+    let cs = capabilities.map(String.init(describing:)).sorted().joined(separator: " ")
     return "method[\(receiver)] (\(inputs.descriptions())) -> \(output) { \(cs) }"
   }
 

--- a/Sources/Compiler/Types/MethodType.swift
+++ b/Sources/Compiler/Types/MethodType.swift
@@ -19,9 +19,7 @@ public struct MethodType: TypeProtocol {
 
   /// Creates an instance with the given properties.
   public init(
-    capabilities: Set<ImplIntroducer>,
-    receiver: AnyType,
-    inputs: [CallableTypeParameter],
+    capabilities: Set<ImplIntroducer>, receiver: AnyType, inputs: [CallableTypeParameter],
     output: AnyType
   ) {
     self.capabilities = capabilities
@@ -37,12 +35,10 @@ public struct MethodType: TypeProtocol {
 
   public func transformParts(_ transformer: (AnyType) -> TypeTransformAction) -> Self {
     MethodType(
-      capabilities: capabilities,
-      receiver: receiver.transform(transformer),
+      capabilities: capabilities, receiver: receiver.transform(transformer),
       inputs: inputs.map({ (p) -> CallableTypeParameter in
         .init(label: p.label, type: p.type.transform(transformer))
-      }),
-      output: output.transform(transformer))
+      }), output: output.transform(transformer))
   }
 
 }

--- a/Sources/Compiler/Types/RemoteType.swift
+++ b/Sources/Compiler/Types/RemoteType.swift
@@ -37,8 +37,6 @@ public struct RemoteType: TypeProtocol {
 
 extension RemoteType: CustomStringConvertible {
 
-  public var description: String {
-    return "remote \(capability) \(base)"
-  }
+  public var description: String { return "remote \(capability) \(base)" }
 
 }

--- a/Sources/Compiler/Types/SkolemType.swift
+++ b/Sources/Compiler/Types/SkolemType.swift
@@ -5,14 +5,10 @@ public struct SkolemType: TypeProtocol {
   public let base: AnyType
 
   /// Creates an instance denoting the existential quantification of `base`.
-  public init<T: TypeProtocol>(quantifying base: T) {
-    self.base = ^base
-  }
+  public init<T: TypeProtocol>(quantifying base: T) { self.base = ^base }
 
   /// Creates an instance denoting the existential quantification of `base`.
-  public init(quantifying base: AnyType) {
-    self.base = base
-  }
+  public init(quantifying base: AnyType) { self.base = base }
 
   public var flags: TypeFlags { .isCanonical }
 

--- a/Sources/Compiler/Types/SubscriptType.swift
+++ b/Sources/Compiler/Types/SubscriptType.swift
@@ -19,11 +19,8 @@ public struct SubscriptType: TypeProtocol {
 
   /// Creates an instance with the given properties.
   public init(
-    isProperty: Bool,
-    capabilities: Set<ImplIntroducer>,
-    environment: AnyType = .void,
-    inputs: [CallableTypeParameter],
-    output: AnyType
+    isProperty: Bool, capabilities: Set<ImplIntroducer>, environment: AnyType = .void,
+    inputs: [CallableTypeParameter], output: AnyType
   ) {
     self.isProperty = isProperty
     self.capabilities = capabilities
@@ -42,12 +39,10 @@ public struct SubscriptType: TypeProtocol {
 
   public func transformParts(_ transformer: (AnyType) -> TypeTransformAction) -> Self {
     SubscriptType(
-      isProperty: isProperty,
-      capabilities: capabilities,
+      isProperty: isProperty, capabilities: capabilities,
       inputs: inputs.map({ (p) -> CallableTypeParameter in
         .init(label: p.label, type: p.type.transform(transformer))
-      }),
-      output: output.transform(transformer))
+      }), output: output.transform(transformer))
   }
 
 }

--- a/Sources/Compiler/Types/SubscriptType.swift
+++ b/Sources/Compiler/Types/SubscriptType.swift
@@ -50,11 +50,7 @@ public struct SubscriptType: TypeProtocol {
 extension SubscriptType: CustomStringConvertible {
 
   public var description: String {
-    let cs =
-      capabilities
-      .map(String.init(describing:))
-      .sorted()
-      .joined(separator: " ")
+    let cs = capabilities.map(String.init(describing:)).sorted().joined(separator: " ")
 
     if isProperty {
       return "property [\(environment)] \(output) { \(cs) }"

--- a/Sources/Compiler/Types/TupleType.swift
+++ b/Sources/Compiler/Types/TupleType.swift
@@ -23,12 +23,9 @@ public struct TupleType: TypeProtocol, Hashable {
 
     var fs = TypeFlags(merging: self.elements.map({ $0.type.flags }))
     switch self.elements.count {
-    case 0:
-      fs.insert(.isCanonical)
-    case 1 where self.elements[0].label == nil:
-      fs.remove(.isCanonical)
-    default:
-      break
+    case 0: fs.insert(.isCanonical)
+    case 1 where self.elements[0].label == nil: fs.remove(.isCanonical)
+    default: break
     }
     flags = fs
   }
@@ -64,11 +61,7 @@ extension TupleType: CustomStringConvertible {
 extension TupleType.Element: CustomStringConvertible {
 
   public var description: String {
-    if let label = label {
-      return "\(label): \(type)"
-    } else {
-      return "\(type)"
-    }
+    if let label = label { return "\(label): \(type)" } else { return "\(type)" }
   }
 
 }

--- a/Sources/Compiler/Types/TypeProtocol.swift
+++ b/Sources/Compiler/Types/TypeProtocol.swift
@@ -16,21 +16,13 @@ extension TypeProtocol {
   /// Creates an instance with the value of `container.base` or returns `nil` if that value has
   /// a different type.
   public init?(_ container: AnyType) {
-    if let t = container.base as? Self {
-      self = t
-    } else {
-      return nil
-    }
+    if let t = container.base as? Self { self = t } else { return nil }
   }
 
   /// Creates an instance with the value of `container.base` or returns `nil` if either that value
   /// has a different type or `container` is `nil`.
   public init?(_ container: AnyType?) {
-    if let t = container.flatMap(Self.init(_:)) {
-      self = t
-    } else {
-      return nil
-    }
+    if let t = container.flatMap(Self.init(_:)) { self = t } else { return nil }
   }
 
   /// Returns whether the specified flags are raised on this type.
@@ -44,10 +36,8 @@ extension TypeProtocol {
   /// the next type in the structure.
   public func transform(_ transformer: (AnyType) -> TypeTransformAction) -> AnyType {
     switch transformer(AnyType(self)) {
-    case .stepInto(let type):
-      return type.transformParts(transformer)
-    case .stepOver(let type):
-      return type
+    case .stepInto(let type): return type.transformParts(transformer)
+    case .stepOver(let type): return type
     }
   }
 
@@ -61,14 +51,11 @@ extension TypeProtocol {
   public var skolemized: AnyType {
     func _impl(type: AnyType) -> TypeTransformAction {
       switch type.base {
-      case let base as AssociatedTypeType:
-        return .stepOver(^SkolemType(quantifying: base))
+      case let base as AssociatedTypeType: return .stepOver(^SkolemType(quantifying: base))
 
-      case let base as GenericTypeParameterType:
-        return .stepOver(^SkolemType(quantifying: base))
+      case let base as GenericTypeParameterType: return .stepOver(^SkolemType(quantifying: base))
 
-      case is AssociatedValueType, is GenericValueParameterType:
-        fatalError("not implemented")
+      case is AssociatedValueType, is GenericValueParameterType: fatalError("not implemented")
 
       default:
         // Nothing to do if `type` isn't parameterized.

--- a/Sources/Compiler/Types/TypeProtocol.swift
+++ b/Sources/Compiler/Types/TypeProtocol.swift
@@ -67,8 +67,7 @@ extension TypeProtocol {
       case let base as GenericTypeParameterType:
         return .stepOver(^SkolemType(quantifying: base))
 
-      case is AssociatedValueType,
-        is GenericValueParameterType:
+      case is AssociatedValueType, is GenericValueParameterType:
         fatalError("not implemented")
 
       default:

--- a/Sources/Compiler/Types/UnionType.swift
+++ b/Sources/Compiler/Types/UnionType.swift
@@ -10,9 +10,7 @@ public struct UnionType: TypeProtocol {
   public init<S: Sequence>(_ elements: S) where S.Element == AnyType {
     self.elements = Set(elements)
     self.flags =
-      self.elements.isEmpty
-      ? [.isCanonical]
-      : TypeFlags(merging: self.elements.map({ $0.flags }))
+      self.elements.isEmpty ? [.isCanonical] : TypeFlags(merging: self.elements.map({ $0.flags }))
   }
 
   public func transform(_ transformer: (AnyType) -> TypeTransformAction) -> Self {

--- a/Sources/Utils/Algorithms.swift
+++ b/Sources/Utils/Algorithms.swift
@@ -7,10 +7,8 @@ extension BidirectionalCollection {
   }
 
   /// Returns the slice of self that remains after dropping leading and trailing whitespace.
-  public func strippingWhitespace() -> SubSequence
-  where Element == Character {
-    return self.drop { c in c.isWhitespace }
-      .dropLast { c in c.isWhitespace }
+  public func strippingWhitespace() -> SubSequence where Element == Character {
+    return self.drop { c in c.isWhitespace }.dropLast { c in c.isWhitespace }
   }
 
 }
@@ -39,9 +37,7 @@ extension Int {
     #if (arch(x86_64) || arch(arm64))
       x |= x &>> 32
     #elseif (!arch(i386) && !arch(arm))
-      if Int.bitWidth > 32 {
-        x |= x &>> 32
-      }
+      if Int.bitWidth > 32 { x |= x &>> 32 }
     #endif
     return Int(bitPattern: x &+ 1)
   }

--- a/Sources/Utils/CustomWitnessSet.swift
+++ b/Sources/Utils/CustomWitnessSet.swift
@@ -15,9 +15,7 @@ public struct CustomWitnessedSet<Element, Witness: HashableWitness<Element>> {
   }
 
   /// Reserves enough space to store the specified number of elements.
-  public mutating func reserve(minimumCapacity: Int) {
-    contents.reserveCapacity(minimumCapacity)
-  }
+  public mutating func reserve(minimumCapacity: Int) { contents.reserveCapacity(minimumCapacity) }
 
 }
 
@@ -27,9 +25,7 @@ extension CustomWitnessedSet: Collection {
 
     fileprivate var base: Set<_Element>.Index
 
-    fileprivate init(_ base: Set<_Element>.Index) {
-      self.base = base
-    }
+    fileprivate init(_ base: Set<_Element>.Index) { self.base = base }
 
     public static func < (l: Self, r: Self) -> Bool { l.base < r.base }
 
@@ -45,25 +41,19 @@ extension CustomWitnessedSet: Collection {
 
   public func index(after i: Index) -> Index { Index(contents.index(after: i.base)) }
 
-  public subscript(position: Index) -> Element {
-    contents[position.base].base
-  }
+  public subscript(position: Index) -> Element { contents[position.base].base }
 
-  public func contains(_ member: Element) -> Bool {
-    contents.contains(_Element(member))
-  }
+  public func contains(_ member: Element) -> Bool { contents.contains(_Element(member)) }
 
 }
 
 extension CustomWitnessedSet: SetAlgebra {
 
-  public init() {
-    contents = []
-  }
+  public init() { contents = [] }
 
-  @discardableResult
-  public mutating func insert(_ newMember: Element) -> (inserted: Bool, memberAfterInsert: Element)
-  {
+  @discardableResult public mutating func insert(_ newMember: Element) -> (
+    inserted: Bool, memberAfterInsert: Element
+  ) {
     let (inserted, memberAfterInsert) = contents.insert(_Element(newMember))
     return (inserted, memberAfterInsert.base)
   }
@@ -82,9 +72,7 @@ extension CustomWitnessedSet: SetAlgebra {
     return result
   }
 
-  public mutating func formUnion(_ other: Self) {
-    contents.formUnion(other.contents)
-  }
+  public mutating func formUnion(_ other: Self) { contents.formUnion(other.contents) }
 
   public func intersection(_ other: Self) -> Self {
     var result = self
@@ -92,9 +80,7 @@ extension CustomWitnessedSet: SetAlgebra {
     return result
   }
 
-  public mutating func formIntersection(_ other: Self) {
-    contents.formIntersection(other.contents)
-  }
+  public mutating func formIntersection(_ other: Self) { contents.formIntersection(other.contents) }
 
   public func symmetricDifference(_ other: Self) -> Self {
     var result = self
@@ -112,9 +98,7 @@ extension CustomWitnessedSet: SetAlgebra {
     return result
   }
 
-  public mutating func subtract(_ other: Self) {
-    contents.subtract(other.contents)
-  }
+  public mutating func subtract(_ other: Self) { contents.subtract(other.contents) }
 
 }
 
@@ -122,9 +106,7 @@ extension CustomWitnessedSet: Hashable {}
 
 extension CustomWitnessedSet: ExpressibleByArrayLiteral {
 
-  public init(arrayLiteral members: Element...) {
-    self.init(members)
-  }
+  public init(arrayLiteral members: Element...) { self.init(members) }
 
 }
 
@@ -136,8 +118,6 @@ extension CustomWitnessedSet: CustomStringConvertible {
 
 extension CustomWitnessedSet: CustomReflectable {
 
-  public var customMirror: Mirror {
-    Mirror(reflecting: contents)
-  }
+  public var customMirror: Mirror { Mirror(reflecting: contents) }
 
 }

--- a/Sources/Utils/CustomWitnessSet.swift
+++ b/Sources/Utils/CustomWitnessSet.swift
@@ -62,9 +62,8 @@ extension CustomWitnessedSet: SetAlgebra {
   }
 
   @discardableResult
-  public mutating func insert(
-    _ newMember: Element
-  ) -> (inserted: Bool, memberAfterInsert: Element) {
+  public mutating func insert(_ newMember: Element) -> (inserted: Bool, memberAfterInsert: Element)
+  {
     let (inserted, memberAfterInsert) = contents.insert(_Element(newMember))
     return (inserted, memberAfterInsert.base)
   }

--- a/Sources/Utils/DirectedGraph.swift
+++ b/Sources/Utils/DirectedGraph.swift
@@ -11,9 +11,7 @@ public struct DirectedGraph<Vertex: Hashable, Label> {
   fileprivate var edges: [Vertex: [Vertex: Label]]
 
   /// Creates an empty graph.
-  public init() {
-    edges = [:]
-  }
+  public init() { edges = [:] }
 
   /// Inserts an edge from `source` to `target`, labeled by `label`.
   ///
@@ -21,10 +19,9 @@ public struct DirectedGraph<Vertex: Hashable, Label> {
   ///   `(false, currentLabel)`, where `currentLabel` is label of the existing edge.
   ///
   /// - Complexity: O(1).
-  @discardableResult
-  public mutating func insertEdge(from source: Vertex, to target: Vertex, labeledBy label: Label)
-    -> (inserted: Bool, labelAfterInsert: Label)
-  {
+  @discardableResult public mutating func insertEdge(
+    from source: Vertex, to target: Vertex, labeledBy label: Label
+  ) -> (inserted: Bool, labelAfterInsert: Label) {
     modifying(
       &edges[source, default: [:]],
       { tips in
@@ -42,8 +39,9 @@ public struct DirectedGraph<Vertex: Hashable, Label> {
   /// - Returns: The label of the removed edge, or `nil` if there was no edge to remove.
   ///
   /// - Complexity: O(1).
-  @discardableResult
-  public mutating func removeEdge(from source: Vertex, to target: Vertex) -> Label? {
+  @discardableResult public mutating func removeEdge(from source: Vertex, to target: Vertex)
+    -> Label?
+  {
     modifying(
       &edges[source, default: [:]],
       { tips in
@@ -82,10 +80,8 @@ extension DirectedGraph where Label == () {
   /// - Returns: `true` if there was no edge between `source` and `target`. Otherwise, `false`.
   ///
   /// - Complexity: O(1).
-  @discardableResult
-  public mutating func insertEdge(from source: Vertex, to target: Vertex) -> Bool {
-    insertEdge(from: source, to: target, labeledBy: ()).inserted
-  }
+  @discardableResult public mutating func insertEdge(from source: Vertex, to target: Vertex) -> Bool
+  { insertEdge(from: source, to: target, labeledBy: ()).inserted }
 
 }
 
@@ -98,9 +94,7 @@ extension DirectedGraph: Equatable where Label: Equatable {
     for (source, lhs) in l.edges {
       let rhs = r.edges[source, default: [:]]
       if lhs.count != rhs.count { return false }
-      for (target, label) in lhs {
-        if rhs[target] != label { return false }
-      }
+      for (target, label) in lhs { if rhs[target] != label { return false } }
       sources.insert(source)
     }
 

--- a/Sources/Utils/DirectedGraph.swift
+++ b/Sources/Utils/DirectedGraph.swift
@@ -22,9 +22,9 @@ public struct DirectedGraph<Vertex: Hashable, Label> {
   ///
   /// - Complexity: O(1).
   @discardableResult
-  public mutating func insertEdge(
-    from source: Vertex, to target: Vertex, labeledBy label: Label
-  ) -> (inserted: Bool, labelAfterInsert: Label) {
+  public mutating func insertEdge(from source: Vertex, to target: Vertex, labeledBy label: Label)
+    -> (inserted: Bool, labelAfterInsert: Label)
+  {
     modifying(
       &edges[source, default: [:]],
       { tips in

--- a/Sources/Utils/DoublyLinkedList.swift
+++ b/Sources/Utils/DoublyLinkedList.swift
@@ -140,8 +140,7 @@ public struct DoublyLinkedList<Element> {
       headOffset = freeOffset
       tailOffset = freeOffset
       freeOffset = storage[newAddress.rawValue].nextOffset
-      storage[newAddress.rawValue] = Bucket(
-        previousOffset: -1, nextOffset: -1, element: newElement)
+      storage[newAddress.rawValue] = Bucket(previousOffset: -1, nextOffset: -1, element: newElement)
       return newAddress
     } else {
       return insert(newElement, after: Address(tailOffset))
@@ -184,16 +183,14 @@ public struct DoublyLinkedList<Element> {
 
       storage.append(
         Bucket(
-          previousOffset: address.rawValue,
-          nextOffset: storage[address.rawValue].nextOffset,
+          previousOffset: address.rawValue, nextOffset: storage[address.rawValue].nextOffset,
           element: newElement))
     } else {
       newAddress = Address(freeOffset)
       freeOffset = storage[freeOffset].nextOffset
 
       storage[newAddress.rawValue] = Bucket(
-        previousOffset: address.rawValue,
-        nextOffset: storage[address.rawValue].nextOffset,
+        previousOffset: address.rawValue, nextOffset: storage[address.rawValue].nextOffset,
         element: newElement)
     }
 
@@ -222,16 +219,14 @@ public struct DoublyLinkedList<Element> {
 
       storage.append(
         Bucket(
-          previousOffset: storage[address.rawValue].previousOffset,
-          nextOffset: address.rawValue,
+          previousOffset: storage[address.rawValue].previousOffset, nextOffset: address.rawValue,
           element: newElement))
     } else {
       newAddress = Address(freeOffset)
       freeOffset = storage[freeOffset].nextOffset
 
       storage[newAddress.rawValue] = Bucket(
-        previousOffset: storage[address.rawValue].previousOffset,
-        nextOffset: address.rawValue,
+        previousOffset: storage[address.rawValue].previousOffset, nextOffset: address.rawValue,
         element: newElement)
     }
 

--- a/Sources/Utils/DoublyLinkedList.swift
+++ b/Sources/Utils/DoublyLinkedList.swift
@@ -10,9 +10,7 @@ public struct DoublyLinkedList<Element> {
 
     fileprivate var rawValue: Int
 
-    fileprivate init(_ rawValue: Int) {
-      self.rawValue = rawValue
-    }
+    fileprivate init(_ rawValue: Int) { self.rawValue = rawValue }
 
     /// Returns whether the element stored at `self` precedes that stored at `other` in `list`.
     public func precedes(_ other: Address, in list: DoublyLinkedList) -> Bool {
@@ -69,9 +67,7 @@ public struct DoublyLinkedList<Element> {
   public var capacity: Int { storage.capacity }
 
   /// The address of the first element.
-  public var firstAddress: Address? {
-    storage.isEmpty ? nil : Address(headOffset)
-  }
+  public var firstAddress: Address? { storage.isEmpty ? nil : Address(headOffset) }
 
   /// Returns the first address at which an element satisfies the given predicate.
   public func firstAddress(where predicate: (Element) throws -> Bool) rethrows -> Address? {
@@ -84,9 +80,7 @@ public struct DoublyLinkedList<Element> {
   }
 
   /// The address of the last element.
-  public var lastAddress: Address? {
-    storage.isEmpty ? nil : Address(tailOffset)
-  }
+  public var lastAddress: Address? { storage.isEmpty ? nil : Address(tailOffset) }
 
   /// Returns the last address at which an element satisfies the given predicate.
   public func lastAddress(where predicate: (Element) throws -> Bool) rethrows -> Address? {
@@ -125,8 +119,7 @@ public struct DoublyLinkedList<Element> {
   }
 
   /// Inserts `newElement` at the end of the list and returns its address.
-  @discardableResult
-  public mutating func append(_ newElement: Element) -> Address {
+  @discardableResult public mutating func append(_ newElement: Element) -> Address {
     if storage.isEmpty {
       count = 1
       headOffset = 0
@@ -148,8 +141,7 @@ public struct DoublyLinkedList<Element> {
   }
 
   /// Inserts `newElement` at the start of the list and returns its address.
-  @discardableResult
-  public mutating func prepend(_ newElement: Element) -> Address {
+  @discardableResult public mutating func prepend(_ newElement: Element) -> Address {
     if storage.isEmpty {
       count = 1
       headOffset = 0
@@ -172,8 +164,9 @@ public struct DoublyLinkedList<Element> {
   /// Inserts `newElement` after the element at `address` and returns its address.
   ///
   /// - Requires: `address` must be a valid an address in `self`.
-  @discardableResult
-  public mutating func insert(_ newElement: Element, after address: Address) -> Address {
+  @discardableResult public mutating func insert(_ newElement: Element, after address: Address)
+    -> Address
+  {
     precondition(isInBounds(address), "address out of bounds")
 
     let newAddress: Address
@@ -208,8 +201,9 @@ public struct DoublyLinkedList<Element> {
   /// Inserts `newElement` before the element at `address` and returns its address.
   ///
   /// - Requires: `address` must be the address of an element in `self`.
-  @discardableResult
-  public mutating func insert(_ newElement: Element, before address: Address) -> Address {
+  @discardableResult public mutating func insert(_ newElement: Element, before address: Address)
+    -> Address
+  {
     precondition(isInBounds(address), "address out of bounds")
 
     let newAddress: Address
@@ -242,8 +236,7 @@ public struct DoublyLinkedList<Element> {
   }
 
   /// Removes the element at `address`.
-  @discardableResult
-  public mutating func remove(at address: Address) -> Element {
+  @discardableResult public mutating func remove(at address: Address) -> Element {
     precondition(isInBounds(address), "address out of bounds")
 
     storage[storage[address.rawValue].previousOffset].nextOffset =
@@ -276,9 +269,7 @@ extension DoublyLinkedList: BidirectionalCollection, MutableCollection {
 
     fileprivate let offset: Int
 
-    public func hash(into hasher: inout Hasher) {
-      hasher.combine(offset)
-    }
+    public func hash(into hasher: inout Hasher) { hasher.combine(offset) }
 
     public static func == (l: Self, r: Self) -> Bool { l.offset == r.offset }
 
@@ -289,22 +280,14 @@ extension DoublyLinkedList: BidirectionalCollection, MutableCollection {
   public var isEmpty: Bool { count == 0 }
 
   /// The first element of the list.
-  public var first: Element? {
-    storage.isEmpty ? nil : storage[headOffset].element!
-  }
+  public var first: Element? { storage.isEmpty ? nil : storage[headOffset].element! }
 
   /// The last element of the list.
-  public var last: Element? {
-    storage.isEmpty ? nil : storage[tailOffset].element!
-  }
+  public var last: Element? { storage.isEmpty ? nil : storage[tailOffset].element! }
 
-  public var startIndex: Index {
-    Index(address: firstAddress ?? Address(0), offset: 0)
-  }
+  public var startIndex: Index { Index(address: firstAddress ?? Address(0), offset: 0) }
 
-  public var endIndex: Index {
-    Index(address: Address(0), offset: count)
-  }
+  public var endIndex: Index { Index(address: Address(0), offset: count) }
 
   public func index(after i: Index) -> Index {
     Index(address: address(after: i.address) ?? Address(0), offset: i.offset + 1)
@@ -325,19 +308,13 @@ extension DoublyLinkedList: BidirectionalCollection, MutableCollection {
 
 extension DoublyLinkedList: Equatable where Element: Equatable {
 
-  public static func == (l: Self, r: Self) -> Bool {
-    l.elementsEqual(r)
-  }
+  public static func == (l: Self, r: Self) -> Bool { l.elementsEqual(r) }
 
 }
 
 extension DoublyLinkedList: Hashable where Element: Hashable {
 
-  public func hash(into hasher: inout Hasher) {
-    for element in self {
-      hasher.combine(element)
-    }
-  }
+  public func hash(into hasher: inout Hasher) { for element in self { hasher.combine(element) } }
 
 }
 
@@ -347,18 +324,14 @@ extension DoublyLinkedList: ExpressibleByArrayLiteral {
     self.init()
 
     reserveCapacity(elements.capacity)
-    for element in elements {
-      append(element)
-    }
+    for element in elements { append(element) }
   }
 
 }
 
 extension DoublyLinkedList: CustomStringConvertible {
 
-  public var description: String {
-    String(describing: Array(self))
-  }
+  public var description: String { String(describing: Array(self)) }
 
 }
 

--- a/Sources/Utils/HashableBox.swift
+++ b/Sources/Utils/HashableBox.swift
@@ -5,16 +5,10 @@ public struct HashableBox<Base, Witness: HashableWitness<Base>>: Hashable {
   public let base: Base
 
   /// Creates a new instance wrapping `base`.
-  public init(_ base: Base) {
-    self.base = base
-  }
+  public init(_ base: Base) { self.base = base }
 
-  public func hash(into hasher: inout Hasher) {
-    Witness.hash(base, into: &hasher)
-  }
+  public func hash(into hasher: inout Hasher) { Witness.hash(base, into: &hasher) }
 
-  public static func == (l: Self, r: Self) -> Bool {
-    Witness.isEqual(l.base, to: r.base)
-  }
+  public static func == (l: Self, r: Self) -> Bool { Witness.isEqual(l.base, to: r.base) }
 
 }

--- a/Sources/Utils/Incidental.swift
+++ b/Sources/Utils/Incidental.swift
@@ -6,9 +6,7 @@ public struct Incidental<T>: Hashable {
   public var value: T
 
   /// Creates a new wrapper around `value`.
-  public init(_ value: T) {
-    self.value = value
-  }
+  public init(_ value: T) { self.value = value }
 
   public func hash(into hasher: inout Hasher) {}
 

--- a/Sources/Utils/Optional+Extensions.swift
+++ b/Sources/Utils/Optional+Extensions.swift
@@ -8,10 +8,7 @@ extension Optional {
 
   /// Evaluates the given closure when this Optional instance is not `nil`, passing the unwrapped
   /// value as a parameter. Otherwise, returns `defaultValue`.
-  public func map<U>(
-    default defaultValue: @autoclosure () -> U,
-    _ transform: (Wrapped) -> U
-  ) -> U {
+  public func map<U>(default defaultValue: @autoclosure () -> U, _ transform: (Wrapped) -> U) -> U {
     map(transform) ?? defaultValue()
   }
 

--- a/Sources/Utils/System.swift
+++ b/Sources/Utils/System.swift
@@ -9,8 +9,7 @@ import Foundation
 @discardableResult
 public func withFiles(in directory: URL, _ action: (URL) throws -> Bool) rethrows -> Bool {
   let enumerator = FileManager.default.enumerator(
-    at: directory,
-    includingPropertiesForKeys: [.isRegularFileKey],
+    at: directory, includingPropertiesForKeys: [.isRegularFileKey],
     options: [.skipsHiddenFiles, .skipsPackageDescendants])!
 
   for case let url as URL in enumerator {

--- a/Sources/Utils/System.swift
+++ b/Sources/Utils/System.swift
@@ -6,14 +6,13 @@ import Foundation
 ///   - action: A closure that is called with the URL of each file and returns whether the
 ///     recursive visit of `directory` should continue.
 /// - Returns: `true` unless `action` returned `false`.
-@discardableResult
-public func withFiles(in directory: URL, _ action: (URL) throws -> Bool) rethrows -> Bool {
+@discardableResult public func withFiles(in directory: URL, _ action: (URL) throws -> Bool) rethrows
+  -> Bool
+{
   let enumerator = FileManager.default.enumerator(
     at: directory, includingPropertiesForKeys: [.isRegularFileKey],
     options: [.skipsHiddenFiles, .skipsPackageDescendants])!
 
-  for case let url as URL in enumerator {
-    guard try action(url) else { return false }
-  }
+  for case let url as URL in enumerator { guard try action(url) else { return false } }
   return true
 }

--- a/Sources/Utils/Unreachable.swift
+++ b/Sources/Utils/Unreachable.swift
@@ -1,15 +1,9 @@
 /// Marks this execution path as unreachable, causing a fatal error otherwise.
 public func unreachable(
   _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line
-) -> Never {
-  fatalError(message(), file: file, line: line)
-}
+) -> Never { fatalError(message(), file: file, line: line) }
 
 /// Returns `lhs!` if `lhs` is non-`nil`; evaluates `rhs()`, which never returns, otherwise.
 public func ?? <T>(lhs: T?, rhs: @autoclosure () -> Never) -> T {
-  if let lhs = lhs {
-    return lhs
-  } else {
-    rhs()
-  }
+  if let lhs = lhs { return lhs } else { rhs() }
 }

--- a/Sources/Utils/Unreachable.swift
+++ b/Sources/Utils/Unreachable.swift
@@ -1,8 +1,6 @@
 /// Marks this execution path as unreachable, causing a fatal error otherwise.
 public func unreachable(
-  _ message: @autoclosure () -> String = "",
-  file: StaticString = #file,
-  line: UInt = #line
+  _ message: @autoclosure () -> String = "", file: StaticString = #file, line: UInt = #line
 ) -> Never {
   fatalError(message(), file: file, line: line)
 }

--- a/Sources/Utils/WideUInt.swift
+++ b/Sources/Utils/WideUInt.swift
@@ -60,9 +60,7 @@ extension WideUInt: Numeric, AdditiveArithmetic {
     bitWidth = source.bitWidth
   }
 
-  public var words: BigUInt.Words {
-    value.words
-  }
+  public var words: BigUInt.Words { value.words }
 
   public init<T>(clamping source: T) where T: BinaryInteger {
     value = .init(clamping: source)
@@ -164,13 +162,9 @@ extension WideUInt: CustomStringConvertible {
 extension BigUInt {
 
   /// Discards all but the low `w` bits of `self`.
-  fileprivate mutating func truncate(toWidth w: Int) {
-    self &= ((1 as Self) << w) - 1
-  }
+  fileprivate mutating func truncate(toWidth w: Int) { self &= ((1 as Self) << w) - 1 }
 
   /// Returns `self`, truncated to fit in `w` bits.
-  fileprivate func truncated(toWidth w: Int) -> Self {
-    self & (((1 as Self) << w) - 1)
-  }
+  fileprivate func truncated(toWidth w: Int) -> Self { self & (((1 as Self) << w) - 1) }
 
 }

--- a/Sources/Utils/WideUInt.swift
+++ b/Sources/Utils/WideUInt.swift
@@ -148,8 +148,8 @@ extension WideUInt: Numeric, AdditiveArithmetic {
   /// - Precondition: `self.bitWidth` == `rhs.bitWidth`
   private func matchingWidth(_ rhs: WideUInt, combine: (BigUInt, BigUInt) -> BigUInt) -> WideUInt {
     precondition(
-      bitWidth == rhs.bitWidth,
-      "mixed-width operations not allowed (\(bitWidth) vs \(rhs.bitWidth)")
+      bitWidth == rhs.bitWidth, "mixed-width operations not allowed (\(bitWidth) vs \(rhs.bitWidth)"
+    )
     return WideUInt(truncatingIfNeeded: combine(value, rhs.value), toWidth: bitWidth)
   }
 

--- a/Tests/ValTests/ASTTests.swift
+++ b/Tests/ValTests/ASTTests.swift
@@ -18,11 +18,8 @@ final class ASTTests: XCTestCase {
     // Create a trait declaration.
     let trait = try ast.insert(
       wellFormed: TraitDecl(
-        accessModifier: nil,
-        identifier: SourceRepresentable(value: "T"),
-        refinements: [],
-        members: [],
-        origin: nil))
+        accessModifier: nil, identifier: SourceRepresentable(value: "T"), refinements: [],
+        members: [], origin: nil))
 
     // Create a source declaration set.
     let source = try ast.insert(wellFormed: TopLevelDeclSet(decls: [AnyDeclID(trait)]))
@@ -38,15 +35,12 @@ final class ASTTests: XCTestCase {
     // Create a module.
     let module = try ast.insert(wellFormed: ModuleDecl(name: "Val"))
     let source = try ast.insert(
-      wellFormed: TopLevelDeclSet(
-        decls: [
-          AnyDeclID(
-            ast.insert(
-              wellFormed: FunctionDecl(
-                introducerRange: nil,
-                identifier: SourceRepresentable(value: "foo"),
-                origin: nil)))
-        ]))
+      wellFormed: TopLevelDeclSet(decls: [
+        AnyDeclID(
+          ast.insert(
+            wellFormed: FunctionDecl(
+              introducerRange: nil, identifier: SourceRepresentable(value: "foo"), origin: nil)))
+      ]))
     ast[module].addSourceFile(source)
 
     // Serialize the AST.

--- a/Tests/ValTests/CXXTests.swift
+++ b/Tests/ValTests/CXXTests.swift
@@ -36,8 +36,7 @@ final class CXXTests: XCTestCase {
   func testTranspiler() throws {
     // Locate the test cases.
     let testCaseDirectory = try XCTUnwrap(
-      Bundle.module.url(forResource: "TestCases/CXX", withExtension: nil),
-      "No test cases")
+      Bundle.module.url(forResource: "TestCases/CXX", withExtension: nil), "No test cases")
 
     // Prepare an AST with the core module loaded.
     var baseAST = AST()
@@ -68,11 +67,8 @@ final class CXXTests: XCTestCase {
         }
 
         let typedProgram = TypedProgram(
-          annotating: checker.program,
-          declTypes: checker.declTypes,
-          exprTypes: checker.exprTypes,
-          implicitCaptures: checker.implicitCaptures,
-          referredDecls: checker.referredDecls,
+          annotating: checker.program, declTypes: checker.declTypes, exprTypes: checker.exprTypes,
+          implicitCaptures: checker.implicitCaptures, referredDecls: checker.referredDecls,
           foldedSequenceExprs: checker.foldedSequenceExprs)
 
         // TODO: Run IR transform passes

--- a/Tests/ValTests/CXXTests.swift
+++ b/Tests/ValTests/CXXTests.swift
@@ -83,14 +83,11 @@ final class CXXTests: XCTestCase {
         for annotation in tc.annotations {
           let code = annotation.argument!.removingTrailingNewlines()
           switch annotation.command {
-          case "cpp":
-            check(cxxSource, contains: code, for: tc.name)
+          case "cpp": check(cxxSource, contains: code, for: tc.name)
 
-          case "h":
-            check(cxxHeader, contains: code, for: tc.name)
+          case "h": check(cxxHeader, contains: code, for: tc.name)
 
-          default:
-            XCTFail("\(tc.name): unexpected test command: '\(annotation.command)'")
+          default: XCTFail("\(tc.name): unexpected test command: '\(annotation.command)'")
           }
         }
       })

--- a/Tests/ValTests/EmitterTests.swift
+++ b/Tests/ValTests/EmitterTests.swift
@@ -7,8 +7,7 @@ final class EmitterTests: XCTestCase {
   func testEmitter() throws {
     // Locate the test cases.
     let testCaseDirectory = try XCTUnwrap(
-      Bundle.module.url(forResource: "TestCases/Lowering", withExtension: nil),
-      "No test cases")
+      Bundle.module.url(forResource: "TestCases/Lowering", withExtension: nil), "No test cases")
 
     // Prepare an AST with the core module loaded.
     var baseAST = AST()
@@ -39,11 +38,8 @@ final class EmitterTests: XCTestCase {
         }
 
         let typedProgram = TypedProgram(
-          annotating: checker.program,
-          declTypes: checker.declTypes,
-          exprTypes: checker.exprTypes,
-          implicitCaptures: checker.implicitCaptures,
-          referredDecls: checker.referredDecls,
+          annotating: checker.program, declTypes: checker.declTypes, exprTypes: checker.exprTypes,
+          implicitCaptures: checker.implicitCaptures, referredDecls: checker.referredDecls,
           foldedSequenceExprs: checker.foldedSequenceExprs)
 
         // Emit Val's IR.
@@ -52,8 +48,7 @@ final class EmitterTests: XCTestCase {
 
         // Run mandatory IR analysis and transformation passes.
         var pipeline: [TransformPass] = [
-          ImplicitReturnInsertionPass(),
-          DefiniteInitializationPass(program: typedProgram),
+          ImplicitReturnInsertionPass(), DefiniteInitializationPass(program: typedProgram),
           LifetimePass(program: typedProgram),
         ]
 

--- a/Tests/ValTests/EmitterTests.swift
+++ b/Tests/ValTests/EmitterTests.swift
@@ -73,10 +73,8 @@ final class EmitterTests: XCTestCase {
             XCTAssert(!success, "\(tc.name): lowering succeeded, but expected failure")
           case "expect-success":
             XCTAssert(success, "\(tc.name): lowering failed, but expected success")
-          case "diagnostic":
-            diagnosticChecker.handle(annotation)
-          default:
-            XCTFail("\(tc.name): unexpected test command: '\(annotation.command)'")
+          case "diagnostic": diagnosticChecker.handle(annotation)
+          default: XCTFail("\(tc.name): unexpected test command: '\(annotation.command)'")
           }
         }
       })

--- a/Tests/ValTests/LexerTests.swift
+++ b/Tests/ValTests/LexerTests.swift
@@ -7,11 +7,7 @@ final class LexerTests: XCTestCase {
     let input = SourceFile(contents: "true false")
     assert(
       tokenize(input),
-      matches: [
-        TokenSpecification(.bool, "true"),
-        TokenSpecification(.bool, "false"),
-      ],
-      in: input)
+      matches: [TokenSpecification(.bool, "true"), TokenSpecification(.bool, "false")], in: input)
   }
 
   func testDecimalInteger() {
@@ -19,14 +15,10 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.int, "0"),
-        TokenSpecification(.int, "001"),
-        TokenSpecification(.int, "42"),
-        TokenSpecification(.int, "00"),
-        TokenSpecification(.int, "1_234"),
-        TokenSpecification(.int, "1_2__34__"),
-      ],
-      in: input)
+        TokenSpecification(.int, "0"), TokenSpecification(.int, "001"),
+        TokenSpecification(.int, "42"), TokenSpecification(.int, "00"),
+        TokenSpecification(.int, "1_234"), TokenSpecification(.int, "1_2__34__"),
+      ], in: input)
   }
 
   func testHexadecimalInteger() {
@@ -34,15 +26,11 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.int, "0x0123"),
-        TokenSpecification(.int, "0xabcdef"),
-        TokenSpecification(.int, "0x__0_a_"),
-        TokenSpecification(.int, "0"),
-        TokenSpecification(.name, "xg"),
-        TokenSpecification(.int, "0"),
+        TokenSpecification(.int, "0x0123"), TokenSpecification(.int, "0xabcdef"),
+        TokenSpecification(.int, "0x__0_a_"), TokenSpecification(.int, "0"),
+        TokenSpecification(.name, "xg"), TokenSpecification(.int, "0"),
         TokenSpecification(.name, "x"),
-      ],
-      in: input)
+      ], in: input)
   }
 
   func testOctalInteger() {
@@ -50,14 +38,10 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.int, "0o0123"),
-        TokenSpecification(.int, "0o__0_6_"),
-        TokenSpecification(.int, "0"),
-        TokenSpecification(.name, "o8"),
-        TokenSpecification(.int, "0"),
-        TokenSpecification(.name, "o"),
-      ],
-      in: input)
+        TokenSpecification(.int, "0o0123"), TokenSpecification(.int, "0o__0_6_"),
+        TokenSpecification(.int, "0"), TokenSpecification(.name, "o8"),
+        TokenSpecification(.int, "0"), TokenSpecification(.name, "o"),
+      ], in: input)
   }
 
   func testBinaryInteger() {
@@ -65,14 +49,10 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.int, "0b01"),
-        TokenSpecification(.int, "0b__0_1_"),
-        TokenSpecification(.int, "0"),
-        TokenSpecification(.name, "b8"),
-        TokenSpecification(.int, "0"),
-        TokenSpecification(.name, "b"),
-      ],
-      in: input)
+        TokenSpecification(.int, "0b01"), TokenSpecification(.int, "0b__0_1_"),
+        TokenSpecification(.int, "0"), TokenSpecification(.name, "b8"),
+        TokenSpecification(.int, "0"), TokenSpecification(.name, "b"),
+      ], in: input)
   }
 
   func testFloatingPoint() {
@@ -80,18 +60,12 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.float, "0.0"),
-        TokenSpecification(.float, "001.00"),
-        TokenSpecification(.float, "0.1_2__34__"),
-        TokenSpecification(.float, "1e1_000"),
-        TokenSpecification(.float, "1.12e+123"),
-        TokenSpecification(.float, "3.45E-6"),
-        TokenSpecification(.int, "1"),
-        TokenSpecification(.dot, "."),
-        TokenSpecification(.int, "1"),
+        TokenSpecification(.float, "0.0"), TokenSpecification(.float, "001.00"),
+        TokenSpecification(.float, "0.1_2__34__"), TokenSpecification(.float, "1e1_000"),
+        TokenSpecification(.float, "1.12e+123"), TokenSpecification(.float, "3.45E-6"),
+        TokenSpecification(.int, "1"), TokenSpecification(.dot, "."), TokenSpecification(.int, "1"),
         TokenSpecification(.name, "e"),
-      ],
-      in: input)
+      ], in: input)
   }
 
   func testString() {
@@ -99,13 +73,10 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.string, #""""#),
-        TokenSpecification(.string, #""a 0+ ""#),
-        TokenSpecification(.string, #""a\nb""#),
-        TokenSpecification(.string, #""a\"""#),
+        TokenSpecification(.string, #""""#), TokenSpecification(.string, #""a 0+ ""#),
+        TokenSpecification(.string, #""a\nb""#), TokenSpecification(.string, #""a\"""#),
         TokenSpecification(.unterminatedString, #""abc "#),
-      ],
-      in: input)
+      ], in: input)
   }
 
   func testKeywords() {
@@ -119,50 +90,28 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.`any`, "any"),
-        TokenSpecification(.`break`, "break"),
-        TokenSpecification(.`catch`, "catch"),
-        TokenSpecification(.`conformance`, "conformance"),
-        TokenSpecification(.`continue`, "continue"),
-        TokenSpecification(.`deinit`, "deinit"),
-        TokenSpecification(.`do`, "do"),
-        TokenSpecification(.`else`, "else"),
-        TokenSpecification(.`extension`, "extension"),
-        TokenSpecification(.`for`, "for"),
-        TokenSpecification(.`fun`, "fun"),
-        TokenSpecification(.`if`, "if"),
-        TokenSpecification(.`import`, "import"),
-        TokenSpecification(.`in`, "in"),
-        TokenSpecification(.`infix`, "infix"),
-        TokenSpecification(.`init`, "init"),
-        TokenSpecification(.`inout`, "inout"),
-        TokenSpecification(.`let`, "let"),
-        TokenSpecification(.`match`, "match"),
-        TokenSpecification(.`namespace`, "namespace"),
-        TokenSpecification(.`nil`, "nil"),
-        TokenSpecification(.`operator`, "operator"),
-        TokenSpecification(.`postfix`, "postfix"),
-        TokenSpecification(.`prefix`, "prefix"),
-        TokenSpecification(.`property`, "property"),
-        TokenSpecification(.`public`, "public"),
-        TokenSpecification(.`return`, "return"),
-        TokenSpecification(.`set`, "set"),
-        TokenSpecification(.`sink`, "sink"),
-        TokenSpecification(.`some`, "some"),
-        TokenSpecification(.`spawn`, "spawn"),
-        TokenSpecification(.`static`, "static"),
-        TokenSpecification(.`subscript`, "subscript"),
-        TokenSpecification(.`trait`, "trait"),
-        TokenSpecification(.`try`, "try"),
-        TokenSpecification(.`type`, "type"),
-        TokenSpecification(.`typealias`, "typealias"),
-        TokenSpecification(.`var`, "var"),
-        TokenSpecification(.`where`, "where"),
-        TokenSpecification(.`while`, "while"),
-        TokenSpecification(.`yield`, "yield"),
-        TokenSpecification(.`yielded`, "yielded"),
-      ],
-      in: input)
+        TokenSpecification(.`any`, "any"), TokenSpecification(.`break`, "break"),
+        TokenSpecification(.`catch`, "catch"), TokenSpecification(.`conformance`, "conformance"),
+        TokenSpecification(.`continue`, "continue"), TokenSpecification(.`deinit`, "deinit"),
+        TokenSpecification(.`do`, "do"), TokenSpecification(.`else`, "else"),
+        TokenSpecification(.`extension`, "extension"), TokenSpecification(.`for`, "for"),
+        TokenSpecification(.`fun`, "fun"), TokenSpecification(.`if`, "if"),
+        TokenSpecification(.`import`, "import"), TokenSpecification(.`in`, "in"),
+        TokenSpecification(.`infix`, "infix"), TokenSpecification(.`init`, "init"),
+        TokenSpecification(.`inout`, "inout"), TokenSpecification(.`let`, "let"),
+        TokenSpecification(.`match`, "match"), TokenSpecification(.`namespace`, "namespace"),
+        TokenSpecification(.`nil`, "nil"), TokenSpecification(.`operator`, "operator"),
+        TokenSpecification(.`postfix`, "postfix"), TokenSpecification(.`prefix`, "prefix"),
+        TokenSpecification(.`property`, "property"), TokenSpecification(.`public`, "public"),
+        TokenSpecification(.`return`, "return"), TokenSpecification(.`set`, "set"),
+        TokenSpecification(.`sink`, "sink"), TokenSpecification(.`some`, "some"),
+        TokenSpecification(.`spawn`, "spawn"), TokenSpecification(.`static`, "static"),
+        TokenSpecification(.`subscript`, "subscript"), TokenSpecification(.`trait`, "trait"),
+        TokenSpecification(.`try`, "try"), TokenSpecification(.`type`, "type"),
+        TokenSpecification(.`typealias`, "typealias"), TokenSpecification(.`var`, "var"),
+        TokenSpecification(.`where`, "where"), TokenSpecification(.`while`, "while"),
+        TokenSpecification(.`yield`, "yield"), TokenSpecification(.`yielded`, "yielded"),
+      ], in: input)
   }
 
   func testIdentifiers() {
@@ -170,13 +119,10 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.name, "foo"),
-        TokenSpecification(.name, "éléphant"),
-        TokenSpecification(.name, "_bar"),
-        TokenSpecification(.name, "_1_2_3"),
+        TokenSpecification(.name, "foo"), TokenSpecification(.name, "éléphant"),
+        TokenSpecification(.name, "_bar"), TokenSpecification(.name, "_1_2_3"),
         TokenSpecification(.under, "_"),
-      ],
-      in: input)
+      ], in: input)
   }
 
   func testBackquotedIdentifier() {
@@ -184,14 +130,10 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.name, "type"),
-        TokenSpecification(.name, "foo"),
-        TokenSpecification(.name, "a_b_"),
-        TokenSpecification(.invalid, "`"),
-        TokenSpecification(.int, "12"),
-        TokenSpecification(.invalid, "`"),
-      ],
-      in: input)
+        TokenSpecification(.name, "type"), TokenSpecification(.name, "foo"),
+        TokenSpecification(.name, "a_b_"), TokenSpecification(.invalid, "`"),
+        TokenSpecification(.int, "12"), TokenSpecification(.invalid, "`"),
+      ], in: input)
   }
 
   func testAttributes() {
@@ -199,12 +141,9 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.attribute, "@implicitcopy"),
-        TokenSpecification(.attribute, "@_foo"),
-        TokenSpecification(.invalid, "@"),
-        TokenSpecification(.int, "2"),
-      ],
-      in: input)
+        TokenSpecification(.attribute, "@implicitcopy"), TokenSpecification(.attribute, "@_foo"),
+        TokenSpecification(.invalid, "@"), TokenSpecification(.int, "2"),
+      ], in: input)
   }
 
   func testOperators() {
@@ -212,28 +151,17 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.assign, "="),
-        TokenSpecification(.arrow, "->"),
-        TokenSpecification(.oper, "*"),
-        TokenSpecification(.oper, "/"),
-        TokenSpecification(.oper, "%"),
-        TokenSpecification(.oper, "+-"),
-        TokenSpecification(.equal, "=="),
-        TokenSpecification(.oper, "!="),
-        TokenSpecification(.oper, "~>"),
-        TokenSpecification(.rAngle, ">"),
-        TokenSpecification(.oper, "!"),
-        TokenSpecification(.lAngle, "<"),
-        TokenSpecification(.oper, "?"),
-        TokenSpecification(.rAngle, ">"),
-        TokenSpecification(.rAngle, ">"),
-        TokenSpecification(.oper, "&|^"),
-        TokenSpecification(.oper, "..."),
-        TokenSpecification(.oper, "..<"),
-        TokenSpecification(.pipe, "|"),
-        TokenSpecification(.ampersand, "&"),
-      ],
-      in: input)
+        TokenSpecification(.assign, "="), TokenSpecification(.arrow, "->"),
+        TokenSpecification(.oper, "*"), TokenSpecification(.oper, "/"),
+        TokenSpecification(.oper, "%"), TokenSpecification(.oper, "+-"),
+        TokenSpecification(.equal, "=="), TokenSpecification(.oper, "!="),
+        TokenSpecification(.oper, "~>"), TokenSpecification(.rAngle, ">"),
+        TokenSpecification(.oper, "!"), TokenSpecification(.lAngle, "<"),
+        TokenSpecification(.oper, "?"), TokenSpecification(.rAngle, ">"),
+        TokenSpecification(.rAngle, ">"), TokenSpecification(.oper, "&|^"),
+        TokenSpecification(.oper, "..."), TokenSpecification(.oper, "..<"),
+        TokenSpecification(.pipe, "|"), TokenSpecification(.ampersand, "&"),
+      ], in: input)
   }
 
   func testCastOperators() {
@@ -241,11 +169,9 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.cast, "is"),
-        TokenSpecification(.cast, "as"),
+        TokenSpecification(.cast, "is"), TokenSpecification(.cast, "as"),
         TokenSpecification(.cast, "as!"),
-      ],
-      in: input)
+      ], in: input)
   }
 
   func testPunctuation() {
@@ -253,13 +179,10 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.comma, ","),
-        TokenSpecification(.semi, ";"),
-        TokenSpecification(.dot, "."),
-        TokenSpecification(.colon, ":"),
+        TokenSpecification(.comma, ","), TokenSpecification(.semi, ";"),
+        TokenSpecification(.dot, "."), TokenSpecification(.colon, ":"),
         TokenSpecification(.twoColons, "::"),
-      ],
-      in: input)
+      ], in: input)
   }
 
   func testDelimiters() {
@@ -267,16 +190,11 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.lParen, "("),
-        TokenSpecification(.rParen, ")"),
-        TokenSpecification(.lBrack, "["),
-        TokenSpecification(.rBrack, "]"),
-        TokenSpecification(.lBrace, "{"),
-        TokenSpecification(.rBrace, "}"),
-        TokenSpecification(.lAngle, "<"),
-        TokenSpecification(.rAngle, ">"),
-      ],
-      in: input)
+        TokenSpecification(.lParen, "("), TokenSpecification(.rParen, ")"),
+        TokenSpecification(.lBrack, "["), TokenSpecification(.rBrack, "]"),
+        TokenSpecification(.lBrace, "{"), TokenSpecification(.rBrace, "}"),
+        TokenSpecification(.lAngle, "<"), TokenSpecification(.rAngle, ">"),
+      ], in: input)
   }
 
   func testComments() {
@@ -295,20 +213,15 @@ final class LexerTests: XCTestCase {
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.name, "a"),
-        TokenSpecification(.assign, "="),
+        TokenSpecification(.name, "a"), TokenSpecification(.assign, "="),
         TokenSpecification(.name, "b"),
         TokenSpecification(.unterminatedBlockComment, "/**** /* Unterminated */"),
-      ],
-      in: input)
+      ], in: input)
   }
 
   func testInvalid() {
     let input = SourceFile(contents: "\0")
-    assert(
-      tokenize(input),
-      matches: [TokenSpecification(.invalid, "\0")],
-      in: input)
+    assert(tokenize(input), matches: [TokenSpecification(.invalid, "\0")], in: input)
   }
 
   private func tokenize(_ input: SourceFile) -> [Token] {
@@ -317,31 +230,22 @@ final class LexerTests: XCTestCase {
   }
 
   private func assert(
-    _ tokens: [Token],
-    matches specs: [TokenSpecification],
-    in source: SourceFile,
-    file: StaticString = #filePath,
-    line: UInt = #line
+    _ tokens: [Token], matches specs: [TokenSpecification], in source: SourceFile,
+    file: StaticString = #filePath, line: UInt = #line
   ) {
     // The list of tokens should have the same lenght as that of the specifications.
     XCTAssert(
-      tokens.count == specs.count,
-      "expected \(specs.count) token(s), found \(tokens.count)",
-      file: file,
-      line: line)
+      tokens.count == specs.count, "expected \(specs.count) token(s), found \(tokens.count)",
+      file: file, line: line)
 
     for (token, spec) in zip(tokens, specs) {
       XCTAssert(
-        token.kind == spec.kind,
-        "token has kind '\(token.kind)', not '\(spec.kind)'",
-        file: spec.file,
-        line: spec.line)
+        token.kind == spec.kind, "token has kind '\(token.kind)', not '\(spec.kind)'",
+        file: spec.file, line: spec.line)
 
       let value = source[token.origin]
       XCTAssert(
-        value == spec.value,
-        "token has value '\(value)', not '\(spec.value)'",
-        file: spec.file,
+        value == spec.value, "token has value '\(value)', not '\(spec.value)'", file: spec.file,
         line: spec.line)
     }
   }

--- a/Tests/ValTests/ParserTests.swift
+++ b/Tests/ValTests/ParserTests.swift
@@ -21,18 +21,14 @@ final class ParserTests: XCTestCase {
         let diagnostics: [Diagnostic]
         do {
           diagnostics = try Parser.parse(tc.source, into: module, in: &ast).diagnostics
-        } catch let error as DiagnosedError {
-          diagnostics = error.diagnostics
-        }
+        } catch let error as DiagnosedError { diagnostics = error.diagnostics }
 
         // Process the test annotations.
         var diagnosticChecker = DiagnosticChecker(testCaseName: tc.name, diagnostics: diagnostics)
         for annotation in tc.annotations {
           switch annotation.command {
-          case "diagnostic":
-            diagnosticChecker.handle(annotation)
-          default:
-            XCTFail("\(tc.name): unexpected test command: '\(annotation.command)'")
+          case "diagnostic": diagnosticChecker.handle(annotation)
+          default: XCTFail("\(tc.name): unexpected test command: '\(annotation.command)'")
           }
         }
 
@@ -455,10 +451,7 @@ final class ParserTests: XCTestCase {
     let input = SourceFile(contents: "fun id<T: Sinkable>(_ x: T) -> T { x }")
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseFunctionOrMethodDecl)
     let decl = try XCTUnwrap(ast[declID] as? FunctionDecl)
-    if case .expr = decl.body {
-    } else {
-      XCTFail()
-    }
+    if case .expr = decl.body {} else { XCTFail() }
   }
 
   func testPostifxFunctionDecl() throws {
@@ -541,19 +534,13 @@ final class ParserTests: XCTestCase {
   func testFunctionDeclBodyBlock() throws {
     let input = SourceFile(contents: "{}")
     let (body, _) = try apply(Parser.functionDeclBody, on: input)
-    if case .block = body {
-    } else {
-      XCTFail()
-    }
+    if case .block = body {} else { XCTFail() }
   }
 
   func testFunctionDeclBodyExpr() throws {
     let input = SourceFile(contents: "{ 0x2a }")
     let (body, _) = try apply(Parser.functionDeclBody, on: input)
-    if case .expr = body {
-    } else {
-      XCTFail()
-    }
+    if case .expr = body {} else { XCTFail() }
   }
 
   func testMethodDeclBody() throws {
@@ -573,20 +560,14 @@ final class ParserTests: XCTestCase {
     let input = SourceFile(contents: "let { }")
     let (declID, ast) = try apply(Parser.methodImplDecl, on: input)
     let decl = try XCTUnwrap(ast[declID])
-    if case .block = decl.body {
-    } else {
-      XCTFail()
-    }
+    if case .block = decl.body {} else { XCTFail() }
   }
 
   func testMethodImplExpr() throws {
     let input = SourceFile(contents: "let { foo }")
     let (declID, ast) = try apply(Parser.methodImplDecl, on: input)
     let decl = try XCTUnwrap(ast[declID])
-    if case .expr = decl.body {
-    } else {
-      XCTFail()
-    }
+    if case .expr = decl.body {} else { XCTFail() }
   }
 
   func testPropertyDecl() throws {
@@ -675,10 +656,7 @@ final class ParserTests: XCTestCase {
     XCTAssertEqual(body?.count, 1)
     if let impl = ast[body?.first] {
       XCTAssertEqual(impl.introducer.value, .let)
-      if case .block = impl.body {
-      } else {
-        XCTFail()
-      }
+      if case .block = impl.body {} else { XCTFail() }
     }
   }
 
@@ -691,10 +669,7 @@ final class ParserTests: XCTestCase {
     XCTAssertEqual(body?.count, 1)
     if let impl = ast[body?.first] {
       XCTAssertEqual(impl.introducer.value, .let)
-      if case .expr = impl.body {
-      } else {
-        XCTFail()
-      }
+      if case .expr = impl.body {} else { XCTFail() }
     }
   }
 
@@ -1201,20 +1176,14 @@ final class ParserTests: XCTestCase {
     let input = SourceFile(contents: "let (x, 0x2a) { }")
     let (caseID, ast) = try apply(Parser.matchCase, on: input)
     let case_ = try XCTUnwrap(ast[caseID])
-    if case .block = case_.body {
-    } else {
-      XCTFail()
-    }
+    if case .block = case_.body {} else { XCTFail() }
   }
 
   func testMatchCaseExpr() throws {
     let input = SourceFile(contents: "let (x, 0x2a) { x }")
     let (caseID, ast) = try apply(Parser.matchCase, on: input)
     let case_ = try XCTUnwrap(ast[caseID])
-    if case .expr = case_.body {
-    } else {
-      XCTFail()
-    }
+    if case .expr = case_.body {} else { XCTFail() }
   }
 
   func testMatchCaseWithCondition() throws {
@@ -1243,10 +1212,7 @@ final class ParserTests: XCTestCase {
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? CondExpr)
 
-    if case .block = expr.success {
-    } else {
-      XCTFail()
-    }
+    if case .block = expr.success {} else { XCTFail() }
 
     XCTAssertNil(expr.failure)
   }
@@ -1256,15 +1222,9 @@ final class ParserTests: XCTestCase {
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? CondExpr)
 
-    if case .block = expr.success {
-    } else {
-      XCTFail()
-    }
+    if case .block = expr.success {} else { XCTFail() }
 
-    if case .block = expr.failure {
-    } else {
-      XCTFail()
-    }
+    if case .block = expr.failure {} else { XCTFail() }
   }
 
   func testConditionalExprExprThenExprElse() throws {
@@ -1272,15 +1232,9 @@ final class ParserTests: XCTestCase {
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? CondExpr)
 
-    if case .expr = expr.success {
-    } else {
-      XCTFail()
-    }
+    if case .expr = expr.success {} else { XCTFail() }
 
-    if case .expr = expr.failure {
-    } else {
-      XCTFail()
-    }
+    if case .expr = expr.failure {} else { XCTFail() }
   }
 
   func testConditionalExprExprElseIfElse() throws {
@@ -1314,9 +1268,7 @@ final class ParserTests: XCTestCase {
     let expr = try XCTUnwrap(ast[exprID] as? TupleExpr)
     XCTAssertEqual(expr.elements.count, 1)
 
-    if expr.elements.count == 1 {
-      XCTAssertNil(expr.elements[0].label)
-    }
+    if expr.elements.count == 1 { XCTAssertNil(expr.elements[0].label) }
   }
 
   func testTupleExprWithMultipleElements() throws {
@@ -1339,9 +1291,7 @@ final class ParserTests: XCTestCase {
     let expr = try XCTUnwrap(ast[exprID] as? TupleTypeExpr)
     XCTAssertEqual(expr.elements.count, 1)
 
-    if expr.elements.count == 1 {
-      XCTAssertNil(expr.elements[0].label)
-    }
+    if expr.elements.count == 1 { XCTAssertNil(expr.elements[0].label) }
   }
 
   func testTupleTypeExprWithMultipleElements() throws {
@@ -1524,9 +1474,7 @@ final class ParserTests: XCTestCase {
     let pattern = try XCTUnwrap(ast[patternID])
     XCTAssertEqual(pattern.elements.count, 1)
 
-    if pattern.elements.count == 1 {
-      XCTAssertNil(pattern.elements[0].label)
-    }
+    if pattern.elements.count == 1 { XCTAssertNil(pattern.elements[0].label) }
   }
 
   func testTuplePatternWithMultipleElements() throws {
@@ -1641,30 +1589,21 @@ final class ParserTests: XCTestCase {
     let input = SourceFile(contents: "var x = foo() else return")
     let (stmtID, ast) = try apply(Parser.conditionalBindingStmt, on: input, context: .functionBody)
     let stmt = try XCTUnwrap(ast[stmtID])
-    if case .exit = stmt.fallback {
-    } else {
-      XCTFail()
-    }
+    if case .exit = stmt.fallback {} else { XCTFail() }
   }
 
   func testConditionalBindingBlock() throws {
     let input = SourceFile(contents: "var x = foo() else { bar(); return }")
     let (stmtID, ast) = try apply(Parser.conditionalBindingStmt, on: input, context: .functionBody)
     let stmt = try XCTUnwrap(ast[stmtID])
-    if case .exit = stmt.fallback {
-    } else {
-      XCTFail()
-    }
+    if case .exit = stmt.fallback {} else { XCTFail() }
   }
 
   func testConditionalBindingExpr() throws {
     let input = SourceFile(contents: "var x = foo() else fatal_error()")
     let (stmtID, ast) = try apply(Parser.conditionalBindingStmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID])
-    if case .expr = stmt.fallback {
-    } else {
-      XCTFail()
-    }
+    if case .expr = stmt.fallback {} else { XCTFail() }
   }
 
   func testConditionalBindingFallback() throws {
@@ -1732,9 +1671,7 @@ extension SourceFile {
     with parser: (inout ParserState) throws -> Element
   ) rethrows -> (element: Element, ast: AST) {
     var state = ParserState(ast: AST(), lexer: Lexer(tokenizing: self))
-    if let c = context {
-      state.contexts.append(c)
-    }
+    if let c = context { state.contexts.append(c) }
 
     let element = try parser(&state)
     return (element, state.ast)
@@ -1747,9 +1684,7 @@ extension SourceFile {
   ) rethrows -> (element: Element?, ast: AST) {
     try parse(
       inContext: context,
-      with: { (state) in
-        try Parser.parseDeclPrologue(in: &state, then: parser)
-      })
+      with: { (state) in try Parser.parseDeclPrologue(in: &state, then: parser) })
   }
 
 }

--- a/Tests/ValTests/ParserTests.swift
+++ b/Tests/ValTests/ParserTests.swift
@@ -8,8 +8,7 @@ final class ParserTests: XCTestCase {
   func testParser() throws {
     // Locate the test cases.
     let testCaseDirectory = try XCTUnwrap(
-      Bundle.module.url(forResource: "TestCases/Parsing", withExtension: nil),
-      "No test cases")
+      Bundle.module.url(forResource: "TestCases/Parsing", withExtension: nil), "No test cases")
 
     // Execute the test cases.
     try TestCase.executeAll(
@@ -276,8 +275,7 @@ final class ParserTests: XCTestCase {
   func testAssociatedTypeDecl() throws {
     let input = SourceFile(contents: "type Foo")
     let (declID, ast) = try input.parseWithDeclPrologue(
-      inContext: .traitBody,
-      with: Parser.parseAssociatedTypeDecl)
+      inContext: .traitBody, with: Parser.parseAssociatedTypeDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.identifier.value, "Foo")
   }
@@ -285,8 +283,7 @@ final class ParserTests: XCTestCase {
   func testAssociatedTypeDeclWithConformances() throws {
     let input = SourceFile(contents: "type Foo: Bar, Ham")
     let (declID, ast) = try input.parseWithDeclPrologue(
-      inContext: .traitBody,
-      with: Parser.parseAssociatedTypeDecl)
+      inContext: .traitBody, with: Parser.parseAssociatedTypeDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.conformances)
   }
@@ -294,8 +291,7 @@ final class ParserTests: XCTestCase {
   func testAssociatedTypeDeclWithWhereClause() throws {
     let input = SourceFile(contents: "type Foo where Foo.Bar == Ham")
     let (declID, ast) = try input.parseWithDeclPrologue(
-      inContext: .traitBody,
-      with: Parser.parseAssociatedTypeDecl)
+      inContext: .traitBody, with: Parser.parseAssociatedTypeDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.whereClause)
   }
@@ -303,8 +299,7 @@ final class ParserTests: XCTestCase {
   func testAssociatedTypeDeclWithWithDefault() throws {
     let input = SourceFile(contents: "type Foo = X")
     let (declID, ast) = try input.parseWithDeclPrologue(
-      inContext: .traitBody,
-      with: Parser.parseAssociatedTypeDecl)
+      inContext: .traitBody, with: Parser.parseAssociatedTypeDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.defaultValue)
   }
@@ -312,8 +307,7 @@ final class ParserTests: XCTestCase {
   func testAssociatedValueDecl() throws {
     let input = SourceFile(contents: "value foo")
     let (declID, ast) = try input.parseWithDeclPrologue(
-      inContext: .traitBody,
-      with: Parser.parseAssociatedValueDecl)
+      inContext: .traitBody, with: Parser.parseAssociatedValueDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.identifier.value, "foo")
   }
@@ -321,8 +315,7 @@ final class ParserTests: XCTestCase {
   func testAssociatedValueDeclWithWhereClause() throws {
     let input = SourceFile(contents: "value foo where @value foo > bar")
     let (declID, ast) = try input.parseWithDeclPrologue(
-      inContext: .traitBody,
-      with: Parser.parseAssociatedValueDecl)
+      inContext: .traitBody, with: Parser.parseAssociatedValueDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.whereClause)
   }
@@ -330,9 +323,7 @@ final class ParserTests: XCTestCase {
   /*
   func testAssociatedValueDeclWithWhereClauseSansHint() throws {
     let input = SourceFile(contents: "value foo where foo > bar")
-    let (declID, ast) = try input.parseWithDeclPrologue(
-      inContext: .traitBody,
-      with: Parser.parseAssociatedValueDecl)
+    let (declID, ast) = try input.parseWithDeclPrologue(       inContext: .traitBody,       with: Parser.parseAssociatedValueDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.whereClause)
   }
@@ -341,8 +332,7 @@ final class ParserTests: XCTestCase {
   func testAssociatedValueDeclWithDefault() throws {
     let input = SourceFile(contents: "value foo = 42")
     let (declID, ast) = try input.parseWithDeclPrologue(
-      inContext: .traitBody,
-      with: Parser.parseAssociatedValueDecl)
+      inContext: .traitBody, with: Parser.parseAssociatedValueDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.defaultValue)
   }
@@ -494,8 +484,7 @@ final class ParserTests: XCTestCase {
 
   func testFunctionDeclSignature() throws {
     let input = SourceFile(contents: "()")
-    let signature = try XCTUnwrap(
-      input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
+    let signature = try XCTUnwrap(input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
     XCTAssertEqual(signature.parameters.count, 0)
     XCTAssertNil(signature.receiverEffect)
     XCTAssertNil(signature.output)
@@ -503,8 +492,7 @@ final class ParserTests: XCTestCase {
 
   func testFunctionDeclSignatureWithParameters() throws {
     let input = SourceFile(contents: "(_ foo: Foo, bar: Bar = .default)")
-    let signature = try XCTUnwrap(
-      input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
+    let signature = try XCTUnwrap(input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
     XCTAssertEqual(signature.parameters.count, 2)
     XCTAssertNil(signature.receiverEffect)
     XCTAssertNil(signature.output)
@@ -512,8 +500,7 @@ final class ParserTests: XCTestCase {
 
   func testFunctionDeclSignatureWithEffect() throws {
     let input = SourceFile(contents: "(_ foo: Foo) inout")
-    let signature = try XCTUnwrap(
-      input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
+    let signature = try XCTUnwrap(input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
     XCTAssertEqual(signature.parameters.count, 1)
     XCTAssertEqual(signature.receiverEffect?.value, .inout)
     XCTAssertNil(signature.output)
@@ -521,8 +508,7 @@ final class ParserTests: XCTestCase {
 
   func testFunctionDeclSignatureWithOutput() throws {
     let input = SourceFile(contents: "(_ foo: Foo) -> C")
-    let signature = try XCTUnwrap(
-      input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
+    let signature = try XCTUnwrap(input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
     XCTAssertEqual(signature.parameters.count, 1)
     XCTAssertNil(signature.receiverEffect)
     XCTAssertEqual(signature.output?.kind, NodeKind(NameExpr.self))
@@ -530,8 +516,7 @@ final class ParserTests: XCTestCase {
 
   func testFunctionDeclSignatureWithOutputAndEffect() throws {
     let input = SourceFile(contents: "(_ foo: Foo) sink -> C")
-    let signature = try XCTUnwrap(
-      input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
+    let signature = try XCTUnwrap(input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
     XCTAssertEqual(signature.parameters.count, 1)
     XCTAssertEqual(signature.receiverEffect?.value, .sink)
     XCTAssertEqual(signature.output?.kind, .init(NameExpr.self))
@@ -1654,8 +1639,7 @@ final class ParserTests: XCTestCase {
 
   func testConditionalBinding() throws {
     let input = SourceFile(contents: "var x = foo() else return")
-    let (stmtID, ast) = try apply(
-      Parser.conditionalBindingStmt, on: input, context: .functionBody)
+    let (stmtID, ast) = try apply(Parser.conditionalBindingStmt, on: input, context: .functionBody)
     let stmt = try XCTUnwrap(ast[stmtID])
     if case .exit = stmt.fallback {
     } else {
@@ -1665,8 +1649,7 @@ final class ParserTests: XCTestCase {
 
   func testConditionalBindingBlock() throws {
     let input = SourceFile(contents: "var x = foo() else { bar(); return }")
-    let (stmtID, ast) = try apply(
-      Parser.conditionalBindingStmt, on: input, context: .functionBody)
+    let (stmtID, ast) = try apply(Parser.conditionalBindingStmt, on: input, context: .functionBody)
     let stmt = try XCTUnwrap(ast[stmtID])
     if case .exit = stmt.fallback {
     } else {
@@ -1686,9 +1669,7 @@ final class ParserTests: XCTestCase {
 
   func testConditionalBindingFallback() throws {
     let input = SourceFile(contents: "return")
-    XCTAssertNotNil(
-      try apply(
-        Parser.conditionalBindingStmt, on: input, context: .functionBody))
+    XCTAssertNotNil(try apply(Parser.conditionalBindingStmt, on: input, context: .functionBody))
   }
 
   func testDeclStmt() throws {
@@ -1736,9 +1717,7 @@ final class ParserTests: XCTestCase {
 
   /// Applies `combinator` on `input`, optionally setting `context` in the parser state.
   func apply<C: Combinator>(
-    _ combinator: C,
-    on input: SourceFile,
-    context: ParserState.Context? = nil
+    _ combinator: C, on input: SourceFile, context: ParserState.Context? = nil
   ) throws -> (element: C.Element?, ast: AST) where C.Context == ParserState {
     try input.parse(inContext: context, with: combinator.parse(_:))
   }

--- a/Tests/ValTests/TypeCheckerTests.swift
+++ b/Tests/ValTests/TypeCheckerTests.swift
@@ -45,10 +45,8 @@ final class TypeCheckerTests: XCTestCase {
             XCTAssert(!success, "\(tc.name): type checking succeeded, but expected failure")
           case "expect-success":
             XCTAssert(success, "\(tc.name): type checking failed, but expected success")
-          case "diagnostic":
-            diagnosticChecker.handle(annotation)
-          default:
-            XCTFail("\(tc.name): unexpected test command: '\(annotation.command)'")
+          case "diagnostic": diagnosticChecker.handle(annotation)
+          default: XCTFail("\(tc.name): unexpected test command: '\(annotation.command)'")
           }
         }
 

--- a/Tests/ValTests/TypeCheckerTests.swift
+++ b/Tests/ValTests/TypeCheckerTests.swift
@@ -7,8 +7,7 @@ final class TypeCheckerTests: XCTestCase {
   func testTypeChecker() throws {
     // Locate the test cases.
     let testCaseDirectory = try XCTUnwrap(
-      Bundle.module.url(forResource: "TestCases/TypeChecking", withExtension: nil),
-      "No test cases")
+      Bundle.module.url(forResource: "TestCases/TypeChecking", withExtension: nil), "No test cases")
 
     // Prepare an AST with the core module loaded.
     var baseAST = AST()

--- a/Tests/ValTests/Utils/DiagnosticChecker.swift
+++ b/Tests/ValTests/Utils/DiagnosticChecker.swift
@@ -22,9 +22,7 @@ struct DiagnosticChecker {
 
   /// Handles a `diagnositc` test annotation.
   mutating func handle(
-    _ annotation: TestAnnotation,
-    file: StaticString = #filePath,
-    line: UInt = #line
+    _ annotation: TestAnnotation, file: StaticString = #filePath, line: UInt = #line
   ) {
     assert(annotation.command == "diagnostic")
 
@@ -32,8 +30,7 @@ struct DiagnosticChecker {
     var report = emittedDiagnostics[annotation.location, default: []]
     guard let i = report.firstIndex(where: { $0.message == annotation.argument }) else {
       XCTFail(
-        "\(testCaseName): missing expected diagnostic at \(annotation.location)",
-        file: file,
+        "\(testCaseName): missing expected diagnostic at \(annotation.location)", file: file,
         line: line)
       return
     }
@@ -47,8 +44,7 @@ struct DiagnosticChecker {
   func finalize(file: StaticString = #filePath, line: UInt = #line) {
     XCTAssert(
       emittedDiagnostics.isEmpty,
-      "\(testCaseName): \(emittedDiagnostics.count) unexpected diagnostic(s)",
-      file: file,
+      "\(testCaseName): \(emittedDiagnostics.count) unexpected diagnostic(s)", file: file,
       line: line)
   }
 

--- a/Tests/ValTests/Utils/DiagnosticChecker.swift
+++ b/Tests/ValTests/Utils/DiagnosticChecker.swift
@@ -14,10 +14,7 @@ struct DiagnosticChecker {
   init<S: Sequence>(testCaseName: String, diagnostics: S) where S.Element == Diagnostic {
     self.testCaseName = testCaseName
     self.emittedDiagnostics = diagnostics.reduce(
-      into: [:],
-      { (ds, d) in
-        ds[d.location.map(LineLocation.init), default: []].append(d)
-      })
+      into: [:], { (ds, d) in ds[d.location.map(LineLocation.init), default: []].append(d) })
   }
 
   /// Handles a `diagnositc` test annotation.

--- a/Tests/ValTests/Utils/TestAnnotation.swift
+++ b/Tests/ValTests/Utils/TestAnnotation.swift
@@ -57,8 +57,7 @@ struct TestAnnotation {
   /// - Parameters:
   ///   - location: The line location of the annotation.
   ///   - body: A collection of characters representing an annotation body.
-  init<S: Collection>(at location: LineLocation, parsing body: S)
-  where S.Element == Character {
+  init<S: Collection>(at location: LineLocation, parsing body: S) where S.Element == Character {
     self.location = location
 
     var s = body.drop(while: { $0.isWhitespace })
@@ -128,9 +127,7 @@ struct TestAnnotation {
         index = stream.index(index, offsetBy: 2)
 
         // We recognized '/*'; ignore if we're already parsing a block comment.
-        if openedBlockComments > 1 {
-          continue
-        }
+        if openedBlockComments > 1 { continue }
 
         // Otherwise, check if the next character is `!` or interpret as a regular block comment.
         assert(indexAfterAnnotationBlockOpener == nil)
@@ -143,8 +140,7 @@ struct TestAnnotation {
       // Look for the closing delimiter of a multiline comment.
       if stream[index...].starts(with: "*/") {
         switch openedBlockComments {
-        case 0:
-          break
+        case 0: break
 
         case 1:
           openedBlockComments = 0
@@ -155,8 +151,7 @@ struct TestAnnotation {
             indexAfterAnnotationBlockOpener = nil
           }
 
-        default:
-          openedBlockComments -= 1
+        default: openedBlockComments -= 1
         }
 
         index = stream.index(index, offsetBy: 2)
@@ -173,9 +168,7 @@ struct TestAnnotation {
       if stream[index...].starts(with: "//") {
         index = stream.index(index, offsetBy: 2)
         let start: String.Index? =
-          (index != stream.endIndex) && (stream[index] == "!")
-          ? stream.index(after: index)
-          : nil
+          (index != stream.endIndex) && (stream[index] == "!") ? stream.index(after: index) : nil
 
         while (index < stream.endIndex) && !stream[index].isNewline {
           index = stream.index(after: index)

--- a/Tests/ValTests/Utils/TestAnnotation.swift
+++ b/Tests/ValTests/Utils/TestAnnotation.swift
@@ -151,8 +151,7 @@ struct TestAnnotation {
           if let start = indexAfterAnnotationBlockOpener {
             annotations.append(
               TestAnnotation(
-                at: LineLocation(url: source.url, line: line),
-                parsing: stream[start..<index]))
+                at: LineLocation(url: source.url, line: line), parsing: stream[start..<index]))
             indexAfterAnnotationBlockOpener = nil
           }
 
@@ -185,8 +184,7 @@ struct TestAnnotation {
         if let start = start {
           annotations.append(
             TestAnnotation(
-              at: LineLocation(url: source.url, line: line),
-              parsing: stream[start..<index]))
+              at: LineLocation(url: source.url, line: line), parsing: stream[start..<index]))
         }
 
         continue

--- a/Tests/ValTests/Utils/TestCase.swift
+++ b/Tests/ValTests/Utils/TestCase.swift
@@ -24,8 +24,7 @@ struct TestCase {
   static func executeAll(in directory: URL, _ handler: (Self) throws -> Void) throws {
     try withFiles(
       in: directory,
-      { (url) in
-        try handler(TestCase(source: SourceFile(contentsOf: url)))
+      { (url) in try handler(TestCase(source: SourceFile(contentsOf: url)))
         return true
       })
   }


### PR DESCRIPTION
There are two commits here, that should be considered separately.

In the first one, I replaced all breaks after “`(`”, “`[`”, and “`,`” and before “`)`” and “`]`” with spaces and ran the swift-format again.  

In the second commit, I turned off the `respectsExistingLineBreaks` option in the swift-format and let it determine all line breaks.

I don't love _all_ of the results (particularly in long parameter—but not argument—lists), but I believe in some cases it's significantly more readable.  WDYT?

See also #145