### PR TITLE
Measure/maintain code coverage in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
       with:
         SORT_ORDER: +cov
-        MINIMUM_COVERAGE: 74.45
+        MINIMUM_COVERAGE: 74
     - name: Build (Release)
       run: swift build -v -c release
     - name: Test (Release)
@@ -52,4 +52,4 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
       with:
         SORT_ORDER: +cov
-        MINIMUM_COVERAGE: 74.45
+        MINIMUM_COVERAGE: 74

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Test (Debug)
       run: swift test -v -c debug --enable-code-coverage
     - uses: mattpolzin/swift-codecov-action@0.7.3
+      if: matrix.os == 'ubuntu'
       with:
         MINIMUM_COVERAGE: 10
         INCLUDE_TESTS: 'true'
@@ -48,6 +49,7 @@ jobs:
     - name: Test (Release)
       run: swift test -v -c release -Xswiftc -enable-testing --enable-code-coverage
     - uses: mattpolzin/swift-codecov-action@0.7.3
+      if: matrix.os == 'ubuntu'
       with:
         MINIMUM_COVERAGE: 10
         INCLUDE_TESTS: 'true'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,8 +38,16 @@ jobs:
     - name: Build (Debug)
       run: swift build -v -c debug
     - name: Test (Debug)
-      run: swift test -v -c debug
+      run: swift test -v -c debug --enable-code-coverage
+    - uses: mattpolzin/swift-codecov-action@0.7.3
+      with:
+        MINIMUM_COVERAGE: 10
+        INCLUDE_TESTS: 'true'
     - name: Build (Release)
       run: swift build -v -c release
     - name: Test (Release)
-      run: swift test -v -c release -Xswiftc -enable-testing
+      run: swift test -v -c release -Xswiftc -enable-testing --enable-code-coverage
+    - uses: mattpolzin/swift-codecov-action@0.7.3
+      with:
+        MINIMUM_COVERAGE: 10
+        INCLUDE_TESTS: 'true'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,16 +40,16 @@ jobs:
     - name: Test (Debug)
       run: swift test -v -c debug --enable-code-coverage
     - uses: mattpolzin/swift-codecov-action@0.7.3
-      if: matrix.os == 'ubuntu'
+      if: matrix.os == 'ubuntu-22.04'
       with:
-        MINIMUM_COVERAGE: 10
+        MINIMUM_COVERAGE: 74
         INCLUDE_TESTS: 'true'
     - name: Build (Release)
       run: swift build -v -c release
     - name: Test (Release)
       run: swift test -v -c release -Xswiftc -enable-testing --enable-code-coverage
     - uses: mattpolzin/swift-codecov-action@0.7.3
-      if: matrix.os == 'ubuntu'
+      if: matrix.os == 'ubuntu-22.04'
       with:
-        MINIMUM_COVERAGE: 10
+        MINIMUM_COVERAGE: 74
         INCLUDE_TESTS: 'true'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,8 +43,7 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
       with:
         SORT_ORDER: +cov
-        MINIMUM_COVERAGE: 74.50
-        INCLUDE_TESTS: 'true'
+        MINIMUM_COVERAGE: 74.45
     - name: Build (Release)
       run: swift build -v -c release
     - name: Test (Release)
@@ -53,5 +52,4 @@ jobs:
       if: matrix.os == 'ubuntu-22.04'
       with:
         SORT_ORDER: +cov
-        MINIMUM_COVERAGE: 74.50
-        INCLUDE_TESTS: 'true'
+        MINIMUM_COVERAGE: 74.45

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,7 +42,8 @@ jobs:
     - uses: mattpolzin/swift-codecov-action@0.7.3
       if: matrix.os == 'ubuntu-22.04'
       with:
-        MINIMUM_COVERAGE: 74
+        SORT_ORDER: +cov
+        MINIMUM_COVERAGE: 74.50
         INCLUDE_TESTS: 'true'
     - name: Build (Release)
       run: swift build -v -c release
@@ -51,5 +52,6 @@ jobs:
     - uses: mattpolzin/swift-codecov-action@0.7.3
       if: matrix.os == 'ubuntu-22.04'
       with:
-        MINIMUM_COVERAGE: 74
+        SORT_ORDER: +cov
+        MINIMUM_COVERAGE: 74.50
         INCLUDE_TESTS: 'true'


### PR DESCRIPTION
Causes CI to fail if our code coverage slips; generates a coverage report with every run.

Currently only checks coverage on ubuntu (the GH action plugin only supports that).  This could certainly be improved by making it work on all OSes and eliminating warnings (and there are other plugin options we can explore) but this will suffice to make sure we don't backslide on testing.  We'll have to update the MINIMUM_COVERAGE as we improve things