### PR TITLE
Dead code

### DIFF
--- a/Tests/ValTests/ParserTests.swift
+++ b/Tests/ValTests/ParserTests.swift
@@ -308,15 +308,6 @@ final class ParserTests: XCTestCase {
     XCTAssertNotNil(decl.whereClause)
   }
 
-  // func testAssociatedValueDeclWithWhereClauseSansHint() throws {
-  //   let input = SourceFile(contents: "value foo where foo > bar")
-  //   let (declID, ast) = try input.parseWithDeclPrologue(
-  //     inContext: .traitBody,
-  //     with: Parser.parseAssociatedValueDecl)
-  //   let decl = try XCTUnwrap(ast[declID])
-  //   XCTAssertNotNil(decl.whereClause)
-  // }
-
   func testAssociatedValueDeclWithDefault() throws {
     let input = SourceFile(contents: "value foo = 42")
     let (declID, ast) = try input.parseWithDeclPrologue(


### PR DESCRIPTION
An alternative would be something like this:
```swift
  func testAssociatedValueDeclWithWhereClauseSansHint() throws {
    let input = SourceFile(contents: "value foo where foo > bar")
    let (declID, ast) = try input.parseWithDeclPrologue(
      inContext: .traitBody,
      with: Parser.parseAssociatedValueDecl)
    let decl = try XCTUnwrap(ast[declID])
    XCTExpectFailure("Not yet implemented") // <========
    XCTAssertNotNil(decl.whereClause)
  }
```
If not yet implemented is indeed the rationale; I can't tell that from the code.  

The alternative is going to make me do a bunch of emacs hacking to avoid treating the XCTest output as a failure:

```
ParserTests.swift:318: Expected failure in -[ValTests.ParserTests testAssociatedValueDeclWithWhereClauseSansHint]: XCTAssertNotNil failedReason: (Not yet implemented)
Test Case '-[ValTests.ParserTests testAssociatedValueDeclWithWhereClauseSansHint]' passed (0.081 seconds).
```

But I'll do the work if that's really more appropriate