### PR TITLE
Inner typed

### DIFF
--- a/Sources/Compiler/CXX/CXXModule.swift
+++ b/Sources/Compiler/CXX/CXXModule.swift
@@ -4,7 +4,7 @@ import Utils
 public struct CXXModule {
 
   /// The module's declaration in Val's AST.
-  public let valDecl: Typed<ModuleDecl>
+  public let valDecl: ModuleDecl.Typed
 
   /// The typed program for wich we are constructing the CXX translation.
   public let program: TypedProgram
@@ -17,9 +17,9 @@ public struct CXXModule {
   public private(set) var cxxFunctionBodies: [CXXRepresentable?] = []
 
   /// A table mapping val function declarations to the ID of the corresponding C++ declaration.
-  private var valToCXXFunction: [Typed<FunctionDecl>: Int] = [:]
+  private var valToCXXFunction: [FunctionDecl.Typed: Int] = [:]
 
-  public init(_ decl: Typed<ModuleDecl>, for program: TypedProgram) {
+  public init(_ decl: ModuleDecl.Typed, for program: TypedProgram) {
     self.valDecl = decl
     self.program = program
   }
@@ -28,7 +28,7 @@ public struct CXXModule {
   ///
   /// - Requires: `valFunctionDecl` must be declared in `self.decl`.
   public mutating func getOrCreateFunction(
-    correspondingTo valFunctionDecl: Typed<FunctionDecl>
+    correspondingTo valFunctionDecl: FunctionDecl.Typed
   ) -> CXXFunctionDecl.ID {
     if let cxxFunctionDecl = valToCXXFunction[valFunctionDecl] { return cxxFunctionDecl }
 

--- a/Sources/Compiler/CXX/CXXTranspiler.swift
+++ b/Sources/Compiler/CXX/CXXTranspiler.swift
@@ -23,7 +23,7 @@ public struct CXXTranspiler {
   }
 
   /// Emits the given top-level declaration into `module`.
-  mutating func emit(topLevel decl: TypedNode<AnyDeclID>, into module: inout CXXModule) {
+  mutating func emit(topLevel decl: AnyDeclID.TypedNode, into module: inout CXXModule) {
     switch decl.kind {
     case FunctionDecl.self:
       emit(function: FunctionDecl.Typed(decl)!, into: &module)
@@ -110,7 +110,7 @@ public struct CXXTranspiler {
   // MARK: Statements
 
   /// Emits the given statement into `module` at the current insertion point.
-  private mutating func emit<ID: StmtID>(stmt: TypedNode<ID>) -> CXXRepresentable {
+  private mutating func emit<ID: StmtID>(stmt: ID.TypedNode) -> CXXRepresentable {
     switch stmt.kind {
     case BraceStmt.self:
       return emit(brace: BraceStmt.Typed(stmt)!)
@@ -153,7 +153,7 @@ public struct CXXTranspiler {
   // MARK: Expressions
 
   private mutating func emit(
-    expr: TypedNode<AnyExprID>,
+    expr: AnyExprID.TypedNode,
     asLValue: Bool
   ) -> CXXRepresentable {
     if asLValue {

--- a/Sources/Compiler/CXX/CXXTranspiler.swift
+++ b/Sources/Compiler/CXX/CXXTranspiler.swift
@@ -14,7 +14,7 @@ public struct CXXTranspiler {
   // MARK: API
 
   /// Emits the C++ module corresponding to the Val module identified by `decl`.
-  public mutating func emit(module decl: Typed<ModuleDecl>) -> CXXModule {
+  public mutating func emit(module decl: ModuleDecl.Typed) -> CXXModule {
     var module = CXXModule(decl, for: program)
     for member in decl.topLevelDecls {
       emit(topLevel: member, into: &module)
@@ -26,14 +26,14 @@ public struct CXXTranspiler {
   mutating func emit(topLevel decl: TypedNode<AnyDeclID>, into module: inout CXXModule) {
     switch decl.kind {
     case FunctionDecl.self:
-      emit(function: Typed<FunctionDecl>(decl)!, into: &module)
+      emit(function: FunctionDecl.Typed(decl)!, into: &module)
     default:
       unreachable("unexpected declaration")
     }
   }
 
   /// Emits the given function declaration into `module`.
-  public mutating func emit(function decl: Typed<FunctionDecl>, into module: inout CXXModule) {
+  public mutating func emit(function decl: FunctionDecl.Typed, into module: inout CXXModule) {
     // Declare the function in the module if necessary.
     let id = module.getOrCreateFunction(correspondingTo: decl)
 
@@ -44,7 +44,7 @@ public struct CXXTranspiler {
   }
 
   /// Translate the function body into a CXX entity.
-  private mutating func emit(funBody body: Typed<FunctionDecl>.Body) -> CXXRepresentable {
+  private mutating func emit(funBody body: FunctionDecl.Typed.Body) -> CXXRepresentable {
     switch body {
     case .block(let stmt):
       return emit(brace: stmt)
@@ -57,7 +57,7 @@ public struct CXXTranspiler {
 
   // MARK: Declarations
 
-  private mutating func emit(localBinding decl: Typed<BindingDecl>) -> CXXRepresentable {
+  private mutating func emit(localBinding decl: BindingDecl.Typed) -> CXXRepresentable {
     let pattern = decl.pattern
 
     switch pattern.introducer.value {
@@ -70,13 +70,13 @@ public struct CXXTranspiler {
     }
   }
 
-  private mutating func emit(storedLocalBinding decl: Typed<BindingDecl>) -> CXXRepresentable {
+  private mutating func emit(storedLocalBinding decl: BindingDecl.Typed) -> CXXRepresentable {
     return CXXComment(comment: "local binding")
   }
 
   /// Emits borrowed bindings.
   private mutating func emit(
-    borrowedLocalBinding decl: Typed<BindingDecl>,
+    borrowedLocalBinding decl: BindingDecl.Typed,
     withCapability capability: RemoteType.Capability
   ) -> CXXRepresentable {
     // There's nothing to do if there's no initializer.
@@ -113,19 +113,19 @@ public struct CXXTranspiler {
   private mutating func emit<ID: StmtID>(stmt: TypedNode<ID>) -> CXXRepresentable {
     switch stmt.kind {
     case BraceStmt.self:
-      return emit(brace: Typed<BraceStmt>(stmt)!)
+      return emit(brace: BraceStmt.Typed(stmt)!)
     case DeclStmt.self:
-      return emit(declStmt: Typed<DeclStmt>(stmt)!)
+      return emit(declStmt: DeclStmt.Typed(stmt)!)
     case ExprStmt.self:
-      return emit(exprStmt: Typed<ExprStmt>(stmt)!)
+      return emit(exprStmt: ExprStmt.Typed(stmt)!)
     case ReturnStmt.self:
-      return emit(returnStmt: Typed<ReturnStmt>(stmt)!)
+      return emit(returnStmt: ReturnStmt.Typed(stmt)!)
     default:
       unreachable("unexpected statement")
     }
   }
 
-  private mutating func emit(brace stmt: Typed<BraceStmt>) -> CXXRepresentable {
+  private mutating func emit(brace stmt: BraceStmt.Typed) -> CXXRepresentable {
     var stmts: [CXXRepresentable] = []
     for s in stmt.stmts {
       stmts.append(emit(stmt: s))
@@ -133,20 +133,20 @@ public struct CXXTranspiler {
     return CXXScopedBlock(stmts: stmts)
   }
 
-  private mutating func emit(declStmt stmt: Typed<DeclStmt>) -> CXXRepresentable {
+  private mutating func emit(declStmt stmt: DeclStmt.Typed) -> CXXRepresentable {
     switch stmt.decl.kind {
     case BindingDecl.self:
-      return emit(localBinding: Typed<BindingDecl>(stmt.decl)!)
+      return emit(localBinding: BindingDecl.Typed(stmt.decl)!)
     default:
       unreachable("unexpected declaration")
     }
   }
 
-  private mutating func emit(exprStmt stmt: Typed<ExprStmt>) -> CXXRepresentable {
+  private mutating func emit(exprStmt stmt: ExprStmt.Typed) -> CXXRepresentable {
     return CXXComment(comment: "expr stmt")
   }
 
-  private mutating func emit(returnStmt stmt: Typed<ReturnStmt>) -> CXXRepresentable {
+  private mutating func emit(returnStmt stmt: ReturnStmt.Typed) -> CXXRepresentable {
     return CXXComment(comment: "return stmt")
   }
 

--- a/Sources/Compiler/IR/Emitter.swift
+++ b/Sources/Compiler/IR/Emitter.swift
@@ -27,7 +27,7 @@ public struct Emitter {
   // MARK: Declarations
 
   /// Emits the given top-level declaration into `module`.
-  mutating func emit(topLevel decl: TypedNode<AnyDeclID>, into module: inout Module) {
+  mutating func emit(topLevel decl: AnyDeclID.TypedNode, into module: inout Module) {
     switch decl.kind {
     case FunctionDecl.self:
       emit(function: FunctionDecl.Typed(decl)!, into: &module)
@@ -247,7 +247,7 @@ public struct Emitter {
   // MARK: Statements
 
   /// Emits the given statement into `module` at the current insertion point.
-  private mutating func emit<ID: StmtID>(stmt: TypedNode<ID>, into module: inout Module) {
+  private mutating func emit<ID: StmtID>(stmt: ID.TypedNode, into module: inout Module) {
     switch stmt.kind {
     case AssignStmt.self:
       emit(assign: AssignStmt.Typed(stmt)!, into: &module)
@@ -310,7 +310,7 @@ public struct Emitter {
   // MARK: r-values
 
   /// Emits `expr` as a r-value into `module` at the current insertion point.
-  private mutating func emitR<ID: ExprID>(expr: TypedNode<ID>, into module: inout Module) -> Operand {
+  private mutating func emitR<ID: ExprID>(expr: ID.TypedNode, into module: inout Module) -> Operand {
     defer {
       // Mark the execution path unreachable if the computed value has type `Never`.
       if expr.type == .never {
@@ -699,7 +699,7 @@ public struct Emitter {
   }
 
   private mutating func emit(
-    argument expr: TypedNode<AnyExprID>,
+    argument expr: AnyExprID.TypedNode,
     to parameterType: ParameterType,
     into module: inout Module
   ) -> Operand {
@@ -722,7 +722,7 @@ public struct Emitter {
   ///
   /// - Requires: `expr` has a lambda type.
   private mutating func emitCallee(
-    _ expr: TypedNode<AnyExprID>,
+    _ expr: AnyExprID.TypedNode,
     conventions: inout [PassingConvention],
     arguments: inout [Operand],
     into module: inout Module
@@ -821,7 +821,7 @@ public struct Emitter {
   /// Emits `expr` as a l-value with the specified capability into `module` at the current
   /// insertion point.
   private mutating func emitL<ID: ExprID>(
-    expr: TypedNode<ID>,
+    expr: ID.TypedNode,
     withCapability capability: RemoteType.Capability,
     into module: inout Module
   ) -> Operand {
@@ -952,7 +952,7 @@ fileprivate extension Emitter {
     }
 
     /// Accesses the operand assigned `decl`, assuming the stack is not empty.
-    subscript<ID: DeclID>(decl: TypedNode<ID>) -> Operand? {
+    subscript<ID: DeclID>(decl: ID.TypedNode) -> Operand? {
       get {
         for frame in frames.reversed() {
           if let operand = frame.locals[decl] { return operand }

--- a/Sources/Compiler/IR/Module.swift
+++ b/Sources/Compiler/IR/Module.swift
@@ -13,7 +13,7 @@ public struct Module {
   public let program: TypedProgram
 
   /// The module's declaration.
-  public let decl: Typed<ModuleDecl>
+  public let decl: ModuleDecl.Typed
 
   /// The def-use chains of the values in this module.
   public private(set) var uses: [Operand: [Use]] = [:]
@@ -25,7 +25,7 @@ public struct Module {
   public private(set) var entryFunctionID: Function.ID?
 
   /// A map from function declaration its ID in the module.
-  private var loweredFunctions: [Typed<FunctionDecl>: Function.ID] = [:]
+  private var loweredFunctions: [FunctionDecl.Typed: Function.ID] = [:]
 
   /// Creates an IR module lowering `decl` from `program`.
   ///
@@ -81,7 +81,7 @@ public struct Module {
 
   /// Returns the identifier of the Val IR function corresponding to `decl`.
   mutating func getOrCreateFunction(
-    correspondingTo decl: Typed<FunctionDecl>,
+    correspondingTo decl: FunctionDecl.Typed,
     program: TypedProgram
   ) -> Function.ID {
     if let id = loweredFunctions[decl] { return id }

--- a/Sources/Compiler/TypeChecking/TypedDeclProperty.swift
+++ b/Sources/Compiler/TypeChecking/TypedDeclProperty.swift
@@ -10,14 +10,14 @@ public struct TypedDeclProperty<Value> {
   }
 
   /// Accesses the property associated with the specified ID.
-  public subscript<ID: DeclID>(decl: TypedNode<ID>) -> Value? {
+  public subscript<ID: DeclID>(decl: ID.TypedNode) -> Value? {
     _read { yield storage[decl.id] }
     _modify { yield &storage[decl.id] }
   }
 
   /// Accesses the property associated with the specified ID, using a default value.
   public subscript<ID: DeclID>(
-    decl: TypedNode<ID>,
+    decl: ID.TypedNode,
     default defaultValue: @autoclosure () -> Value
   ) -> Value {
     _read { yield storage[decl.id, default: defaultValue()] }

--- a/Sources/Compiler/TypedNode.swift
+++ b/Sources/Compiler/TypedNode.swift
@@ -31,8 +31,12 @@ public struct TypedNode<ID: NodeIDProtocol> : Hashable {
 
 }
 
-/// An AST node with type information.
-public typealias Typed<T: AST.Node> = TypedNode<NodeID<T>>
+extension AST.Node {
+
+  /// Type describing the current node with type information.
+  public typealias Typed = TypedNode<NodeID<Self>>
+
+}
 
 extension TypedProgram {
   /// Bundles `id` together with `self`.
@@ -130,7 +134,7 @@ extension TypedNode where ID: DeclID {
 
 extension TypedNode where ID == NodeID<VarDecl> {
   /// The binding decl containing this var.
-  var binding: Typed<BindingDecl> {
+  var binding: BindingDecl.Typed {
     .init(whole: whole, id: whole.varToBinding[id]!)
   }
 }
@@ -199,7 +203,7 @@ extension TypedNode where ID == NodeID<NameExpr> {
 
 extension TypedNode where ID: PatternID {
   /// The names associated with this pattern.
-  var names: [(path: [Int], pattern: Typed<NamePattern>)] {
+  var names: [(path: [Int], pattern: NamePattern.Typed)] {
     whole.ast.names(in: id).map({ (path: $0.path, pattern: whole[$0.pattern]) })
   }
 }
@@ -227,7 +231,7 @@ extension TypedNode where ID == NodeID<FunctionDecl> {
     case expr(TypedNode<AnyExprID>)
 
     /// A block body.
-    case block(Typed<BraceStmt>)
+    case block(BraceStmt.Typed)
 
   }
 


### PR DESCRIPTION
The current syntax of `Typed<AST.Node>` is ugly. We want to make it easier to use.

Instead of that syntax, introduce an inner type alias in each AST node, so that we can write `Node.Typed` to get the typed node from an AST node.