### PR TITLE
Emit cxx control stmt

### DIFF
--- a/Sources/CodeGen/CXX/CXXTranspiler.swift
+++ b/Sources/CodeGen/CXX/CXXTranspiler.swift
@@ -288,7 +288,23 @@ public struct CXXTranspiler {
   }
 
   private mutating func emit(whileStmt stmt: WhileStmt.Typed) -> CXXRepresentable {
-    return CXXComment(comment: "WhileStmt", original: AnyNodeID.TypedNode(stmt))
+    // TODO: multiple conditions
+    // TODO: bindings in conditions
+    let condition: CXXRepresentable
+    if stmt.condition.count == 1 {
+      switch stmt.condition[0] {
+      case .expr(let condExpr):
+        condition = emitR(expr: program[condExpr])
+      case .decl(let decl):
+        condition = CXXComment(
+          comment: "binding condition", original: AnyNodeID.TypedNode(program[decl]))
+      }
+    } else {
+      fatalError("not implemented")
+    }
+    let _ = condition
+    return CXXWhileStmt(
+      condition: condition, body: emit(stmt: stmt.body), original: AnyNodeID.TypedNode(stmt))
   }
   private mutating func emit(doWhileStmt stmt: DoWhileStmt.Typed) -> CXXRepresentable {
     return CXXComment(comment: "DoWhileStmt", original: AnyNodeID.TypedNode(stmt))

--- a/Sources/CodeGen/CXX/CXXTranspiler.swift
+++ b/Sources/CodeGen/CXX/CXXTranspiler.swift
@@ -457,72 +457,7 @@ public struct CXXTranspiler {
     let callee: CXXRepresentable
 
     if let calleeNameExpr = NameExpr.Typed(expr.callee) {
-      switch calleeNameExpr.decl {
-      case .direct(let calleeDecl) where calleeDecl.kind == BuiltinDecl.self:
-        // Callee refers to a built-in function.
-        assert(calleeType.environment == .void)
-        callee = CXXIdentifier(calleeNameExpr.name.value.stem)
-
-      case .direct(let calleeDecl) where calleeDecl.kind == FunctionDecl.self:
-        // Callee is a direct reference to a function or initializer declaration.
-        // TODO: handle captures
-        callee = CXXIdentifier(nameOfDecl(calleeDecl))
-
-      case .direct(let calleeDecl) where calleeDecl.kind == InitializerDecl.self:
-        switch InitializerDecl.Typed(calleeDecl)!.introducer.value {
-        case .`init`:
-          // TODO: The function is a custom initializer.
-          fatalError("not implemented")
-
-        case .memberwiseInit:
-          // The function is a memberwise initializer. In that case, the whole call expression is
-          // lowered as a `record` instruction.
-          // TODO: implement this
-          fatalError("not implemented")
-        }
-
-      case .member(let calleeDecl) where calleeDecl.kind == FunctionDecl.self:
-        // Callee is a member reference to a function or method.
-        let receiverType = calleeType.captures[0].type
-
-        var receiver: CXXRepresentable
-
-        // Add the receiver to the arguments.
-        if let type = RemoteType(receiverType) {
-          // The receiver as a borrowing convention.
-          switch calleeNameExpr.domain {
-          case .none:
-            receiver = CXXReceiverExpr(original: AnyExprID.TypedNode(expr))
-
-          case .expr(let receiverID):
-            receiver = emitL(expr: receiverID, withCapability: type.capability)
-
-          case .implicit:
-            unreachable()
-          }
-        } else {
-          // The receiver is consumed.
-          switch calleeNameExpr.domain {
-          case .none:
-            receiver = CXXReceiverExpr(original: AnyExprID.TypedNode(expr))
-
-          case .expr(let receiverID):
-            receiver = emitR(expr: receiverID)
-
-          case .implicit:
-            unreachable()
-          }
-        }
-
-        // Emit the function reference.
-        callee = CXXCompoundExpr(
-          base: receiver, id: CXXIdentifier(nameOfDecl(calleeDecl)),
-          original: AnyExprID.TypedNode(expr))
-
-      default:
-        // Evaluate the callee as a function object.
-        callee = emitR(expr: expr.callee)
-      }
+      callee = emitR(name: calleeNameExpr, forCalleWithType: calleeType)
     } else {
       // Evaluate the callee as a function object.
       callee = emitR(expr: expr.callee)
@@ -539,9 +474,80 @@ public struct CXXTranspiler {
   }
 
   private mutating func emitR(
-    name expr: NameExpr.Typed
+    name expr: NameExpr.Typed,
+    forCalleWithType calleeType: LambdaType? = nil
   ) -> CXXRepresentable {
-    return CXXComment(comment: "name expression", original: AnyNodeID.TypedNode(expr))
+    switch expr.decl {
+    case .direct(let calleeDecl) where calleeDecl.kind == BuiltinDecl.self:
+      // Callee refers to a built-in function.
+      assert(calleeType == nil || calleeType!.environment == .void)
+      return CXXIdentifier(expr.name.value.stem)
+
+    case .direct(let calleeDecl) where calleeDecl.kind == FunctionDecl.self:
+      // Callee is a direct reference to a function or initializer declaration.
+      // TODO: handle captures
+      return CXXIdentifier(nameOfDecl(calleeDecl))
+
+    case .direct(let calleeDecl) where calleeDecl.kind == InitializerDecl.self:
+      switch InitializerDecl.Typed(calleeDecl)!.introducer.value {
+      case .`init`:
+        // TODO: The function is a custom initializer.
+        fatalError("not implemented")
+
+      case .memberwiseInit:
+        // The function is a memberwise initializer. In that case, the whole call expression is
+        // lowered as a `record` instruction.
+        // TODO: implement this
+        fatalError("not implemented")
+      }
+    case .direct(let calleeDecl) where calleeDecl.kind == VarDecl.self:
+      return CXXIdentifier(nameOfDecl(calleeDecl))
+
+    case .direct(_):
+      fatalError("not implemented")
+
+    case .member(let calleeDecl) where calleeDecl.kind == FunctionDecl.self:
+      // Callee is a member reference to a function or method.
+      assert(calleeType != nil)
+      let receiverType = calleeType!.captures[0].type
+
+      var receiver: CXXRepresentable
+
+      // Add the receiver to the arguments.
+      if let type = RemoteType(receiverType) {
+        // The receiver as a borrowing convention.
+        switch expr.domain {
+        case .none:
+          receiver = CXXReceiverExpr(original: AnyExprID.TypedNode(expr))
+
+        case .expr(let receiverID):
+          receiver = emitL(expr: receiverID, withCapability: type.capability)
+
+        case .implicit:
+          unreachable()
+        }
+      } else {
+        // The receiver is consumed.
+        switch expr.domain {
+        case .none:
+          receiver = CXXReceiverExpr(original: AnyExprID.TypedNode(expr))
+
+        case .expr(let receiverID):
+          receiver = emitR(expr: receiverID)
+
+        case .implicit:
+          unreachable()
+        }
+      }
+
+      // Emit the function reference.
+      return CXXCompoundExpr(
+        base: receiver, id: CXXIdentifier(nameOfDecl(calleeDecl)),
+        original: AnyExprID.TypedNode(expr))
+
+    case .member(_):
+      fatalError("not implemented")
+    }
   }
 
   private mutating func emitR(

--- a/Sources/CodeGen/CXX/CXXTranspiler.swift
+++ b/Sources/CodeGen/CXX/CXXTranspiler.swift
@@ -315,10 +315,10 @@ public struct CXXTranspiler {
     return CXXComment(comment: "ForStmt", original: AnyNodeID.TypedNode(stmt))
   }
   private mutating func emit(breakStmt stmt: BreakStmt.Typed) -> CXXRepresentable {
-    return CXXComment(comment: "BreakStmt", original: AnyNodeID.TypedNode(stmt))
+    return CXXBreakStmt(original: AnyNodeID.TypedNode(stmt))
   }
   private mutating func emit(continueStmt stmt: ContinueStmt.Typed) -> CXXRepresentable {
-    return CXXComment(comment: "ContinueStmt", original: AnyNodeID.TypedNode(stmt))
+    return CXXContinueStmt(original: AnyNodeID.TypedNode(stmt))
   }
   private mutating func emit(yieldStmt stmt: YieldStmt.Typed) -> CXXRepresentable {
     return CXXComment(comment: "YieldStmt", original: AnyNodeID.TypedNode(stmt))

--- a/Sources/CodeGen/CXX/CXXTranspiler.swift
+++ b/Sources/CodeGen/CXX/CXXTranspiler.swift
@@ -302,12 +302,14 @@ public struct CXXTranspiler {
     } else {
       fatalError("not implemented")
     }
-    let _ = condition
     return CXXWhileStmt(
       condition: condition, body: emit(stmt: stmt.body), original: AnyNodeID.TypedNode(stmt))
   }
   private mutating func emit(doWhileStmt stmt: DoWhileStmt.Typed) -> CXXRepresentable {
-    return CXXComment(comment: "DoWhileStmt", original: AnyNodeID.TypedNode(stmt))
+    return CXXDoWhileStmt(
+      body: emit(stmt: stmt.body),
+      condition: emitR(expr: stmt.condition),
+      original: AnyNodeID.TypedNode(stmt))
   }
   private mutating func emit(forStmt stmt: ForStmt.Typed) -> CXXRepresentable {
     return CXXComment(comment: "ForStmt", original: AnyNodeID.TypedNode(stmt))

--- a/Sources/CodeGen/CXX/CXXTranspiler.swift
+++ b/Sources/CodeGen/CXX/CXXTranspiler.swift
@@ -232,6 +232,18 @@ public struct CXXTranspiler {
       return emit(assignStmt: AssignStmt.Typed(stmt)!)
     case ReturnStmt.self:
       return emit(returnStmt: ReturnStmt.Typed(stmt)!)
+    case WhileStmt.self:
+      return emit(whileStmt: WhileStmt.Typed(stmt)!)
+    case DoWhileStmt.self:
+      return emit(doWhileStmt: DoWhileStmt.Typed(stmt)!)
+    case ForStmt.self:
+      return emit(forStmt: ForStmt.Typed(stmt)!)
+    case BreakStmt.self:
+      return emit(breakStmt: BreakStmt.Typed(stmt)!)
+    case ContinueStmt.self:
+      return emit(continueStmt: ContinueStmt.Typed(stmt)!)
+    case YieldStmt.self:
+      return emit(yieldStmt: YieldStmt.Typed(stmt)!)
     default:
       unreachable("unexpected statement")
     }
@@ -273,6 +285,25 @@ public struct CXXTranspiler {
       expr = emitR(expr: stmt.value!)
     }
     return CXXReturnStmt(expr: expr, original: AnyNodeID.TypedNode(stmt))
+  }
+
+  private mutating func emit(whileStmt stmt: WhileStmt.Typed) -> CXXRepresentable {
+    return CXXComment(comment: "WhileStmt", original: AnyNodeID.TypedNode(stmt))
+  }
+  private mutating func emit(doWhileStmt stmt: DoWhileStmt.Typed) -> CXXRepresentable {
+    return CXXComment(comment: "DoWhileStmt", original: AnyNodeID.TypedNode(stmt))
+  }
+  private mutating func emit(forStmt stmt: ForStmt.Typed) -> CXXRepresentable {
+    return CXXComment(comment: "ForStmt", original: AnyNodeID.TypedNode(stmt))
+  }
+  private mutating func emit(breakStmt stmt: BreakStmt.Typed) -> CXXRepresentable {
+    return CXXComment(comment: "BreakStmt", original: AnyNodeID.TypedNode(stmt))
+  }
+  private mutating func emit(continueStmt stmt: ContinueStmt.Typed) -> CXXRepresentable {
+    return CXXComment(comment: "ContinueStmt", original: AnyNodeID.TypedNode(stmt))
+  }
+  private mutating func emit(yieldStmt stmt: YieldStmt.Typed) -> CXXRepresentable {
+    return CXXComment(comment: "YieldStmt", original: AnyNodeID.TypedNode(stmt))
   }
 
   // MARK: Expressions

--- a/Sources/CodeGen/CXX/Stmt/CXXBreakStmt.swift
+++ b/Sources/CodeGen/CXX/Stmt/CXXBreakStmt.swift
@@ -1,0 +1,14 @@
+import Core
+
+/// A C++ `break` statement
+struct CXXBreakStmt: CXXRepresentable {
+
+  /// The original node in Val AST.
+  /// This node can be of any type.
+  let original: AnyNodeID.TypedNode?
+
+  func writeCode<Target: TextOutputStream>(into target: inout Target) {
+    target.write("break;\n")
+  }
+
+}

--- a/Sources/CodeGen/CXX/Stmt/CXXContinueStmt.swift
+++ b/Sources/CodeGen/CXX/Stmt/CXXContinueStmt.swift
@@ -1,0 +1,14 @@
+import Core
+
+/// A C++ `continue` statement
+struct CXXContinueStmt: CXXRepresentable {
+
+  /// The original node in Val AST.
+  /// This node can be of any type.
+  let original: AnyNodeID.TypedNode?
+
+  func writeCode<Target: TextOutputStream>(into target: inout Target) {
+    target.write("continue;\n")
+  }
+
+}

--- a/Sources/CodeGen/CXX/Stmt/CXXDoWhileStmt.swift
+++ b/Sources/CodeGen/CXX/Stmt/CXXDoWhileStmt.swift
@@ -1,0 +1,24 @@
+import Core
+
+/// A C++ `do`-`while` statement
+struct CXXDoWhileStmt: CXXRepresentable {
+
+  /// The statement to be executed as part of the loop.
+  let body: CXXRepresentable
+
+  /// The expression to be tested at the end of the loop.
+  let condition: CXXRepresentable
+
+  /// The original node in Val AST.
+  /// This node can be of any type.
+  let original: AnyNodeID.TypedNode?
+
+  func writeCode<Target: TextOutputStream>(into target: inout Target) {
+    target.write("do ")
+    body.writeCode(into: &target)
+    target.write("while ( ")
+    condition.writeCode(into: &target)
+    target.write(" );\n")
+  }
+
+}

--- a/Sources/CodeGen/CXX/Stmt/CXXIfStmt.swift
+++ b/Sources/CodeGen/CXX/Stmt/CXXIfStmt.swift
@@ -1,0 +1,30 @@
+import Core
+
+/// A C++ conditional statement
+struct CXXIfStmt: CXXRepresentable {
+
+  /// The expression to be tested by the conditional.
+  let condition: CXXRepresentable
+
+  /// The statement to be executed if the condition is true.
+  let trueStmt: CXXRepresentable
+  /// The statement to be executed if the condition is false.
+  /// Can be missing.
+  let falseStmt: CXXRepresentable?
+
+  /// The original node in Val AST.
+  /// This node can be of any type.
+  let original: AnyNodeID.TypedNode?
+
+  func writeCode<Target: TextOutputStream>(into target: inout Target) {
+    target.write("if ( ")
+    condition.writeCode(into: &target)
+    target.write(" ) ")
+    trueStmt.writeCode(into: &target)
+    if falseStmt != nil {
+      target.write("else ")
+      falseStmt!.writeCode(into: &target)
+    }
+  }
+
+}

--- a/Sources/CodeGen/CXX/Stmt/CXXWhileStmt.swift
+++ b/Sources/CodeGen/CXX/Stmt/CXXWhileStmt.swift
@@ -1,0 +1,23 @@
+import Core
+
+/// A C++ `while` statement
+struct CXXWhileStmt: CXXRepresentable {
+
+  /// The expression to be tested by the `while` loop.
+  let condition: CXXRepresentable
+
+  /// The statement to be executed as part of the loop.
+  let body: CXXRepresentable
+
+  /// The original node in Val AST.
+  /// This node can be of any type.
+  let original: AnyNodeID.TypedNode?
+
+  func writeCode<Target: TextOutputStream>(into target: inout Target) {
+    target.write("while ( ")
+    condition.writeCode(into: &target)
+    target.write(" ) ")
+    body.writeCode(into: &target)
+  }
+
+}

--- a/Sources/Core/ScopedProgram.swift
+++ b/Sources/Core/ScopedProgram.swift
@@ -890,6 +890,8 @@ extension ScopedProgram {
       visit(braceStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
     case BraceStmt.self:
       break
+    case BreakStmt.self:
+      break
     case CondBindingStmt.self:
       visit(condBindingStmt: NodeID(rawValue: stmt.rawValue), withState: &state)
     case ContinueStmt.self:

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -2724,7 +2724,7 @@ public enum Parser {
       }))
 
   static let continueStmt =
-    (take(.break)
+    (take(.continue)
       .map({ (state, token) -> NodeID<ContinueStmt> in
         state.insert(ContinueStmt(origin: token.origin))
       }))

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1057,7 +1057,22 @@ public struct TypeChecker {
     case YieldStmt.self:
       return check(yield: NodeID(rawValue: id.rawValue), inScope: lexicalContext)
 
-    case WhileStmt.self, DoWhileStmt.self, ForStmt.self, BreakStmt.self, ContinueStmt.self:
+    case WhileStmt.self:
+      // TODO: properly implement this
+      let stmt = program.ast[NodeID<WhileStmt>(rawValue: id.rawValue)]
+      var success = true
+      for cond in stmt.condition {
+        switch cond {
+        case .expr(let condExpr):
+          success = (deduce(typeOf: condExpr, expecting: nil, inScope: lexicalContext) != nil) && success
+        default:
+          success = false
+        }
+      }
+      success = check(brace: stmt.body) && success
+      return success
+
+    case DoWhileStmt.self, ForStmt.self, BreakStmt.self, ContinueStmt.self:
       // TODO: implement checks for these statements
       return true
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1057,6 +1057,10 @@ public struct TypeChecker {
     case YieldStmt.self:
       return check(yield: NodeID(rawValue: id.rawValue), inScope: lexicalContext)
 
+    case WhileStmt.self, DoWhileStmt.self, ForStmt.self, BreakStmt.self, ContinueStmt.self:
+      // TODO: implement checks for these statements
+      return true
+
     default:
       unreachable("unexpected statement")
     }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1064,7 +1064,8 @@ public struct TypeChecker {
       for cond in stmt.condition {
         switch cond {
         case .expr(let condExpr):
-          success = (deduce(typeOf: condExpr, expecting: nil, inScope: lexicalContext) != nil) && success
+          success =
+            (deduce(typeOf: condExpr, expecting: nil, inScope: lexicalContext) != nil) && success
         default:
           success = false
         }
@@ -1072,7 +1073,16 @@ public struct TypeChecker {
       success = check(brace: stmt.body) && success
       return success
 
-    case DoWhileStmt.self, ForStmt.self, BreakStmt.self, ContinueStmt.self:
+    case DoWhileStmt.self:
+      // TODO: properly implement this
+      let stmt = program.ast[NodeID<DoWhileStmt>(rawValue: id.rawValue)]
+      var success = true
+      success = check(brace: stmt.body) && success
+      success =
+        (deduce(typeOf: stmt.condition, expecting: nil, inScope: lexicalContext) != nil) && success
+      return success
+
+    case ForStmt.self, BreakStmt.self, ContinueStmt.self:
       // TODO: implement checks for these statements
       return true
 

--- a/Tests/ValTests/TestCases/CXX/Stmt/ContinueAndBreak.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/ContinueAndBreak.val
@@ -11,8 +11,7 @@
     continue;
     inc(count);
     }
-    return // name expression
-    ;
+    return count;
     }
  */
 

--- a/Tests/ValTests/TestCases/CXX/Stmt/ContinueAndBreak.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/ContinueAndBreak.val
@@ -1,0 +1,49 @@
+/*! cpp
+    int lengthForCollatzSequence(int n) {
+    int count = 0;
+    while ( true ) {
+    if ( atTheEndOfCollatzSequence(n) ) {
+    break;
+    }
+    ;
+    n = nextCollatz(n);
+    inc(count);
+    continue;
+    inc(count);
+    }
+    return // name expression
+    ;
+    }
+ */
+
+fun nextCollatz(_ n: Int) -> Int {
+    1
+    // if n % 2 == 0 {
+    //     n/2
+    // } else {
+    //     n*3+1
+    // }
+}
+
+fun atTheEndOfCollatzSequence(_ n: Int) -> Bool {
+    true
+    // n == 1
+}
+
+fun inc(_ n: inout Int) {
+    // n++
+}
+
+fun lengthForCollatzSequence(of n: Int) -> Int {
+    var count = 0
+    while true {
+        if atTheEndOfCollatzSequence(n) {
+            break
+        }
+        n = nextCollatz(n)
+        inc(count)
+        continue
+        inc(count)  // should not execute
+    }
+    return count
+}

--- a/Tests/ValTests/TestCases/CXX/Stmt/DoWhileStmt.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/DoWhileStmt.val
@@ -1,0 +1,37 @@
+/*! cpp
+    void test1() {
+    do {
+    fooing();
+    }
+    while ( mooing() );
+    erring();
+    }
+ */
+/*! cpp
+    void test2() {
+    do {
+    fooing();
+    baring();
+    }
+    while ( mooing() );
+    erring();
+    }
+ */
+fun fooing() {}
+fun baring() {}
+fun mooing() -> Bool { true }
+fun erring() {}
+
+fun test1() {
+    do {
+        fooing()
+    } while mooing()
+    erring();
+}
+fun test2() {
+    do {
+        fooing()
+        baring()
+    } while mooing()
+    erring();
+}

--- a/Tests/ValTests/TestCases/CXX/Stmt/IfStmt.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/IfStmt.val
@@ -1,0 +1,61 @@
+/*! cpp
+    void test_if_then_else() {
+    if ( mooing() ) (void) fooing();
+    else (void) baring();
+    ;
+    erring();
+    }
+ */
+/*! cpp
+    void test_if_then_else_blocks() {
+    if ( mooing() ) {
+    fooing();
+    fooing();
+    }
+    else {
+    baring();
+    baring();
+    }
+    ;
+    erring();
+    }
+ */
+/*! cpp
+    void test_if_no_else() {
+    if ( mooing() ) (void) fooing();
+    ;
+    erring();
+    }
+ */
+fun fooing() {}
+fun baring() {}
+fun mooing() -> Bool { true }
+fun erring() {}
+
+fun test_if_then_else() {
+    if mooing() {
+        fooing()
+    } else {
+        baring()
+    }
+    erring()
+}
+
+fun test_if_then_else_blocks() {
+    if mooing() {
+        fooing()
+        fooing()
+    } else {
+        baring()
+        baring()
+    }
+    erring()
+}
+
+fun test_if_no_else() {
+    if mooing() {
+        fooing()
+    }
+    erring()
+}
+

--- a/Tests/ValTests/TestCases/CXX/Stmt/WhileStmt.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/WhileStmt.val
@@ -1,0 +1,35 @@
+/*! cpp
+    void test1() {
+    while ( mooing() ) {
+    fooing();
+    }
+    erring();
+    }
+ */
+/*! cpp
+    void test2() {
+    while ( mooing() ) {
+    fooing();
+    baring();
+    }
+    erring();
+    }
+ */
+fun fooing() {}
+fun baring() {}
+fun mooing() -> Bool { true }
+fun erring() {}
+
+fun test1() {
+    while mooing() {
+        fooing()
+    }
+    erring();
+}
+fun test2() {
+    while mooing() {
+        fooing()
+        baring()
+    }
+    erring();
+}


### PR DESCRIPTION
Basic code to emit Val statements to CXX.

This does not include `for` and `yield` statements, as they require more complex semantics.

Add basic tests to cover some simple scenarios.