### PR TITLE
Improve type inference for integer literals

### DIFF
--- a/Sources/CLI/main.swift
+++ b/Sources/CLI/main.swift
@@ -140,7 +140,7 @@ struct CLI: ParsableCommand {
     var checker = TypeChecker(program: ScopedProgram(ast: ast), isBuiltinModuleVisible: true)
     var typeCheckingSucceeded = true
 
-    // Type check the code library.
+    // Type check the core library.
     typeCheckingSucceeded = checker.check(module: checker.program.ast.corelib!)
 
     // Type-check the input.

--- a/Sources/Core/Constraints/FunctionCallConstraint.swift
+++ b/Sources/Core/Constraints/FunctionCallConstraint.swift
@@ -47,6 +47,6 @@ public struct FunctionCallConstraint: Constraint, Hashable {
 
 extension FunctionCallConstraint: CustomStringConvertible {
 
-  public var description: String { "\(calleeType)\(list: parameters) -> \(returnType)" }
+  public var description: String { "\(calleeType)(\(list: parameters)) -> \(returnType)" }
 
 }

--- a/Sources/FrontEnd/TypeChecking/ConstraintGenerator.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintGenerator.swift
@@ -367,7 +367,7 @@ struct ConstraintGenerator {
     let trait = checker.program.ast.coreTrait(named: "ExpressibleByIntegerLiteral")!
     let cause = ConstraintCause(.literal, at: checker.program.ast[id].origin)
 
-    // Constrain the type of the literal to be conforming to `ExpressibleByIntegerLiteral` or,
+    // Constrain the type of the literal to conform to `ExpressibleByIntegerLiteral` or,
     // unless it's been already inferred from context, to be equal to `Int`.
     let expectedType = expectedTypes[id] ?? ^TypeVariable(node: AnyNodeID(id))
     if expectedType.base is TypeVariable {

--- a/Sources/FrontEnd/TypeChecking/ConstraintGenerator.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintGenerator.swift
@@ -367,25 +367,18 @@ struct ConstraintGenerator {
     let trait = checker.program.ast.coreTrait(named: "ExpressibleByIntegerLiteral")!
     let cause = ConstraintCause(.literal, at: checker.program.ast[id].origin)
 
-    switch expectedTypes[id]?.base {
-    case let tau as TypeVariable:
-      // The type of the expression is a variable, possibly constrained elsewhere; constrain it to
-      // either be `Int` or conform to `ExpressibleByIntegerLiteral`.
+    // Constrain the type of the literal to be conforming to `ExpressibleByIntegerLiteral` or,
+    // unless it's been already inferred from context, to be equal to `Int`.
+    let expectedType = expectedTypes[id] ?? ^TypeVariable(node: AnyNodeID(id))
+    if expectedType.base is TypeVariable {
       constraints.append(
         expressibleByLiteralConstraint(
-          ^tau, trait: trait, defaultType: ^checker.program.ast.coreType(named: "Int")!,
-           because: cause))
-      assume(typeOf: id, equals: tau, at: checker.program.ast[id].origin)
-
-    case .some(let expectedType):
-      // The type of has been fixed; constrain it to conform to `ExpressibleByIntegerLiteral`.
-      constraints.append(ConformanceConstraint(^expectedType, conformsTo: [trait], because: cause))
+          expectedType, trait: trait, defaultType: ^checker.program.ast.coreType(named: "Int")!,
+          because: cause))
       assume(typeOf: id, equals: expectedType, at: checker.program.ast[id].origin)
-
-    case nil:
-      // Without contextual information, infer the type of the literal as `Val.Int`.
-      let intType = checker.program.ast.coreType(named: "Int")!
-      assume(typeOf: id, equals: intType, at: checker.program.ast[id].origin)
+    } else {
+      constraints.append(ConformanceConstraint(expectedType, conformsTo: [trait], because: cause))
+      assume(typeOf: id, equals: expectedType, at: checker.program.ast[id].origin)
     }
   }
 


### PR DESCRIPTION
The PR allows the type checker to infer the type of an integer literal based on the result of an overload constraint. For example:

```
fun fn(x: Int) -> Int {}
fun fn(x: Double) -> Double {}

public fun main() {
  let _ : Double = fn(x: 1)
}
```

The solver is allowed to infer `1` has type `Double` after overload resolution concludes `fn` has type `[] (x: Double) -> Double`.