### PR TITLE
Remove needless copy initializer

### DIFF
--- a/Sources/Core/AST/NodeIDs/NodeID.swift
+++ b/Sources/Core/AST/NodeIDs/NodeID.swift
@@ -10,12 +10,14 @@ public protocol NodeIDProtocol: Hashable, Codable {
 }
 
 public protocol ConcreteNodeID: NodeIDProtocol {
+
   associatedtype Subject: Node
-  init(_ x: NodeID<Subject>)
+
 }
 
 /// The ID of a node in an AST.
 public struct NodeID<Subject: Node>: ConcreteNodeID {
+
   /// The type of a node ID's raw value.
   public typealias RawValue = Int
 
@@ -23,8 +25,6 @@ public struct NodeID<Subject: Node>: ConcreteNodeID {
 
   /// The dynamic type of node being referred to.
   public var kind: NodeKind { NodeKind(Subject.self) }
-
-  public init(_ source: Self) { self = source }
 
   /// Creates an instance with the same raw value as `x` failing iff `x.kind != Subject.kind`.
   public init?<Other: NodeIDProtocol>(_ x: Other) {

--- a/Sources/Core/TypedNode.swift
+++ b/Sources/Core/TypedNode.swift
@@ -105,7 +105,7 @@ extension TypedNode where ID: ConcreteNodeID {
   where ID == NodeID<Target> {
     guard let myID = NodeID<ID.Subject>(s.id) else { return nil }
     program = s.program
-    id = .init(myID)
+    id = myID
   }
 }
 


### PR DESCRIPTION
It seems like `ConcreteNodeID` was requiring a copy initializer. Since all types are copyable in Swift, it should be sufficient to just use copy-initialization with `=`, as shown with the suggested change in `TypedNode.swift`.