### PR TITLE
Solver tracer

### DIFF
--- a/Docs/CLI.md
+++ b/Docs/CLI.md
@@ -1,0 +1,15 @@
+# Command line interface
+
+## Options
+
+### -trace-inference
+
+Enable tracing of type inference requests at the given line.
+
+**Example:**
+
+```bash
+valc --typecheck --trace-inference main.val:16 main.val
+```
+
+Running this command will show a trace of the type constraint solver for all root expressions at line 16 of `main.val`.

--- a/Sources/CLI/main.swift
+++ b/Sources/CLI/main.swift
@@ -62,10 +62,10 @@ struct CLI: ParsableCommand {
     help: "Type-check the input file(s).")
   var typeCheckOnly: Bool = false
 
-  @Flag(
+  @Option(
     name: [.customLong("trace-inference")],
-    help: "Enable of type inference requests.")
-  var isInferenceTracingEnabled: Bool = false
+    help: "Enable tracing of type inference requests at the given line.")
+  var inferenceTracingRange: SourceRange?
 
   @Option(
     name: [.customLong("emit")],
@@ -145,7 +145,7 @@ struct CLI: ParsableCommand {
     var checker = TypeChecker(
       program: ScopedProgram(ast: ast),
       isBuiltinModuleVisible: true,
-      isInferenceTracingEnabled: isInferenceTracingEnabled)
+      enablingInferenceTracingIn: inferenceTracingRange)
     var typeCheckingSucceeded = true
 
     // Type check the core library.

--- a/Sources/CLI/main.swift
+++ b/Sources/CLI/main.swift
@@ -62,6 +62,11 @@ struct CLI: ParsableCommand {
     help: "Type-check the input file(s).")
   var typeCheckOnly: Bool = false
 
+  @Flag(
+    name: [.customLong("trace-inference")],
+    help: "Enable of type inference requests.")
+  var isInferenceTracingEnabled: Bool = false
+
   @Option(
     name: [.customLong("emit")],
     help: "Emit the specified type output files.")
@@ -137,7 +142,10 @@ struct CLI: ParsableCommand {
     ast.importCoreModule()
 
     // Initialize the type checker.
-    var checker = TypeChecker(program: ScopedProgram(ast: ast), isBuiltinModuleVisible: true)
+    var checker = TypeChecker(
+      program: ScopedProgram(ast: ast),
+      isBuiltinModuleVisible: true,
+      isInferenceTracingEnabled: isInferenceTracingEnabled)
     var typeCheckingSucceeded = true
 
     // Type check the core library.

--- a/Sources/Core/AST/NodeIDs/NodeID.swift
+++ b/Sources/Core/AST/NodeIDs/NodeID.swift
@@ -1,11 +1,17 @@
 /// A type denoting the ID of a node.
-public protocol NodeIDProtocol: Hashable, Codable {
+public protocol NodeIDProtocol: Hashable, Codable, CustomStringConvertible {
 
   /// The raw value of the ID.
   var rawValue: NodeID.RawValue { get }
 
   /// The identifier of type of the referred node.
   var kind: NodeKind { get }
+
+}
+
+extension NodeIDProtocol {
+
+  public var description: String { "\(kind)(\(rawValue))" }
 
 }
 

--- a/Sources/Core/Constraints/OverloadConstraint.swift
+++ b/Sources/Core/Constraints/OverloadConstraint.swift
@@ -94,7 +94,7 @@ public struct OverloadConstraint: Constraint, Hashable {
 extension OverloadConstraint: CustomStringConvertible {
 
   public var description: String {
-    "\(overloadedExpr):\(overloadedExprType) ∈ {\(choices.descriptions())}"
+    "\(overloadedExpr) ∈ {\(choices.descriptions())}"
   }
 
 }
@@ -102,7 +102,7 @@ extension OverloadConstraint: CustomStringConvertible {
 extension OverloadConstraint.Candidate: CustomStringConvertible {
 
   public var description: String {
-    "\(reference):\(type) => {\(constraints.descriptions(joinedBy: " ∧ "))}:\(penalties)"
+    "\(reference) => {\(constraints.descriptions(joinedBy: " ∧ "))}:\(penalties)"
   }
 
 }

--- a/Sources/Core/SourceFile.swift
+++ b/Sources/Core/SourceFile.swift
@@ -1,4 +1,4 @@
-import Foundation  // For `URL` and `UUID`
+import Foundation
 
 /// A Val source file.
 ///
@@ -73,6 +73,39 @@ public struct SourceFile {
     }
 
     return (lineIndex, columnIndex)
+  }
+
+  /// Returns the location corresponding to the given 1-based line and column indices, or `nil` if
+  /// these indices do not correspond to a valid location.
+  public func location(at line: Int, _ column: Int) -> SourceLocation? {
+    var position = contents.startIndex
+
+    // Get to the given line.
+    var currentLine = 1
+    while (currentLine < line) && (position != contents.endIndex) {
+      defer { position = contents.index(after: position) }
+      if contents[position].isNewline {
+        currentLine += 1
+        if currentLine == line { break }
+      }
+    }
+
+    // Make sure the line number is in bounds.
+    if currentLine != line { return nil }
+
+    // Get to the given column.
+    var currentColumn = 1
+    while (currentColumn < column) && (position != contents.endIndex) {
+      if contents[position].isNewline { break }
+      currentColumn += 1
+      position = contents.index(after: position)
+    }
+
+    // Make sure the cilumn number is in bounds.
+    if currentColumn != column { return nil }
+
+    // We're done.
+    return SourceLocation(source: self, index: position)
   }
 
 }

--- a/Sources/Core/SourceLocation.swift
+++ b/Sources/Core/SourceLocation.swift
@@ -56,6 +56,15 @@ extension SourceLocation: Codable {
 
 }
 
+extension SourceLocation: CustomStringConvertible {
+
+  public var description: String {
+    let (line, column) = source.lineAndColumnIndices(at: self)
+    return "\(source.url.relativePath):\(line):\(column)"
+  }
+
+}
+
 extension SourceLocation: CustomReflectable {
 
   public var customMirror: Mirror {

--- a/Sources/Core/SourceRange.swift
+++ b/Sources/Core/SourceRange.swift
@@ -24,6 +24,11 @@ public struct SourceRange: Hashable {
     self.upperBound = upperBound
   }
 
+  /// Returns whether `self` contains the given location.
+  public func contains(_ l: SourceLocation) -> Bool {
+    (l.source == source) && (l.index >= lowerBound) && (l.index < upperBound)
+  }
+
   /// Returns the first source location in this range.
   public func first() -> SourceLocation {
     SourceLocation(source: source, index: lowerBound)

--- a/Sources/FrontEnd/TypeChecking/ConstraintSolver.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSolver.swift
@@ -31,16 +31,24 @@ struct ConstraintSolver {
   /// The score of the best solution computed so far.
   private var best = Solution.Score.worst
 
+  /// Indicates whether this instance should log a trace.
+  private let isLoggingEnabled: Bool
+
+  /// The current indentation level for logging messages.
+  private var indentation = 0
+
   /// Creates an instance that solves the constraints in `fresh` in `scope`, using `comparator` to
   /// choose between competing solutions.
   init<S: Sequence>(
     scope: AnyScopeID,
     fresh: S,
-    comparingSolutionsWith comparator: AnyType
+    comparingSolutionsWith comparator: AnyType,
+    loggingTrace isLoggingEnabled: Bool
   ) where S.Element == Constraint {
     self.comparator = comparator
     self.scope = scope
     self.fresh = Array(fresh)
+    self.isLoggingEnabled = isLoggingEnabled
   }
 
   /// The current score of the solver's solution.
@@ -56,9 +64,15 @@ struct ConstraintSolver {
   /// Solves the constraints and returns the best solution, or `nil` if a better solution has
   /// already been computed.
   private mutating func solve(using checker: inout TypeChecker) -> Solution? {
+    logState()
+    log("steps:")
+
     while let constraint = fresh.popLast() {
       // Make sure the current solution is still worth exploring.
-      if score > best { return nil }
+      if score > best {
+        log("- abort")
+        return nil
+      }
 
       switch constraint {
       case let c as ConformanceConstraint:
@@ -91,6 +105,10 @@ struct ConstraintSolver {
     conformance constraint: ConformanceConstraint,
     using checker: inout TypeChecker
   ) {
+    log("- solve: \"\(constraint)\"")
+    indentation += 1; defer { indentation -= 1 }
+    log("actions:")
+
     let subject = typeAssumptions[constraint.subject]
 
     switch subject.base {
@@ -104,6 +122,7 @@ struct ConstraintSolver {
       let nonConforming = constraint.traits.subtracting(conformedTraits)
 
       if !nonConforming.isEmpty {
+        log("- fail")
         for trait in nonConforming {
           diagnostics.append(
             .diagnose(constraint.subject, doesNotConformTo: trait, at: constraint.cause.origin))
@@ -117,6 +136,10 @@ struct ConstraintSolver {
 
   /// Eliminates `L == R` by unifying `L` with `R`.
   private mutating func solve(equality constraint: EqualityConstraint) {
+    log("- solve: \"\(constraint)\"")
+    indentation += 1; defer { indentation -= 1 }
+    log("actions:")
+
     let l = typeAssumptions[constraint.left]
     let r = typeAssumptions[constraint.right]
 
@@ -124,16 +147,21 @@ struct ConstraintSolver {
 
     switch (l.base, r.base) {
     case (let tau as TypeVariable, _):
+      log("- assume \"\(tau) = \(r)\"")
       typeAssumptions.assign(r, to: tau)
       refresh(constraintsDependingOn: tau)
 
     case (_, let tau as TypeVariable):
+      log("- assume \"\(tau) = \(l)\"")
       typeAssumptions.assign(l, to: tau)
       refresh(constraintsDependingOn: tau)
 
     case (let l as TupleType, let r as TupleType):
       // Make sure `L` and `R` are structurally compatible.
-      if !checkStructuralCompatibility(l, r, cause: constraint.cause) { return }
+      if !checkStructuralCompatibility(l, r, cause: constraint.cause) {
+        log("- fail")
+        return
+      }
 
       // Break down the constraint.
       for i in 0 ..< l.elements.count {
@@ -143,6 +171,7 @@ struct ConstraintSolver {
     case (let l as LambdaType, let r as LambdaType):
       // Parameter labels must match.
       if l.inputs.map(\.label) != r.inputs.map(\.label) {
+        log("- fail")
         diagnostics.append(.diagnose(type: ^l, incompatibleWith: ^r, at: constraint.cause.origin))
         return
       }
@@ -158,12 +187,14 @@ struct ConstraintSolver {
     case (let l as MethodType, let r as MethodType):
       // Parameter labels must match.
       if l.inputs.map(\.label) != r.inputs.map(\.label) {
+        log("- fail")
         diagnostics.append(.diagnose(type: ^l, incompatibleWith: ^r, at: constraint.cause.origin))
         return
       }
 
       // Capabilities must match.
       if l.capabilities != r.capabilities {
+        log("- fail")
         diagnostics.append(.diagnose(type: ^l, incompatibleWith: ^r, at: constraint.cause.origin))
         return
       }
@@ -177,6 +208,7 @@ struct ConstraintSolver {
       solve(equality: .init(l.receiver, r.receiver, because: constraint.cause))
 
     default:
+      log("- fail")
       diagnostics.append(.diagnose(type: l, incompatibleWith: r, at: constraint.cause.origin))
     }
   }
@@ -184,6 +216,10 @@ struct ConstraintSolver {
   /// Eliminates `L <: R` if the solver has enough information to check that `L` is subtype of `R`
   /// or must be unified with `R`. Otherwise, postpones the constraint.
   private mutating func solve(subtyping constraint: SubtypingConstraint) {
+    log("- solve: \"\(constraint)\"")
+    indentation += 1; defer { indentation -= 1 }
+    log("actions:")
+
     let l = typeAssumptions[constraint.left]
     let r = typeAssumptions[constraint.right]
 
@@ -225,6 +261,10 @@ struct ConstraintSolver {
   /// Eliminates `L ⤷ R` if the solver has enough information to choose whether the constraint can
   /// be simplified as equality or subtyping. Otherwise, postpones the constraint.
   private mutating func solve(parameter constraint: ParameterConstraint) {
+    log("- solve: \"\(constraint)\"")
+    indentation += 1; defer { indentation -= 1 }
+    log("actions:")
+
     let l = typeAssumptions[constraint.left]
     let r = typeAssumptions[constraint.right]
 
@@ -238,10 +278,10 @@ struct ConstraintSolver {
     case let p as ParameterType:
       // Either `L` is equal to the bare type of `R`, or it's a. Note: the equality requirement for
       // arguments passed mutably is verified after type inference.
-      schedule(
-        inferenceConstraint(l, isSubtypeOf: p.bareType, because: constraint.cause))
+      schedule(inferenceConstraint(l, isSubtypeOf: p.bareType, because: constraint.cause))
 
     default:
+      log("- fail")
       diagnostics.append(.diagnose(invalidParameterType: r, at: constraint.cause.origin))
     }
   }
@@ -253,6 +293,10 @@ struct ConstraintSolver {
     member constraint: MemberConstraint,
     using checker: inout TypeChecker
   ) {
+    log("- solve: \"\(constraint)\"")
+    indentation += 1; defer { indentation -= 1 }
+    log("actions:")
+
     let l = typeAssumptions[constraint.subject]
     let r = typeAssumptions[constraint.memberType]
 
@@ -296,6 +340,7 @@ struct ConstraintSolver {
 
     // Fail if we couldn't find any candidate.
     if candidates.isEmpty {
+      log("- fail")
       diagnostics.append(
         .diagnose(
           undefinedName: "\(constraint.memberName)",
@@ -306,6 +351,8 @@ struct ConstraintSolver {
     // If there's only one candidate, solve an equality constraint direcly.
     if let pick = candidates.uniqueElement {
       solve(equality: .init(pick.type, r, because: constraint.cause))
+
+      log("- assume \(constraint.memberExpr) &> \(pick.reference)")
       bindingAssumptions[constraint.memberExpr] = pick.reference
       return
     }
@@ -323,6 +370,10 @@ struct ConstraintSolver {
     functionCall constraint: FunctionCallConstraint,
     using checker: inout TypeChecker
   ) {
+    log("- solve: \"\(constraint)\"")
+    indentation += 1; defer { indentation -= 1 }
+    log("actions:")
+
     let f = typeAssumptions[constraint.calleeType]
 
     // Postpone the solving if `F` is still unknown.
@@ -335,6 +386,7 @@ struct ConstraintSolver {
 
     // Make sure `F` is callable.
     guard let callee = f.base as? CallableType else {
+      log("- fail")
       diagnostics.append(.diagnose(nonCallableType: f, at: constraint.cause.origin))
       return
     }
@@ -343,6 +395,7 @@ struct ConstraintSolver {
     if !checkStructuralCompatibility(
       found: constraint.parameters, expected: callee.inputs, cause: constraint.cause)
     {
+      log("- fail")
       return
     }
 
@@ -361,14 +414,18 @@ struct ConstraintSolver {
     disjunction constraint: DisjunctionConstraint,
     using checker: inout TypeChecker
   ) -> Solution? {
-    explore(
+    log("- solve: \"\(constraint)\"")
+    indentation += 1; defer { indentation -= 1 }
+    log("actions:")
+
+    return explore(
       constraint.choices,
       cause: constraint.cause,
       using: &checker,
       configuringSubSolversWith: { (solver, choice) in
         solver.penalties += choice.penalties
         for c in choice.constraints {
-          solver.schedule(c)
+          solver.insert(fresh: c)
         }
       })
   }
@@ -379,7 +436,11 @@ struct ConstraintSolver {
     overload constraint: OverloadConstraint,
     using checker: inout TypeChecker
   ) -> Solution? {
-    explore(
+    log("- solve: \"\(constraint)\"")
+    indentation += 1; defer { indentation -= 1 }
+    log("actions:")
+
+    return explore(
       constraint.choices,
       cause: constraint.cause,
       using: &checker,
@@ -387,7 +448,7 @@ struct ConstraintSolver {
         solver.penalties += choice.penalties
         solver.bindingAssumptions[constraint.overloadedExpr] = choice.reference
         for c in choice.constraints {
-          solver.schedule(c)
+          solver.insert(fresh: c)
         }
       })
   }
@@ -400,6 +461,9 @@ struct ConstraintSolver {
     using checker: inout TypeChecker,
     configuringSubSolversWith configureSubSolver: (inout Self, Choices.Element) -> Void
   ) -> Solution? where Choices.Element: Choice {
+    log("- fork:")
+    indentation += 1; defer { indentation -= 1 }
+
     /// The results of the exploration.
     var results: [Solution] = []
 
@@ -408,8 +472,12 @@ struct ConstraintSolver {
       var underestimatedChoiceScore = score
       underestimatedChoiceScore.penalties += choice.penalties
       if underestimatedChoiceScore > best {
+        log("- skip: \"\(choice)\"")
         continue
       }
+
+      log("- pick: \"\(choice)\"")
+      indentation += 1; defer { indentation -= 1 }
 
       // Explore the result of this choice.
       var subSolver = self
@@ -482,14 +550,28 @@ struct ConstraintSolver {
     solutions.append(newSolution)
   }
 
-  /// Schedules `constraint` to be solved.
+  /// Schedules `constraint` to be solved in the future.
   private mutating func schedule(_ constraint: Constraint) {
+    log("- schedule \(constraint)")
+    insert(fresh: constraint)
+  }
+
+  /// Schedules `constraint` to be solved only once the solver has inferred more information about
+  /// at least one of its type variables.
+  ///
+  /// - Requires: `constraint` must involve type variables.
+  private mutating func postpone(_ constraint: Constraint) {
+    log("- postpone \(constraint)")
+    insert(stale: constraint)
+  }
+
+  /// Inserts `constraint` into the fresh set.
+  private mutating func insert(fresh constraint: Constraint) {
     fresh.append(constraint)
   }
 
-  /// Schedules `constraint` to be solved once the solver has inferred more information about its
-  /// type variables.
-  private mutating func postpone(_ constraint: Constraint) {
+  /// Inserts `constraint` into the stale set.
+  private mutating func insert(stale constraint: Constraint) {
     stale.append(constraint)
   }
 
@@ -497,6 +579,7 @@ struct ConstraintSolver {
   private mutating func refresh(constraintsDependingOn variable: TypeVariable) {
     for i in (0 ..< stale.count).reversed() {
       if stale[i].depends(on: variable) {
+        log("- refresh \(stale[i])")
         fresh.append(stale.remove(at: i))
       }
     }
@@ -556,6 +639,21 @@ struct ConstraintSolver {
     }
 
     return true
+  }
+
+  /// Logs a line of text in the standard output.
+  private func log(_ line: @autoclosure () -> String) {
+    if !isLoggingEnabled { return }
+    print(String(repeating: "  ", count: indentation) + line())
+  }
+
+  /// Logs the current state of `self` in the standard output.
+  private func logState() {
+    if !isLoggingEnabled { return }
+    log("fresh:")
+    for c in fresh { log("- \"\(c)\"") }
+    log("stale:")
+    for c in stale { log("- \"\(c)\"") }
   }
 
 }
@@ -690,7 +788,8 @@ extension TypeChecker {
     }
 
     // Solve the constraint system.
-    var solver = ConstraintSolver(scope: scope, fresh: constraints, comparingSolutionsWith: .void)
+    var solver = ConstraintSolver(
+      scope: scope, fresh: constraints, comparingSolutionsWith: .void, loggingTrace: false)
     return solver.apply(using: &self).diagnostics.isEmpty
   }
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1495,7 +1495,8 @@ public struct TypeChecker {
     var solver = ConstraintSolver(
       scope: AnyScopeID(scope),
       fresh: initialConstraints + constraintGeneration.constraints,
-      comparingSolutionsWith: constraintGeneration.inferredTypes[expr]!)
+      comparingSolutionsWith: constraintGeneration.inferredTypes[expr]!,
+      loggingTrace: true)
     var solution = solver.apply(using: &self)
     solution.addDiagnostics(constraintGeneration.diagnostics)
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -28,6 +28,9 @@ public struct TypeChecker {
   /// Indicates whether the built-in symbols are visible.
   public var isBuiltinModuleVisible: Bool
 
+  /// Indicates whether tracing in turned on for type inference requests.
+  public let isInferenceTracingEnabled: Bool
+
   /// The set of lambda expressions whose declarations are pending type checking.
   public private(set) var pendingLambdas: [NodeID<LambdaExpr>] = []
 
@@ -35,9 +38,14 @@ public struct TypeChecker {
   ///
   /// - Note: `program` is stored in the type checker and mutated throughout type checking (e.g.,
   ///   to insert synthesized declarations).
-  public init(program: ScopedProgram, isBuiltinModuleVisible: Bool = false) {
+  public init(
+    program: ScopedProgram,
+    isBuiltinModuleVisible: Bool = false,
+    isInferenceTracingEnabled: Bool = false
+  ) {
     self.program = program
     self.isBuiltinModuleVisible = isBuiltinModuleVisible
+    self.isInferenceTracingEnabled = isInferenceTracingEnabled
   }
 
   // MARK: Type system
@@ -1496,7 +1504,7 @@ public struct TypeChecker {
       scope: AnyScopeID(scope),
       fresh: initialConstraints + constraintGeneration.constraints,
       comparingSolutionsWith: constraintGeneration.inferredTypes[expr]!,
-      loggingTrace: true)
+      loggingTrace: isInferenceTracingEnabled)
     var solution = solver.apply(using: &self)
     solution.addDiagnostics(constraintGeneration.diagnostics)
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1503,9 +1503,15 @@ public struct TypeChecker {
     let shouldLogTrace: Bool
     if
       let tracingRange = inferenceTracingRange,
-      let subjectRange = program.ast[expr].origin
+      let subjectRange = program.ast[expr].origin,
+      tracingRange.contains(subjectRange.first())
     {
-      shouldLogTrace = tracingRange.contains(subjectRange.first())
+      shouldLogTrace = true
+
+      let loc = subjectRange.first()
+      let subjectDescription = subjectRange.source[subjectRange]
+      print("Inferring type of '\(subjectDescription)' at \(loc)")
+      print("---")
     } else {
       shouldLogTrace = false
     }

--- a/Tests/ValTests/SourceFileTests.swift
+++ b/Tests/ValTests/SourceFileTests.swift
@@ -1,0 +1,22 @@
+import Core
+import XCTest
+
+final class SourceFileTests: XCTestCase {
+
+  func testLocationConversion() {
+    let source = SourceFile(contents: """
+    import Greetings
+
+    public fun main() {
+      print("Hello, World!")
+    }
+    """)
+
+    for position in source.contents.indices {
+      let location = SourceLocation(source: source, index: position)
+      let (line, column) = source.lineAndColumnIndices(at: location)
+      XCTAssertEqual(source.location(at: line, column), location)
+    }
+  }
+
+}


### PR DESCRIPTION
This PR implements support for logging how type constraints are being solved.

Usage example:

```bash
valc --typecheck --trace-inference main.val:16 main.val
```

This command will type check `main.val` and show a trace of the type constraint solver for all root expressions at line 16 of `main.val`.