### PR TITLE
explicitly include `Utils`

### DIFF
--- a/Sources/Core/Types/ExistentialType.swift
+++ b/Sources/Core/Types/ExistentialType.swift
@@ -1,3 +1,5 @@
+import Utils
+
 /// An existential type, optionally bound by traits and constraints on associated types.
 public struct ExistentialType: TypeProtocol {
 

--- a/Sources/Core/Types/InstantiatedType.swift
+++ b/Sources/Core/Types/InstantiatedType.swift
@@ -1,3 +1,5 @@
+import Utils
+
 /// A type whose generic parameters have been substituted by variables along with the constraints
 /// related to these variables.
 public struct InstantiatedType: Hashable {

--- a/Sources/IR/InstructionID.swift
+++ b/Sources/IR/InstructionID.swift
@@ -1,3 +1,5 @@
+import Utils
+
 /// The stable identity of an instruction in its module.
 ///
 /// - SeeAlso: `InstructionIndex`

--- a/Sources/IR/InstructionIndex.swift
+++ b/Sources/IR/InstructionIndex.swift
@@ -2,6 +2,8 @@
 ///
 /// An index identifies a function, a basic block in the function, and a position in the block,
 /// including the "past-the-end" position that isn't valid for use as a subscript argument. Unlike
+import Utils
+
 /// an identity, an index is not *stable*: inserting or removing instructions from the containing
 /// block may invalidate existing indices.
 ///


### PR DESCRIPTION
Swift 6 will disallow use of modules without an explicit include in the source file.  Add the missing includes in a few sites that trigger this issue.