### PR TITLE
Emit cxx return

### DIFF
--- a/Sources/CodeGen/CXX/CXXTranspiler.swift
+++ b/Sources/CodeGen/CXX/CXXTranspiler.swift
@@ -53,7 +53,7 @@ public struct CXXTranspiler {
       return emit(brace: stmt)
 
     case .expr(let expr):
-      let exprBody = CXXReturnStmt(expr: emitR(expr: expr), original: expr)
+      let exprBody = CXXReturnStmt(expr: emitR(expr: expr), original: AnyNodeID.TypedNode(expr))
       return CXXScopedBlock(stmts: [exprBody], original: AnyNodeID.TypedNode(expr))
     }
   }
@@ -155,7 +155,11 @@ public struct CXXTranspiler {
   }
 
   private mutating func emit(returnStmt stmt: ReturnStmt.Typed) -> CXXRepresentable {
-    return CXXComment(comment: "return stmt", original: AnyNodeID.TypedNode(stmt))
+    var expr: CXXRepresentable?
+    if stmt.value != nil {
+      expr = emitR(expr: stmt.value!)
+    }
+    return CXXReturnStmt(expr: expr, original: AnyNodeID.TypedNode(stmt))
   }
 
   // MARK: Expressions

--- a/Sources/CodeGen/CXX/Stmt/CXXReturnStmt.swift
+++ b/Sources/CodeGen/CXX/Stmt/CXXReturnStmt.swift
@@ -8,7 +8,7 @@ struct CXXReturnStmt: CXXRepresentable {
 
   /// The original node in Val AST.
   /// This node can be of any type.
-  let original: AnyExprID.TypedNode?
+  let original: AnyNodeID.TypedNode?
 
   func writeCode<Target: TextOutputStream>(into target: inout Target) {
     if expr != nil {

--- a/Tests/ValTests/TestCases/CXX/Stmt/ExpressionFunction.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/ExpressionFunction.val
@@ -1,0 +1,9 @@
+/*! h
+    int returns_value();
+ */
+/*! cpp
+    int returns_value() {
+    return 13;
+    }
+ */
+public fun returns_value() -> Int { 13 }

--- a/Tests/ValTests/TestCases/CXX/Stmt/ReturnExpr.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/ReturnExpr.val
@@ -1,0 +1,11 @@
+/*! h
+    int returns_value();
+ */
+/*! cpp
+    int returns_value() {
+    return 13;
+    }
+ */
+public fun returns_value() -> Int {
+    return 13
+}

--- a/Tests/ValTests/TestCases/CXX/Stmt/ReturnVoid.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/ReturnVoid.val
@@ -1,0 +1,17 @@
+/*! cpp
+    void returns_void() {
+    // expr stmt
+    return;
+    // expr stmt
+    }
+ */
+public fun prefooer() {
+}
+public fun postfooer() {
+}
+
+public fun returns_void() {
+    prefooer()
+    return
+    postfooer()
+}


### PR DESCRIPTION
Add possibility to emit CXX return statements from Val `return` statements, with or without returning value.

Add tests to cover cases in which `CXXReturnStmt` needs to be emitted:
- function implicitly returning a value
- explicit `return` statement without any value
- explicit `return` statement with value