### PR TITLE
Attempt to work around Windows CI problem

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -19,15 +19,6 @@
       }
     },
     {
-      "identity" : "swift-algorithms",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-algorithms.git",
-      "state" : {
-        "revision" : "b14b7f4c528c942f121c8b860b9410b2bf57825e",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "swift-argument-parser",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
@@ -43,15 +34,6 @@
       "state" : {
         "revision" : "f504716c27d2e5d4144fa4794b12129301d17729",
         "version" : "1.0.3"
-      }
-    },
-    {
-      "identity" : "swift-numerics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-numerics",
-      "state" : {
-        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
-        "version" : "1.0.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -25,9 +25,6 @@ let package = Package(
       url: "https://github.com/apple/swift-collections.git",
       from: "1.0.0"),
     .package(
-      url: "https://github.com/apple/swift-algorithms.git",
-      from: "1.0.0"),
-    .package(
       url: "https://github.com/val-lang/Durian.git",
       from: "1.2.0"),
     .package(
@@ -64,7 +61,6 @@ let package = Package(
       name: "Core",
       dependencies: [
         "Utils",
-        .product(name: "Algorithms", package: "swift-algorithms"),
       ],
       swiftSettings: allTargetsSwiftSettings),
 

--- a/Sources/Core/SourceFile.swift
+++ b/Sources/Core/SourceFile.swift
@@ -1,4 +1,3 @@
-import Algorithms
 import Foundation
 import Utils
 

--- a/Sources/Utils/Algorithms.swift
+++ b/Sources/Utils/Algorithms.swift
@@ -38,3 +38,35 @@ extension Int {
   }
 
 }
+
+extension Collection {
+  /// Returns the index of the first element in the collection
+  /// that matches the predicate.
+  ///
+  /// The collection must already be partitioned according to the
+  /// predicate, as if `self.partition(by: predicate)` had already
+  /// been called.
+  ///
+  /// - Efficiency: At most log(N) invocations of `predicate`, where
+  ///   N is the length of `self`.  At most log(N) index offsetting
+  ///   operations if `self` conforms to `RandomAccessCollection`;
+  ///   at most N such operations otherwise.
+  public func partitioningIndex(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Index {
+    var n = distance(from: startIndex, to: endIndex)
+    var l = startIndex
+
+    while n > 0 {
+      let half = n / 2
+      let mid = index(l, offsetBy: half)
+      if try predicate(self[mid]) {
+        n = half
+      } else {
+        l = index(after: mid)
+        n -= half + 1
+      }
+    }
+    return l
+  }
+}


### PR DESCRIPTION
The theory is that depending on Swift Numerics indirectly via two paths is the root cause.

Before this PR, BigInt and Swift-Algorithms both pull in swift-numerics.

/cc @compnerd 