### PR TITLE
Update CLI documentation

### DIFF
--- a/Docs/CLI.md
+++ b/Docs/CLI.md
@@ -1,8 +1,58 @@
 # Command line interface
 
+## Usage
+
+```bash
+valc [--modules] [--import-builtin] [--no-std] [--typecheck] [--trace-inference <file:line>] [--emit <output-type>] [-o <file>] [--verbose] [<inputs> ...]
+```
+
+Compiles `<inputs>` and produces an output `<file>` of the specified `<output-type>`.
+
 ## Options
 
-### -trace-inference
+### `--modules`
+
+**Not implemented**
+
+Compile `<inputs>` as separate modules.
+
+**Example:**
+```swift
+// In `Sources/Hello/Hello.val`
+import Greetings
+public fun main() {
+  greet("World")
+}
+```
+```swift
+// In `Sources/Greetings/Greetings.val`
+public fun greet(_ name: String) {
+  print("Hello, ${name}!")
+}
+```
+
+```bash
+valc --modules Sources/Hello Sources/Greet -o hello
+```
+
+Running this command will:
+1. Build the source files in the `Sources/Hello` directory into a module named `Hello`
+2. Build the source files in the `Sources/Greetings` directory into a module named `Greetings`
+3. Link the `Hello` and `Greetings` modules as an executable named `hello`.
+
+### `--import-builtin`
+
+Import the built-in module.  Allows using Val's built-in types and functions (e.g., `Builtin.terminate()`) in Val code.
+
+### `--no-std`
+
+Do not include the standard library module.
+
+### `--typecheck`
+
+Type-check the input file(s).  Exits the compilation pipeline after type-checking and does not produce an output file.
+
+### `--trace-inference <file:line>`
 
 Enable tracing of type inference requests at the given line.
 
@@ -13,3 +63,29 @@ valc --typecheck --trace-inference main.val:16 main.val
 ```
 
 Running this command will show a trace of the type constraint solver for all root expressions at line 16 of `main.val`.
+
+### `--emit <output-type>`
+
+Emit the specified output type (default: `binary`).  Each type represents a stage of the compilation pipeline.
+
+| `<output-type>` | Description |
+|--|--|
+| `raw-ast` | AST before type checking |
+| `raw-ir`  | Val IR before mandatory transformations |
+| `ir`      | Val IR |
+| `cpp`     | C++ code |
+| `binary`  | Executable binary |
+
+**Example:**
+```bash
+valc --emit raw-ast -o main.json main.val
+```
+Running this command will parse `main.val`, write the untyped AST in `main.json`, and exit the compilation pipeline.
+
+### `-o <file>`
+
+Write output to `<file>`.
+
+### `-v`, `--verbose`
+
+Use verbose output.

--- a/Sources/CLI/main.swift
+++ b/Sources/CLI/main.swift
@@ -64,17 +64,21 @@ private struct CLI: ParsableCommand {
 
   @Option(
     name: [.customLong("trace-inference")],
-    help: "Enable tracing of type inference requests at the given line.")
+    help: ArgumentHelp(
+      "Enable tracing of type inference requests at the given line.",
+      valueName: "file:line"))
   private var inferenceTracingRange: SourceRange?
 
   @Option(
     name: [.customLong("emit")],
-    help: "Emit the specified type output files.")
+    help: ArgumentHelp(
+      "Emit the specified type output files. From: raw-ast, raw-ir, ir, cpp, binary",
+      valueName: "output-type"))
   private var outputType: OutputType = .binary
 
   @Option(
     name: [.customShort("o")],
-    help: "Write output to <o>.",
+    help: ArgumentHelp("Write output to <file>.", valueName: "file"),
     transform: URL.init(fileURLWithPath:))
   private var outputURL: URL?
 


### PR DESCRIPTION
* Added all options to CLI.md
    * Options are described in the same order as presented in the CLI usage
    * Prefer alphabetical or a more "most likely used" ordering?
* Specified supported emit values in CLI help
    * resolves #41
    * This multi-line option help is non-standard and does set a precedence for wordy help in the future.
    * Prefer a comma-delimited list and leave it to CLI.md to describe the options?
* Minor edits to --trace-inference and -o for clarification

CLI before:
```bash
$ valc
Error: Missing expected argument '<inputs> ...'

USAGE: valc [--modules] [--import-builtin] [--no-std] [--typecheck] [--trace-inference <trace-inference>] [--emit <emit>] [-o <o>] [--verbose] [<inputs> ...]

ARGUMENTS:
  <inputs>

OPTIONS:
  --modules               Compile inputs as separate modules.
  --import-builtin        Import the built-in module.
  --no-std                Do not include the standard library.
  --typecheck             Type-check the input file(s).
  --trace-inference <trace-inference>
                          Enable tracing of type inference requests at the given line.
  --emit <emit>           Emit the specified type output files. (default: binary)
  -o <o>                  Write output to <o>.
  -v, --verbose           Use verbose output.
  -h, --help              Show help information.

$ valc --emit foo ~/main.val 
Error: The value 'foo' is invalid for '--emit <emit>'
Help:  --emit <emit>  Emit the specified type output files.
Usage: valc [--modules] [--import-builtin] [--no-std] [--typecheck] [--trace-inference <trace-inference>] [--emit <emit>] [-o <o>] [--verbose] [<inputs> ...]
  See 'valc --help' for more information.
```

CLI after:
```bash
$ valc 
Error: Missing expected argument '<inputs> ...'

USAGE: valc [--modules] [--import-builtin] [--no-std] [--typecheck] [--trace-inference <file:line>] [--emit <output-type>] [-o <file>] [--verbose] [<inputs> ...]

ARGUMENTS:
  <inputs>

OPTIONS:
  --modules               Compile inputs as separate modules.
  --import-builtin        Import the built-in module.
  --no-std                Do not include the standard library.
  --typecheck             Type-check the input file(s).
  --trace-inference <file:line>
                          Enable tracing of type inference requests at the given line.
  --emit <output-type>    Emit the specified type output files.  From:
                              raw-ast   AST before type checking.
                              raw-ir    Val IR before mandatory transformations.
                              ir        Val IR.
                              cpp       C++ code.
                              binary    Executable binary. (default: binary)
  -o <file>               Write output to <file>.
  -v, --verbose           Use verbose output.
  -h, --help              Show help information.

$ valc --emit foo ~/main.val 
Error: The value 'foo' is invalid for '--emit <output-type>'
Help:  --emit <output-type>  Emit the specified type output files.  From:
    raw-ast   AST before type checking.
    raw-ir    Val IR before mandatory transformations.
    ir        Val IR.
    cpp       C++ code.
    binary    Executable binary.
Usage: valc [--modules] [--import-builtin] [--no-std] [--typecheck] [--trace-inference <file:line>] [--emit <output-type>] [-o <file>] [--verbose] [<inputs> ...]
  See 'valc --help' for more information.
```