### PR TITLE
Use typed nodes in the IR code

### DIFF
--- a/Sources/Core/TypedNode.swift
+++ b/Sources/Core/TypedNode.swift
@@ -135,15 +135,9 @@ extension TypedNode where ID: DeclID {
   }
 
   /// The type of the declared entity.
-  /// In most cases, the type is valid, so we extract the value from the optional by default.
+  /// If the declaration type is invalid, we return `.error` type.
   public var type: AnyType {
-    program.declTypes[id]!
-  }
-
-  /// The type of the declared entity, as optional
-  /// This is to be used in cases in which the type is not always valid.
-  public var typeOpt: AnyType? {
-    program.declTypes[id]
+    program.declTypes[id] ?? .error
   }
 
   /// The implicit captures for the declared entity.

--- a/Sources/Core/TypedNode.swift
+++ b/Sources/Core/TypedNode.swift
@@ -135,8 +135,15 @@ extension TypedNode where ID: DeclID {
   }
 
   /// The type of the declared entity.
+  /// In most cases, the type is valid, so we extract the value from the optional by default.
   public var type: AnyType {
     program.declTypes[id]!
+  }
+
+  /// The type of the declared entity, as optional
+  /// This is to be used in cases in which the type is not always valid.
+  public var typeOpt: AnyType? {
+    program.declTypes[id]
   }
 
   /// The implicit captures for the declared entity.

--- a/Sources/IR/AbstractTypeLayout.swift
+++ b/Sources/IR/AbstractTypeLayout.swift
@@ -52,12 +52,12 @@ extension TypedProgram {
 
     switch type.base {
     case let type as ProductType:
-      for m in ast[type.decl].members where m.kind == BindingDecl.self {
-        let binding = NodeID<BindingDecl>(rawValue: m.rawValue)
-        for (_, name) in ast.names(in: ast[binding].pattern) {
-          let decl = ast[name].decl
-          indices[ast[decl].name] = types.count
-          types.append(declTypes[decl] ?? .error)
+      let decl = self[type.decl]
+      for m in decl.members where m.kind == BindingDecl.self {
+        let binding = BindingDecl.Typed(m)!
+        for (_, name) in binding.pattern.names {
+          indices[name.decl.name] = types.count
+          types.append(name.decl.type)
         }
       }
 

--- a/Sources/IR/AbstractTypeLayout.swift
+++ b/Sources/IR/AbstractTypeLayout.swift
@@ -57,7 +57,7 @@ extension TypedProgram {
         let binding = BindingDecl.Typed(m)!
         for (_, name) in binding.pattern.names {
           indices[name.decl.name] = types.count
-          types.append(name.decl.type)
+          types.append(name.decl.typeOpt ?? .error)
         }
       }
 

--- a/Sources/IR/AbstractTypeLayout.swift
+++ b/Sources/IR/AbstractTypeLayout.swift
@@ -57,7 +57,7 @@ extension TypedProgram {
         let binding = BindingDecl.Typed(m)!
         for (_, name) in binding.pattern.names {
           indices[name.decl.name] = types.count
-          types.append(name.decl.typeOpt ?? .error)
+          types.append(name.decl.type)
         }
       }
 

--- a/Sources/IR/Analysis/LifetimePass.swift
+++ b/Sources/IR/Analysis/LifetimePass.swift
@@ -31,7 +31,7 @@ public struct LifetimePass: TransformPass {
           // Delete the borrow if it's never used.
           if borrowLifetime.isEmpty {
             if let decl = borrow.binding {
-              diagnostics.append(.unusedBinding(name: program.ast[decl].name, at: borrow.range))
+              diagnostics.append(.unusedBinding(name: decl.name, at: borrow.range))
             }
             module[block].instructions.remove(at: instruction.address)
             continue

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -240,7 +240,7 @@ public struct Emitter {
               .address(name.decl.type),
               from: source,
               at: path,
-              binding: name.decl.id,
+              binding: name.decl,
               range: name.decl.origin),
             to: insertionBlock!)[0]
       }

--- a/Sources/IR/Operands/Instruction/AllocStackInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AllocStackInstruction.swift
@@ -7,11 +7,11 @@ public struct AllocStackInstruction: Instruction {
   public let allocatedType: AnyType
 
   /// The binding in source program to which the instruction corresponds, if any.
-  public let binding: NodeID<VarDecl>?
+  public let binding: VarDecl.Typed?
 
   public let range: SourceRange?
 
-  init(_ allocatedType: AnyType, binding: NodeID<VarDecl>? = nil, range: SourceRange? = nil) {
+  init(_ allocatedType: AnyType, binding: VarDecl.Typed? = nil, range: SourceRange? = nil) {
     self.allocatedType = allocatedType
     self.binding = binding
     self.range = range

--- a/Sources/IR/Operands/Instruction/BorrowInstruction.swift
+++ b/Sources/IR/Operands/Instruction/BorrowInstruction.swift
@@ -16,7 +16,7 @@ public struct BorrowInstruction: Instruction {
   public let path: [Int]
 
   /// The binding in source program to which the instruction corresponds, if any.
-  public let binding: NodeID<VarDecl>?
+  public let binding: VarDecl.Typed?
 
   public let range: SourceRange?
 
@@ -25,7 +25,7 @@ public struct BorrowInstruction: Instruction {
     _ borrowedType: LoweredType,
     from location: Operand,
     at path: [Int] = [],
-    binding: NodeID<VarDecl>? = nil,
+    binding: VarDecl.Typed? = nil,
     range: SourceRange? = nil
   ) {
     self.borrowedType = borrowedType


### PR DESCRIPTION
IR code used in a few occasions untyped nodes. Use typed nodes instead.

This is a continuation of the effort to use typed nodes instead of pairing AST nodes with TypedProgram.