### PR TITLE
Parse operator notations after function introducers

### DIFF
--- a/Library/Core/Int.val
+++ b/Library/Core/Int.val
@@ -6,22 +6,22 @@ public type Int {
   /// Returns the sum of `self` and `other`.
   ///
   /// - Requires: The sum of the two arguments must be representable in the arguments' type.
-  public infix fun + (_ other: Self) -> Self {
+  public fun infix+ (_ other: Self) -> Self {
     Int(value: Builtin.i64_add(value, other.value))
   }
 
   /// Returns `self` subtracted by `other`.
-  public infix fun - (_ other: Self) -> Self {
+  public fun infix- (_ other: Self) -> Self {
     Int(value: Builtin.i64_sub(value, other.value))
   }
 
   /// Returns the product of `self` and `other`
-  public infix fun * (_ other: Self) -> Self {
+  public fun infix* (_ other: Self) -> Self {
     Int(value: Builtin.i64_mul(value, other.value))
   }
 
   /// Returns `true` if `self` is smaller than `other`. Otherwise, returns `false`.
-  public infix fun < (_ other: Self) -> Bool {
+  public fun infix< (_ other: Self) -> Bool {
     Bool(value: Builtin.i64_lt(value, other.value))
   }
 

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -577,13 +577,13 @@ public enum Parser {
     assert(prologue.memberModifiers.count <= 1)
     return state.insert(
       FunctionDecl(
-        introducerSite: head.name.introducerSite,
+        introducerSite: head.introducerSite,
         attributes: prologue.attributes,
         accessModifier: prologue.accessModifiers.first,
         memberModifier: prologue.memberModifiers.first,
         receiverEffect: signature.receiverEffect,
-        notation: head.name.notation,
-        identifier: head.name.stem,
+        notation: head.notation,
+        identifier: head.stem,
         genericClause: head.genericClause,
         explicitCaptures: head.captures,
         parameters: signature.parameters,
@@ -620,11 +620,11 @@ public enum Parser {
     assert(prologue.accessModifiers.count <= 1)
     return state.insert(
       MethodDecl(
-        introducerSite: head.name.introducerSite,
+        introducerSite: head.introducerSite,
         attributes: prologue.attributes,
         accessModifier: prologue.accessModifiers.first,
-        notation: head.name.notation,
-        identifier: head.name.stem,
+        notation: head.notation,
+        identifier: head.stem,
         genericClause: head.genericClause,
         parameters: signature.parameters,
         output: signature.output,
@@ -1113,37 +1113,31 @@ public enum Parser {
         site: state.range(from: prologue.startIndex)))
   }
 
-  private static func parseFunctionDeclHead(
+  static func parseFunctionDeclHead(
     in state: inout ParserState
   ) throws -> FunctionDeclHead? {
-    // Parse the function's introducer and identifier.
-    guard let name = try parseFunctionDeclIntroducerAndIdentifier(in: &state) else { return nil }
+    guard let introducer = state.take(.fun) else { return nil }
+
+    let stem: SourceRepresentable<Identifier>
+    let notation: SourceRepresentable<OperatorNotation>?
+
+    if let n = try operatorNotation.parse(&state) {
+      stem = try state.expect("operator", using: operatorIdentifier)
+      notation = n
+    } else {
+      stem = try state.token(state.expect("identifier", using: { $0.take(.name) }))
+      notation = nil
+    }
 
     let genericClause = try genericClause.parse(&state)
     let captures = try captureList.parse(&state) ?? []
 
-    return FunctionDeclHead(name: name, genericClause: genericClause, captures: captures)
-  }
-
-  static func parseFunctionDeclIntroducerAndIdentifier(
-    in state: inout ParserState
-  ) throws -> FunctionDeclName? {
-    if let introducer = state.take(.fun) {
-      let stem = try state.expect("identifier", using: { $0.take(.name) })
-      return FunctionDeclName(
-        introducerSite: introducer.site, stem: state.token(stem), notation: nil)
-    }
-
-    if let notation = try operatorNotation.parse(&state) {
-      _ = try state.expect("'fun'", using: { $0.take(.fun) })
-      let stem = try state.expect("operator", using: operatorIdentifier)
-      return FunctionDeclName(
-        introducerSite: notation.site,
-        stem: stem,
-        notation: notation)
-    }
-
-    return nil
+    return FunctionDeclHead(
+      introducerSite: introducer.site,
+      stem: stem,
+      notation: notation,
+      genericClause: genericClause,
+      captures: captures)
   }
 
   static func parseFunctionDeclSignature(
@@ -2983,8 +2977,8 @@ struct DeclPrologue {
 
 }
 
-/// The parsed name of a function declaration.
-struct FunctionDeclName {
+/// The parsed head of a function declaration.
+struct FunctionDeclHead {
 
   /// The site of the `fun` introducer.
   let introducerSite: SourceRange
@@ -2994,14 +2988,6 @@ struct FunctionDeclName {
 
   /// The notation of the declared function, if any.
   let notation: SourceRepresentable<OperatorNotation>?
-
-}
-
-/// The parsed head of a function declaration.
-struct FunctionDeclHead {
-
-  /// The name of the declaration.
-  let name: FunctionDeclName
 
   /// The generic clause of the declaration, if any.
   let genericClause: SourceRepresentable<GenericClause>?

--- a/Tests/ValTests/ParserTests.swift
+++ b/Tests/ValTests/ParserTests.swift
@@ -440,7 +440,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testPostifxFunctionDecl() throws {
-    let input = testCode("postfix fun +() -> T { x }")
+    let input = testCode("fun postfix+ () -> T { x }")
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseFunctionOrMethodDecl)
     let decl = try XCTUnwrap(ast[declID] as? FunctionDecl)
     XCTAssertEqual(decl.notation?.value, .postfix)
@@ -508,15 +508,15 @@ final class ParserTests: XCTestCase {
   func testFunctionDeclIdentifier() throws {
     let input = testCode("fun foo")
     let identifier = try XCTUnwrap(
-      input.parse(with: Parser.parseFunctionDeclIntroducerAndIdentifier(in:)).element)
+      input.parse(with: Parser.parseFunctionDeclHead(in:)).element)
     XCTAssertEqual(identifier.stem.value, "foo")
     XCTAssertNil(identifier.notation)
   }
 
   func testFunctionDeclOperator() throws {
-    let input = testCode("postfix fun ++")
+    let input = testCode("fun postfix++")
     let identifier = try XCTUnwrap(
-      input.parse(with: Parser.parseFunctionDeclIntroducerAndIdentifier(in:)).element)
+      input.parse(with: Parser.parseFunctionDeclHead(in:)).element)
     XCTAssertEqual(identifier.stem.value, "++")
     XCTAssertEqual(identifier.notation?.value, .postfix)
   }


### PR DESCRIPTION
This change improves the consistency of the grammar (see https://github.com/val-lang/val-lang.github.io/discussions/43).