### PR TITLE
Emit CXX expression statements

### DIFF
--- a/Sources/CodeGen/CXX/CXXTranspiler.swift
+++ b/Sources/CodeGen/CXX/CXXTranspiler.swift
@@ -218,7 +218,8 @@ public struct CXXTranspiler {
       }
       if stmts.isEmpty {
         // No pattern found; just call the initializer, dropping the result.
-        return CXXVoidCast(baseExpr: cxxInitialzer, original: initializer)
+        let cxxExpr = CXXVoidCast(baseExpr: cxxInitialzer, original: initializer)
+        return CXXExprStmt(expr: cxxExpr, original: AnyNodeID.TypedNode(initializer))
       } else {
         return CXXScopedBlock(stmts: stmts, original: AnyNodeID.TypedNode(initializer))
       }
@@ -265,7 +266,7 @@ public struct CXXTranspiler {
   }
 
   private mutating func emit(exprStmt stmt: ExprStmt.Typed) -> CXXRepresentable {
-    return CXXComment(comment: "expr stmt", original: AnyNodeID.TypedNode(stmt))
+    return CXXExprStmt(expr: emitR(expr: stmt.expr), original: AnyNodeID.TypedNode(stmt))
   }
 
   private mutating func emit(returnStmt stmt: ReturnStmt.Typed) -> CXXRepresentable {

--- a/Sources/CodeGen/CXX/Stmt/CXXExprStmt.swift
+++ b/Sources/CodeGen/CXX/Stmt/CXXExprStmt.swift
@@ -1,0 +1,17 @@
+import Core
+
+/// A C++ expression statement.
+struct CXXExprStmt: CXXRepresentable {
+
+  /// The expression contained in this statement.
+  let expr: CXXRepresentable
+
+  /// The original node in Val AST.
+  let original: AnyNodeID.TypedNode
+
+  func writeCode<Target: TextOutputStream>(into target: inout Target) {
+    expr.writeCode(into: &target)
+    target.write(";\n")
+  }
+
+}

--- a/Tests/ValTests/TestCases/CXX/Stmt/ExprStmt.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/ExprStmt.val
@@ -1,0 +1,15 @@
+/*! cpp
+    void test() {
+    fooling();
+    baring();
+    }
+ */
+public fun fooling() {
+}
+public fun baring() {
+}
+
+public fun test() {
+    fooling()
+    baring()
+}

--- a/Tests/ValTests/TestCases/CXX/Stmt/ExprStmtFromBinding.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/ExprStmtFromBinding.val
@@ -1,0 +1,10 @@
+/*! cpp
+    void test() {
+    (void) mooing();
+    }
+ */
+public fun mooing() -> Int { 23 }
+
+public fun test() {
+    let _ = mooing()
+}

--- a/Tests/ValTests/TestCases/CXX/Stmt/ReturnVoid.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/ReturnVoid.val
@@ -1,8 +1,8 @@
 /*! cpp
     void returns_void() {
-    // expr stmt
+    prefooer();
     return;
-    // expr stmt
+    postfooer();
     }
  */
 public fun prefooer() {


### PR DESCRIPTION
Val's `ExprStmt` would be translated into a `CXXExprStmt`. Also, bindings without any pattern will result in a `CXXExprStmt` (with a `CXXVoidCast`)