### PR TITLE
Emit classes

### DIFF
--- a/Sources/CodeGen/CXX/CXXModule.swift
+++ b/Sources/CodeGen/CXX/CXXModule.swift
@@ -11,25 +11,17 @@ public struct CXXModule {
   /// The typed program for wich we are constructing the CXX translation.
   public let program: TypedProgram
 
-  /// The C++ functions declared in `self`.
-  private var cxxFunctions: [CXXFunctionDecl] = []
-
-  /// The C++ classes declared in this module.
-  private var cxxClasses: [CXXClassDecl] = []
+  /// The C++ top-level declarations for this module
+  private var cxxTopLevelDecls: [CXXTopLevelDecl] = []
 
   public init(_ decl: ModuleDecl.Typed, for program: TypedProgram) {
     self.valDecl = decl
     self.program = program
   }
 
-  /// Add a function to this module.
-  public mutating func addFunction(_ functionDecl: CXXFunctionDecl) {
-    cxxFunctions.append(functionDecl)
-  }
-
-  /// Add a class to this module.
-  public mutating func addClass(_ classDecl: CXXClassDecl) {
-    cxxClasses.append(classDecl)
+  /// Add a top-level C++ declaration to this module.
+  public mutating func addTopLevelDecl(_ decl: CXXTopLevelDecl) {
+    cxxTopLevelDecls.append(decl)
   }
 
   // MARK: Serialization
@@ -50,16 +42,9 @@ public struct CXXModule {
     // Create a namespace for the entire module.
     output.write("namespace \(valDecl.name) {\n\n")
 
-    // Emit classes declarations.
-    for decl in cxxClasses {
-      decl.writeSignature(into: &output)
-      output.write(";\n")
-    }
-
-    // Emit top-level functions.
-    for decl in cxxFunctions {
-      decl.writeSignature(into: &output)
-      output.write(";\n")
+    // Emit the C++ text needed for the header corresponding to the C++ declarations.
+    for decl in cxxTopLevelDecls {
+      decl.writeDeclaration(into: &output)
     }
 
     output.write("\n}\n\n")  // module namespace
@@ -79,20 +64,9 @@ public struct CXXModule {
     // Create a namespace for the entire module.
     output.write("namespace \(valDecl.name) {\n\n")
 
-    // Emit classes definitions
-    for decl in cxxClasses {
-      decl.writeSignature(into: &output)
-      output.write(" ")
+    // Emit the C++ text needed for the source file corresponding to the C++ declarations.
+    for decl in cxxTopLevelDecls {
       decl.writeDefinition(into: &output)
-    }
-
-    // Emit top-level functions.
-    for decl in cxxFunctions {
-      decl.writeSignature(into: &output)
-      output.write(" ")
-      if decl.body != nil {
-        decl.body!.writeCode(into: &output)
-      }
     }
 
     output.write("\n}\n")  // module namespace

--- a/Sources/CodeGen/CXX/CXXTranspiler.swift
+++ b/Sources/CodeGen/CXX/CXXTranspiler.swift
@@ -30,6 +30,8 @@ public struct CXXTranspiler {
     switch decl.kind {
     case FunctionDecl.self:
       emit(function: FunctionDecl.Typed(decl)!, into: &module)
+    case ProductTypeDecl.self:
+      emit(type: ProductTypeDecl.Typed(decl)!, into: &module)
     default:
       unreachable("unexpected declaration")
     }
@@ -59,6 +61,11 @@ public struct CXXTranspiler {
   }
 
   // MARK: Declarations
+
+  /// Emits the given function declaration into `module`.
+  private mutating func emit(type decl: ProductTypeDecl.Typed, into module: inout CXXModule) {
+    let _ = module.getOrCreateClass(correspondingTo: decl)
+  }
 
   private mutating func emit(localBinding decl: BindingDecl.Typed) -> CXXRepresentable {
     let pattern = decl.pattern

--- a/Sources/CodeGen/CXX/CXXTranspiler.swift
+++ b/Sources/CodeGen/CXX/CXXTranspiler.swift
@@ -91,7 +91,7 @@ public struct CXXTranspiler {
     }
 
     // Create the C++ function object.
-    module.addFunction(
+    module.addTopLevelDecl(
       CXXFunctionDecl(
         identifier: identifier,
         output: output,
@@ -171,7 +171,7 @@ public struct CXXTranspiler {
     }
 
     // Create the C++ class.
-    module.addClass(CXXClassDecl(name: name, members: cxxMembers, original: decl))
+    module.addTopLevelDecl(CXXClassDecl(name: name, members: cxxMembers, original: decl))
   }
 
   private mutating func emit(localBinding decl: BindingDecl.Typed) -> CXXRepresentable {

--- a/Sources/CodeGen/CXX/Decl/CXXClassAttribute.swift
+++ b/Sources/CodeGen/CXX/Decl/CXXClassAttribute.swift
@@ -1,0 +1,28 @@
+import Core
+
+/// An attribute of a C++ class.
+public struct CXXClassAttribute: CXXRepresentable {
+
+  /// The type of the attribute.
+  public let type: CXXTypeExpr
+  /// The name of the attribute.
+  public let name: CXXIdentifier
+  /// The initializer of the attribute.
+  public let initializer: CXXRepresentable?
+  /// True if this is a static class attribute.
+  public let isStatic: Bool
+
+  /// The original node in Val AST.
+  let original: VarDecl.Typed
+
+  public func writeCode<Target: TextOutputStream>(into target: inout Target) {
+    target.write("\(type) ")
+    name.writeCode(into: &target)
+    if let value = initializer {
+      target.write(" = ")
+      value.writeCode(into: &target)
+    }
+    target.write(";\n")
+  }
+
+}

--- a/Sources/CodeGen/CXX/Decl/CXXClassDecl.swift
+++ b/Sources/CodeGen/CXX/Decl/CXXClassDecl.swift
@@ -1,7 +1,7 @@
 import Core
 
 /// A C++ class declaration.
-public struct CXXClassDecl {
+public struct CXXClassDecl: CXXTopLevelDecl {
 
   /// The ID of a C++ class in its module.
   public typealias ID = Int
@@ -34,9 +34,13 @@ public struct CXXClassDecl {
     target.write("class \(name)")
   }
 
-  /// Writes the definition of the class into `target`.
+  public func writeDeclaration<Target: TextOutputStream>(into target: inout Target) {
+    writeSignature(into: &target)
+    target.write(";\n")
+  }
   public func writeDefinition<Target: TextOutputStream>(into target: inout Target) {
-    target.write("{\n")
+    writeSignature(into: &target)
+    target.write(" {\n")
     target.write("public:\n")
     for member in members {
       switch member {

--- a/Sources/CodeGen/CXX/Decl/CXXClassDecl.swift
+++ b/Sources/CodeGen/CXX/Decl/CXXClassDecl.swift
@@ -6,8 +6,25 @@ public struct CXXClassDecl {
   /// The ID of a C++ class in its module.
   public typealias ID = Int
 
+  /// The type of a CXX class member.
+  public enum ClassMember {
+
+    /// A CXX class attribute
+    case attribute(CXXClassAttribute)
+
+    /// A CXX class method
+    case method
+
+    /// A CXX constructor
+    case constructor
+
+  }
+
   /// The name of the function.
   public let name: CXXIdentifier
+
+  /// The class membmers.
+  public let members: [ClassMember]
 
   /// The original node in Val AST.
   let original: ProductTypeDecl.Typed
@@ -20,6 +37,17 @@ public struct CXXClassDecl {
   /// Writes the definition of the class into `target`.
   public func writeDefinition<Target: TextOutputStream>(into target: inout Target) {
     target.write("{\n")
+    target.write("public:\n")
+    for member in members {
+      switch member {
+      case .attribute(let attribute):
+        attribute.writeCode(into: &target)
+      case .method:
+        target.write("// method\n")
+      case .constructor:
+        target.write("// constructor\n")
+      }
+    }
     target.write("};\n")
   }
 

--- a/Sources/CodeGen/CXX/Decl/CXXClassDecl.swift
+++ b/Sources/CodeGen/CXX/Decl/CXXClassDecl.swift
@@ -1,0 +1,26 @@
+import Core
+
+/// A C++ class declaration.
+public struct CXXClassDecl {
+
+  /// The ID of a C++ class in its module.
+  public typealias ID = Int
+
+  /// The name of the function.
+  public let name: CXXIdentifier
+
+  /// The original node in Val AST.
+  let original: ProductTypeDecl.Typed
+
+  /// Writes the signature of the class into `target`.
+  public func writeSignature<Target: TextOutputStream>(into target: inout Target) {
+    target.write("class \(name)")
+  }
+
+  /// Writes the definition of the class into `target`.
+  public func writeDefinition<Target: TextOutputStream>(into target: inout Target) {
+    target.write("{\n")
+    target.write("};\n")
+  }
+
+}

--- a/Sources/CodeGen/CXX/Decl/CXXFunctionDecl.swift
+++ b/Sources/CodeGen/CXX/Decl/CXXFunctionDecl.swift
@@ -18,6 +18,9 @@ public struct CXXFunctionDecl {
   /// The parameters of the function.
   public let parameters: [Parameter]
 
+  /// The body of the function.
+  public let body: CXXRepresentable?
+
   /// The original node in Val AST.
   let original: FunctionDecl.Typed
 

--- a/Sources/CodeGen/CXX/Decl/CXXFunctionDecl.swift
+++ b/Sources/CodeGen/CXX/Decl/CXXFunctionDecl.swift
@@ -1,7 +1,7 @@
 import Core
 
 /// A C++ function declaration.
-public struct CXXFunctionDecl {
+public struct CXXFunctionDecl: CXXTopLevelDecl {
 
   /// The ID of a C++ function in its module.
   public typealias ID = Int
@@ -34,4 +34,17 @@ public struct CXXFunctionDecl {
     target.write(")")
   }
 
+  public func writeDeclaration<Target: TextOutputStream>(into target: inout Target) {
+    writeSignature(into: &target)
+    target.write(";\n")
+  }
+  public func writeDefinition<Target: TextOutputStream>(into target: inout Target) {
+    writeSignature(into: &target)
+    if body != nil {
+      target.write(" ")
+      body!.writeCode(into: &target)
+    } else {
+      target.write(";\n")
+    }
+  }
 }

--- a/Sources/CodeGen/CXX/Decl/CXXTopLevelDecl.swift
+++ b/Sources/CodeGen/CXX/Decl/CXXTopLevelDecl.swift
@@ -1,0 +1,10 @@
+/// A C++ top-level declaration that needs to be written both to headers and source files.
+public protocol CXXTopLevelDecl {
+
+  /// Write into target the CXX code that needs to reach the header of the module.
+  func writeDeclaration<Target: TextOutputStream>(into target: inout Target)
+
+  /// Write into target the CXX code corresponding to the definition of `self`.
+  func writeDefinition<Target: TextOutputStream>(into target: inout Target)
+
+}

--- a/Tests/ValTests/TestCases/CXX/SimpleType.val
+++ b/Tests/ValTests/TestCases/CXX/SimpleType.val
@@ -3,6 +3,10 @@
  */
 /*! cpp
     class Point {
+    public:
+    int x;
+    int y;
+    // constructor
     };
  */
 

--- a/Tests/ValTests/TestCases/CXX/SimpleType.val
+++ b/Tests/ValTests/TestCases/CXX/SimpleType.val
@@ -1,0 +1,14 @@
+/*! h
+    class Point;
+ */
+/*! cpp
+    class Point {
+    };
+ */
+
+public type Point {
+
+  var x: Int
+  var y: Int
+
+}


### PR DESCRIPTION
The CXX transpiler is lacking the ability to emit C++ classes from Val product types.

Add support for emitting classes. The support, at this point, is just basic: we know to write the attributes of simple product types.
We now have 2 top-level declaration types that can be translated into a C++ module: functions and classes. Both of them need to be able to write the "header part" and the "source part".

Testing:
*  add a simple test to show translation of a Point type