### PR TITLE
Fix XCTest shims

### DIFF
--- a/Tests/ValTests/Utils/XCTest+Shims.swift
+++ b/Tests/ValTests/Utils/XCTest+Shims.swift
@@ -37,7 +37,7 @@ import XCTest
   struct XCTSourceCodeContext {
 
     /// A representation of a location in source code where a test issue occurred.
-    var site: XCTSourceCodeLocation?
+    var location: XCTSourceCodeLocation?
 
   }
 
@@ -92,10 +92,12 @@ import XCTest
   extension XCTestCase {
 
     func record(_ issue: XCTIssue) {
-      let site = issue.sourceCodeContext!.site!
+      let location = issue.sourceCodeContext!.location!
       recordFailure(
-        withDescription: issue.compactDescription, inFile: site.fileURL.path,
-        atLine: site.lineNumber, expected: true)
+        withDescription: issue.compactDescription,
+        inFile: location.fileURL.path,
+        atLine: location.lineNumber,
+        expected: true)
     }
 
   }

--- a/Tests/ValTests/Utils/XCTest+Shims.swift
+++ b/Tests/ValTests/Utils/XCTest+Shims.swift
@@ -1,8 +1,9 @@
 import XCTest
 
 /// This file declares a lightweight compatibility layer to fill some of the missing parts of
-/// swift-corelibs-xctest API.
-/// See https://github.com/apple/swift-corelibs-xctest/issues/348
+/// swift-corelibs-xctest API. See https://github.com/apple/swift-corelibs-xctest/issues/348
+///
+/// Do not modify the name of any type or property. Those are meant to match Apple's API.
 
 #if !os(macOS)
 


### PR DESCRIPTION
We cannot change the API of the types in XCTest+Shims.swift. Everything in this file is meant to reproduce XCTest's API on non-Apple platforms.