### PR TITLE
Remove 'SourceRange.eliminateFIXME'

### DIFF
--- a/Sources/Core/AST/Decl/BuiltinDecl.swift
+++ b/Sources/Core/AST/Decl/BuiltinDecl.swift
@@ -4,8 +4,10 @@ public struct BuiltinDecl: Decl {
   public let site: SourceRange
 
   public init() {
-    let f = SourceFile(synthesizedText: "/* built-in declaration */")
-    self.site = f.range(f.text.startIndex ..< f.text.endIndex)
+    self.site = Self.source.range(Self.source.text.startIndex ..< Self.source.text.endIndex)
   }
+
+  /// A synthesized source file to define the site of this type's instances.
+  private static let source = SourceFile(synthesizedText: "/* built-in declaration */")
 
 }

--- a/Sources/Core/AST/Decl/BuiltinDecl.swift
+++ b/Sources/Core/AST/Decl/BuiltinDecl.swift
@@ -1,13 +1,11 @@
 /// An abstract node representing a built-in declaration.
 public struct BuiltinDecl: Decl {
 
-  public let site: SourceRange
+  public init() {}
 
-  public init() {
-    self.site = Self.source.range(Self.source.text.startIndex ..< Self.source.text.endIndex)
-  }
+  public var site: SourceRange { Self.site }
 
-  /// A synthesized source file to define the site of this type's instances.
-  private static let source = SourceFile(synthesizedText: "/* built-in declaration */")
+  /// A synthesized site for all instances.
+  private static let site = SourceFile(synthesizedText: "/* built-in declaration */").wholeRange
 
 }

--- a/Sources/Core/AST/Decl/BuiltinDecl.swift
+++ b/Sources/Core/AST/Decl/BuiltinDecl.swift
@@ -3,9 +3,9 @@ public struct BuiltinDecl: Decl {
 
   public init() {}
 
-  public var site: SourceRange { Self.site }
+  public var site: SourceRange { Self.siteConstant }
 
   /// A synthesized site for all instances.
-private static let siteConstant = SourceFile(synthesizedText: "/* built-in declaration */").wholeRange
+  private static let siteConstant = SourceFile(synthesizedText: "/* built-in */").wholeRange
 
 }

--- a/Sources/Core/AST/Decl/BuiltinDecl.swift
+++ b/Sources/Core/AST/Decl/BuiltinDecl.swift
@@ -1,6 +1,11 @@
 /// An abstract node representing a built-in declaration.
 public struct BuiltinDecl: Decl {
 
-  public var site: SourceRange { .eliminateFIXME }
+  public let site: SourceRange
+
+  public init() {
+    let f = SourceFile(synthesizedText: "/* built-in declaration */")
+    self.site = f.range(f.text.startIndex ..< f.text.endIndex)
+  }
 
 }

--- a/Sources/Core/AST/Decl/ModuleDecl.swift
+++ b/Sources/Core/AST/Decl/ModuleDecl.swift
@@ -10,7 +10,7 @@ public struct ModuleDecl: SingleEntityDecl, LexicalScope {
   public init(name: String) {
     self.name = name
     let f = SourceFile(synthesizedText: "/* module: \(name) */")
-    self.site = f.position(f.text.startIndex) ..< f.position(f.text.endIndex)
+    self.site = f.range(f.text.startIndex ..< f.text.endIndex)
   }
 
   public let site: SourceRange

--- a/Sources/Core/AST/Decl/ModuleDecl.swift
+++ b/Sources/Core/AST/Decl/ModuleDecl.swift
@@ -9,8 +9,7 @@ public struct ModuleDecl: SingleEntityDecl, LexicalScope {
 
   public init(name: String) {
     self.name = name
-    let f = SourceFile(synthesizedText: "/* module: \(name) */")
-    self.site = f.range(f.text.startIndex ..< f.text.endIndex)
+    self.site = SourceFile(synthesizedText: "/* module: \(name) */").wholeRange
   }
 
   public let site: SourceRange

--- a/Sources/Core/AST/Decl/SubscriptImplDecl.swift
+++ b/Sources/Core/AST/Decl/SubscriptImplDecl.swift
@@ -11,7 +11,7 @@ public struct SubscriptImplDecl: Decl, LexicalScope {
     case block(NodeID<BraceStmt>)
 
     /// The node wrappedby this instance.
-    public var node: AnyNodeID {
+    public var base: AnyNodeID {
       switch self {
       case .expr(let n):
         return AnyNodeID(n)

--- a/Sources/Core/AST/Decl/SubscriptImplDecl.swift
+++ b/Sources/Core/AST/Decl/SubscriptImplDecl.swift
@@ -10,6 +10,16 @@ public struct SubscriptImplDecl: Decl, LexicalScope {
     /// A block body.
     case block(NodeID<BraceStmt>)
 
+    /// The node wrappedby this instance.
+    public var node: AnyNodeID {
+      switch self {
+      case .expr(let n):
+        return AnyNodeID(n)
+      case .block(let n):
+        return AnyNodeID(n)
+      }
+    }
+
   }
 
   public let site: SourceRange

--- a/Sources/Core/AST/Decl/TopLevelDeclSet.swift
+++ b/Sources/Core/AST/Decl/TopLevelDeclSet.swift
@@ -1,15 +1,16 @@
 /// A set of declarations at the top-level of a source file.
 public struct TopLevelDeclSet: Node, LexicalScope {
 
+  public let site: SourceRange
+
   /// The declarations in the set.
   public private(set) var decls: [AnyDeclID]
 
   /// Creates an instance with the given properties.
-  public init(decls: [AnyDeclID] = []) {
+  public init(decls: [AnyDeclID], site: SourceRange) {
     self.decls = decls
+    self.site = site
   }
-
-  public var site: SourceRange { .eliminateFIXME }
 
   public func validateForm(in ast: AST, into diagnostics: inout Diagnostics) {
     for d in decls {

--- a/Sources/Core/SourceFile.swift
+++ b/Sources/Core/SourceFile.swift
@@ -34,6 +34,11 @@ public struct SourceFile {
     url.deletingPathExtension().lastPathComponent
   }
 
+  /// A range covering the whole contents of this instance.
+  public var wholeRange: SourceRange {
+    range(text.startIndex ..< text.endIndex)
+  }
+
   /// Creates a source file with the specified contents, creating a unique random URL.
   public init(synthesizedText text: String) {
     self.url = URL(string: "synthesized://\(UUID().uuidString)")!

--- a/Sources/Core/SourceRange.swift
+++ b/Sources/Core/SourceRange.swift
@@ -42,8 +42,6 @@ public struct SourceRange: Hashable {
 
   /// Returns a copy of `self` extended to cover `other`.
   public func extended(toCover other: SourceRange) -> SourceRange {
-    if self == .eliminateFIXME { return other }
-    if other == .eliminateFIXME { return self }
     precondition(file == other.file, "incompatible ranges")
     return file.range(Swift.min(start, other.start) ..< Swift.max(end, other.end))
   }
@@ -104,16 +102,5 @@ extension SourceRange: CustomReflectable {
         "end": file.position(end),
       ])
   }
-
-}
-
-extension SourceRange {
-
-  private static let nullFile = SourceFile(synthesizedText: "/* eliminate me */")
-
-  /// Temporary stand-in for `nil` as we eliminate optional SourceRange.  See
-  /// https://github.com/val-lang/val/issues/239
-  public static let eliminateFIXME = SourceRange(
-    nullFile.text.startIndex ..< nullFile.text.endIndex, in: nullFile)
 
 }

--- a/Sources/Core/TypedNode.swift
+++ b/Sources/Core/TypedNode.swift
@@ -24,6 +24,11 @@ public struct TypedNode<ID: NodeIDProtocol>: Hashable {
     self.id = id
   }
 
+  /// The site from which self was parsed.
+  public var site: SourceRange {
+    program.ast[id].site
+  }
+
   /// Equality comparison; only check the node ID.
   public static func == (lhs: TypedNode<ID>, rhs: TypedNode<ID>) -> Bool {
     lhs.id == rhs.id

--- a/Sources/Core/TypedNode.swift
+++ b/Sources/Core/TypedNode.swift
@@ -70,7 +70,7 @@ extension TypedNode where ID: ConcreteNodeID {
 
   /// The corresponding AST node.
   private var syntax: ID.Subject {
-    program.ast[NodeID(id)!]
+    program.ast[NodeID<ID.Subject>(rawValue: id.rawValue)]
   }
 
   /// Accesses the given member of the corresponding AST node.

--- a/Sources/Core/TypedNode.swift
+++ b/Sources/Core/TypedNode.swift
@@ -58,10 +58,12 @@ extension NodeIDProtocol {
 }
 
 extension TypedProgram {
+
   /// Bundles `id` together with `self`.
   public subscript<TargetID: NodeIDProtocol>(_ id: TargetID) -> TypedNode<TargetID> {
     TypedNode(id, in: self)
   }
+
 }
 
 extension TypedNode where ID: ConcreteNodeID {
@@ -107,6 +109,7 @@ extension TypedNode where ID: ConcreteNodeID {
     program = s.program
     id = myID
   }
+
 }
 
 extension TypedNode {
@@ -117,6 +120,7 @@ extension TypedNode {
 }
 
 extension TypedNode where ID: ScopeID {
+
   /// The parent scope, if any
   public var parent: AnyScopeID.TypedNode? {
     program.scopeToParent[id].map { .init($0, in: program) }
@@ -126,9 +130,11 @@ extension TypedNode where ID: ScopeID {
   public var decls: LazyMapCollection<[AnyDeclID], AnyDeclID.TypedNode> {
     program.scopeToDecls[id, default: []].lazy.map { .init($0, in: program) }
   }
+
 }
 
 extension TypedNode where ID: DeclID {
+
   /// The scope in which this declaration resides.
   public var scope: AnyScopeID.TypedNode {
     .init(program.declToScope[id]!, in: program)
@@ -144,23 +150,29 @@ extension TypedNode where ID: DeclID {
   public var implicitCaptures: [ImplicitCapture]? {
     program.implicitCaptures[id]
   }
+
 }
 
 extension TypedNode where ID == NodeID<VarDecl> {
+
   /// The binding decl containing this var.
   public var binding: BindingDecl.Typed {
     .init(program.varToBinding[id]!, in: program)
   }
+
 }
 
 extension TypedNode where ID: ExprID {
+
   /// The type of this expression
   public var type: AnyType {
     program.exprTypes[id]!
   }
+
 }
 
 extension TypedNode where ID == NodeID<NameExpr> {
+
   public enum Domain: Equatable {
 
     /// No domain.
@@ -188,6 +200,7 @@ extension TypedNode where ID == NodeID<NameExpr> {
 
   /// A reference to a declaration.
   public enum DeclRef: Hashable {
+
     /// A direct reference.
     case direct(AnyDeclID.TypedNode)
 
@@ -201,6 +214,7 @@ extension TypedNode where ID == NodeID<NameExpr> {
       case .member(let d): return d
       }
     }
+
   }
 
   /// The declaration of this name.
@@ -212,16 +226,20 @@ extension TypedNode where ID == NodeID<NameExpr> {
       return .member(program[decl])
     }
   }
+
 }
 
 extension TypedNode where ID: PatternID {
+
   /// The names associated with this pattern.
   public var names: [(path: [Int], pattern: NamePattern.Typed)] {
     program.ast.names(in: id).map({ (path: $0.path, pattern: program[$0.pattern]) })
   }
+
 }
 
 extension TypedNode where ID == NodeID<ModuleDecl> {
+
   /// Collection of (typed) top-level declarations of the module.
   public typealias TopLevelDecls = LazyMapSequence<
     FlattenSequence<
@@ -237,9 +255,11 @@ extension TypedNode where ID == NodeID<ModuleDecl> {
   public var topLevelDecls: TopLevelDecls {
     program.ast.topLevelDecls(id).map({ program[$0] })
   }
+
 }
 
 extension TypedNode where ID == NodeID<FunctionDecl> {
+
   /// The body of the function, containing typed information
   public enum Body {
 
@@ -264,6 +284,7 @@ extension TypedNode where ID == NodeID<FunctionDecl> {
       return .none
     }
   }
+
 }
 
 extension TypedNode where ID == NodeID<SequenceExpr> {

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -1072,21 +1072,21 @@ public enum Parser {
       if state.ast[m].introducer.value == .memberwiseInit { return m }
     }
 
-    let site = state.emptyRange(at: startIndex)
+    let startOfTypeDecl = state.emptyRange(at: startIndex)
     let receiver = state.insert(
       synthesized: ParameterDecl(
-        identifier: SourceRepresentable(value: "self", range: site),
-        site: site))
+        identifier: SourceRepresentable(value: "self", range: startOfTypeDecl),
+        site: startOfTypeDecl))
     let m = state.insert(
       synthesized: InitializerDecl(
-        introducer: SourceRepresentable(value: .memberwiseInit, range: site),
+        introducer: SourceRepresentable(value: .memberwiseInit, range: startOfTypeDecl),
         attributes: [],
         accessModifier: nil,
         genericClause: nil,
         parameters: [],
         receiver: receiver,
         body: nil,
-        site: site))
+        site: startOfTypeDecl))
     members.append(AnyDeclID(m))
     return m
   }

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -890,7 +890,7 @@ public enum Parser {
           in: &state,
           introducedBy: SourceRepresentable(
             value: .let,
-            range: state.emptyRange(at: state.ast[body.node].site.start)),
+            range: state.emptyRange(at: state.ast[body.base].site.start)),
           body: body,
           asNonStaticMember: isNonStaticMember)
         return [impl]
@@ -961,7 +961,7 @@ public enum Parser {
     }
 
     let site: SourceRange
-    if let n = body?.node {
+    if let n = body?.base {
       site = introducer.site.extended(toCover: state.ast[n].site)
     } else {
       site = introducer.site

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -934,7 +934,8 @@ public enum Parser {
     }
   }
 
-  /// Inserts into `state.ast` a subscript implementation having the given `introducer` and `body` returning its ID.
+  /// Inserts a subscript having the given `introducer` and `body` into `state.ast` and returns its
+  /// ID.
   ///
   /// - Parameters:
   ///   - introducer: The introducer of the declaration, or `nil` if it is implicit. In that case,

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -1042,7 +1042,7 @@ public enum Parser {
 
     // Retrieve or synthesize the type's memberwise initializer.
     var members = parts.1
-    let memberwiseInit = getOrCreateMemberwiseInitializer(
+    let memberwiseInit = memberwiseInitializer(
       ofDeclStartingAt: parts.0.0.0.0.site.start,
       among: &members,
       updating: &state)
@@ -1062,7 +1062,7 @@ public enum Parser {
 
   /// Returns the first memberwise initializer declaration in `members` or synthesizes an implicit
   /// one, appends it into `members`, and returns it.
-  private static func getOrCreateMemberwiseInitializer(
+  private static func memberwiseInitializer(
     ofDeclStartingAt startIndex: SourceFile.Index,
     among members: inout [AnyDeclID],
     updating state: inout ParserState

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -2853,14 +2853,14 @@ public enum Parser {
     (maybe(passingConvention)
       .andCollapsingSoftFailures(expr)
       .map({ (state, tree) -> NodeID<ParameterTypeExpr> in
-        let site = state.range(from: tree.0?.site.start ?? state.ast[tree.1].site.start)
+        let s = state.range(from: tree.0?.site.start ?? state.ast[tree.1].site.start)
         return state.insert(
           ParameterTypeExpr(
             convention: tree.0 ?? SourceRepresentable(
               value: .let,
-              range: state.emptyRange(at: site.start)),
+              range: state.emptyRange(at: s.start)),
             bareType: tree.1,
-            site: site,
+            site: s,
             synthesized: tree.0 == nil
           ))
       }))

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -30,26 +30,12 @@ public enum Parser {
     in ast: inout AST,
     diagnostics: inout Diagnostics
   ) throws -> NodeID<TopLevelDeclSet> {
-
-    // Temporarily stash the ast and diagnostics in the parser state, avoiding CoW costs
+    // Temporarily stash the AST and diagnostics in the parser state, avoiding CoW costs
     var state = ParserState(ast: ast, lexer: Lexer(tokenizing: input), diagnostics: diagnostics)
     defer { diagnostics = state.diagnostics }
     diagnostics = Diagnostics()
 
-    let translation = Self.parseSourceFile(in: &state)
-    try state.diagnostics.throwOnError()
-
-    // Make sure the entire input was consumed.
-    assert(state.peek() == nil, "expected EOF")
-
-    state.ast[module].addSourceFile(translation)
-    ast = state.ast
-
-    return translation
-  }
-
-  /// Parses an instance of `TopLevelDeclSet`.
-  static func parseSourceFile(in state: inout ParserState) -> NodeID<TopLevelDeclSet> {
+    // Parse the input.
     var members: [AnyDeclID] = []
 
     while let head = state.peek() {
@@ -57,6 +43,7 @@ public enum Parser {
       if state.take(.semi) != nil { continue }
 
       // Attempt to parse a member.
+      let startIndex = state.currentIndex
       do {
         if let member = try parseDecl(in: &state) {
           members.append(member)
@@ -67,7 +54,10 @@ public enum Parser {
         continue
       } catch let error {
         state.diagnostics.report(
-          Diagnostic(level: .error, message: error.localizedDescription, site: .eliminateFIXME))
+          Diagnostic(
+            level: .error,
+            message: error.localizedDescription,
+            site: state.lexer.sourceCode.range(startIndex ..< state.currentIndex)))
         continue
       }
 
@@ -99,7 +89,18 @@ public enum Parser {
       }
     }
 
-    return state.insert(TopLevelDeclSet(decls: members))
+    // Make sure the entire input was consumed.
+    assert(state.peek() == nil, "expected EOF")
+
+    let translation = state.insert(
+      TopLevelDeclSet(
+        decls: members,
+        site: input.range(input.text.startIndex ..< input.text.endIndex)))
+    state.ast[module].addSourceFile(translation)
+
+    try state.diagnostics.throwOnError()
+    ast = state.ast
+    return translation
   }
 
   // MARK: Declarations
@@ -566,8 +567,8 @@ public enum Parser {
     if state.isAtTypeScope && !prologue.isStatic {
       receiver = state.insert(
         synthesized: ParameterDecl(
-          identifier: SourceRepresentable(value: "self", range: .eliminateFIXME),
-          site: .eliminateFIXME))
+          identifier: SourceRepresentable(value: "self", range: head.introducerSite),
+          site: head.introducerSite))
     } else {
       receiver = nil
     }
@@ -687,8 +688,8 @@ public enum Parser {
     // Init declarations require an implicit receiver parameter.
     let receiver = state.insert(
       synthesized: ParameterDecl(
-        identifier: SourceRepresentable(value: "self", range: .eliminateFIXME),
-        site: .eliminateFIXME))
+        identifier: SourceRepresentable(value: "self", range: introducer.site),
+        site: introducer.site))
 
     // Create a new `InitializerDecl`.
     assert(prologue.accessModifiers.count <= 1)
@@ -710,9 +711,10 @@ public enum Parser {
     withPrologue prologue: DeclPrologue,
     in state: inout ParserState
   ) throws -> NodeID<InitializerDecl>? {
-    // Parse the parts of the declaration.
-    let parser = (take(nameTokenWithValue: "memberwise").and(take(.`init`)))
-    guard let parts = try parser.parse(&state) else { return nil }
+    // Parse the introducer.
+    guard let a = state.take(nameTokenWithValue: "memberwise") else { return nil }
+    let b = try state.expect("'init'", using: { $0.take(.`init`) })
+    let introducerSite = a.site.extended(toCover: b.site)
 
     // Init declarations cannot be static.
     if let modifier = prologue.memberModifiers.first(where: { (m) in m.value == .static }) {
@@ -722,14 +724,14 @@ public enum Parser {
     // Init declarations require an implicit receiver parameter.
     let receiver = state.insert(
       synthesized: ParameterDecl(
-        identifier: SourceRepresentable(value: "self", range: .eliminateFIXME),
-        site: .eliminateFIXME))
+        identifier: SourceRepresentable(value: "self", range: introducerSite),
+        site: introducerSite))
 
     // Create a new `InitializerDecl`.
     assert(prologue.accessModifiers.count <= 1)
     return state.insert(
       InitializerDecl(
-        introducer: SourceRepresentable(value: .memberwiseInit, range: parts.0.site),
+        introducer: SourceRepresentable(value: .memberwiseInit, range: introducerSite),
         attributes: prologue.attributes,
         accessModifier: prologue.accessModifiers.first,
         genericClause: nil,
@@ -886,7 +888,9 @@ public enum Parser {
       if let body = try subscriptImplDeclBody.parse(&state) {
         let impl = try buildSubscriptImplDecl(
           in: &state,
-          withIntroducer: SourceRepresentable(value: .let, range: .eliminateFIXME),
+          introducedBy: SourceRepresentable(
+            value: .let,
+            range: state.emptyRange(at: state.ast[body.node].site.start)),
           body: body,
           asNonStaticMember: isNonStaticMember)
         return [impl]
@@ -911,7 +915,7 @@ public enum Parser {
       if let (introducer, body) = try subscriptImplDecl.parse(&state) {
         let impl = try buildSubscriptImplDecl(
           in: &state,
-          withIntroducer: introducer,
+          introducedBy: introducer,
           body: body,
           asNonStaticMember: isNonStaticMember)
         impls.append(impl)
@@ -930,9 +934,18 @@ public enum Parser {
     }
   }
 
+  /// Inserts in `state.ast` a subscript implementation declaration introduced with the given
+  /// introducer and body and returns its ID.
+  ///
+  /// - Parameters:
+  ///   - introducer: The introducer of the declaration, or `nil` if it is implicit. In that case,
+  ///     it is synthesized as `let`.
+  ///   - body: The body of the declaration, or `nil` if that body should must be synthesized or
+  ///     if the declaration denotes a trait requirement.
+  /// - Requires: `body` is not `nil` if `introducer` is.
   private static func buildSubscriptImplDecl(
     in state: inout ParserState,
-    withIntroducer introducer: SourceRepresentable<ImplIntroducer>,
+    introducedBy introducer: SourceRepresentable<ImplIntroducer>,
     body: SubscriptImplDecl.Body?,
     asNonStaticMember isNonStaticMember: Bool
   ) throws -> NodeID<SubscriptImplDecl> {
@@ -941,22 +954,17 @@ public enum Parser {
     if isNonStaticMember {
       receiver = state.insert(
         synthesized: ParameterDecl(
-          identifier: SourceRepresentable(value: "self", range: .eliminateFIXME),
-          site: .eliminateFIXME))
+          identifier: SourceRepresentable(value: "self", range: introducer.site),
+          site: introducer.site))
     } else {
       receiver = nil
     }
 
     let site: SourceRange
-    if introducer.site != .eliminateFIXME {
-      site = state.range(from: introducer.site.start)
+    if let n = body?.node {
+      site = introducer.site.extended(toCover: state.ast[n].site)
     } else {
-      switch body! {
-      case .expr(let id):
-        site = state.ast[id].site
-      case .block(let id):
-        site = state.ast[id].site
-      }
+      site = introducer.site
     }
 
     // Create a new `SubscriptImplDecl`.
@@ -992,8 +1000,8 @@ public enum Parser {
     // Synthesize the `Self` parameter of the trait.
     let selfParameterDecl = state.insert(
       GenericParameterDecl(
-        identifier: SourceRepresentable(value: "Self", range: .eliminateFIXME),
-        site: .eliminateFIXME))
+        identifier: SourceRepresentable(value: "Self", range: name.site),
+        site: name.site))
     members.append(AnyDeclID(selfParameterDecl))
 
     // Create a new `TraitDecl`.
@@ -1034,7 +1042,10 @@ public enum Parser {
 
     // Retrieve or synthesize the type's memberwise initializer.
     var members = parts.1
-    let memberwiseInit = findOrSynthesizeMemberwiseInitDecl(in: &members, updating: &state)
+    let memberwiseInit = getOrCreateMemberwiseInitializer(
+      ofDeclStartingAt: parts.0.0.0.0.site.start,
+      among: &members,
+      updating: &state)
 
     // Create a new `ProductTypeDecl`.
     assert(prologue.accessModifiers.count <= 1)
@@ -1051,8 +1062,9 @@ public enum Parser {
 
   /// Returns the first memberwise initializer declaration in `members` or synthesizes an implicit
   /// one, appends it into `members`, and returns it.
-  private static func findOrSynthesizeMemberwiseInitDecl(
-    in members: inout [AnyDeclID],
+  private static func getOrCreateMemberwiseInitializer(
+    ofDeclStartingAt startIndex: SourceFile.Index,
+    among members: inout [AnyDeclID],
     updating state: inout ParserState
   ) -> NodeID<InitializerDecl> {
     for member in members where member.kind == InitializerDecl.self {
@@ -1060,20 +1072,21 @@ public enum Parser {
       if state.ast[m].introducer.value == .memberwiseInit { return m }
     }
 
+    let site = state.emptyRange(at: startIndex)
     let receiver = state.insert(
       synthesized: ParameterDecl(
-        identifier: SourceRepresentable(value: "self", range: .eliminateFIXME),
-        site: .eliminateFIXME))
+        identifier: SourceRepresentable(value: "self", range: site),
+        site: site))
     let m = state.insert(
       synthesized: InitializerDecl(
-        introducer: SourceRepresentable(value: .memberwiseInit, range: .eliminateFIXME),
+        introducer: SourceRepresentable(value: .memberwiseInit, range: site),
         attributes: [],
         accessModifier: nil,
         genericClause: nil,
         parameters: [],
         receiver: receiver,
         body: nil,
-        site: .eliminateFIXME))
+        site: site))
     members.append(AnyDeclID(m))
     return m
   }
@@ -1198,8 +1211,8 @@ public enum Parser {
       .map({ (state, tree) -> NodeID<MethodImplDecl> in
         let receiver = state.insert(
           ParameterDecl(
-            identifier: SourceRepresentable(value: "self", range: .eliminateFIXME),
-            site: .eliminateFIXME))
+            identifier: SourceRepresentable(value: "self", range: tree.0.site),
+            site: tree.0.site))
         return state.insert(
           MethodImplDecl(
             introducer: tree.0,
@@ -1491,7 +1504,7 @@ public enum Parser {
       let `operator` = state.insert(
         NameExpr(
           name: SourceRepresentable(
-            value: Name(stem: operatorStem.value, notation: .infix), range: .eliminateFIXME),
+            value: Name(stem: operatorStem.value, notation: .infix), range: operatorStem.site),
           site: operatorStem.site))
       tail.append(SequenceExpr.TailElement(operator: `operator`, operand: operand))
     }
@@ -2203,9 +2216,8 @@ public enum Parser {
     let output = try state.expect("type expression", using: parseExpr(in:))
 
     // Synthesize the environment as an empty tuple if we parsed `[]`.
-    let e =
-      environement
-      ?? AnyExprID(state.insert(TupleTypeExpr(elements: [], site: .eliminateFIXME)))
+    let e = environement ?? AnyExprID(
+      state.insert(TupleTypeExpr(elements: [], site: state.emptyRange(at: opener.site.start))))
 
     let expr = state.insert(
       LambdaTypeExpr(
@@ -2841,12 +2853,14 @@ public enum Parser {
     (maybe(passingConvention)
       .andCollapsingSoftFailures(expr)
       .map({ (state, tree) -> NodeID<ParameterTypeExpr> in
-        state.insert(
+        let site = state.range(from: tree.0?.site.start ?? state.ast[tree.1].site.start)
+        return state.insert(
           ParameterTypeExpr(
-            convention: tree.0 ?? SourceRepresentable(value: .let, range: .eliminateFIXME),
+            convention: tree.0 ?? SourceRepresentable(
+              value: .let,
+              range: state.emptyRange(at: site.start)),
             bareType: tree.1,
-            site: state.range(
-              from: tree.0?.site.start ?? state.ast[tree.1].site.start),
+            site: site,
             synthesized: tree.0 == nil
           ))
       }))

--- a/Sources/FrontEnd/Parse/ParserState.swift
+++ b/Sources/FrontEnd/Parse/ParserState.swift
@@ -117,6 +117,11 @@ struct ParserState {
     lexer.sourceCode.range(startIndex ..< currentIndex)
   }
 
+  /// Returns an empty site starting and ending at `index`.
+  func emptyRange(at index: String.Index) -> SourceRange {
+    lexer.sourceCode.range(index ..< index)
+  }
+
   /// Returns whether `token` is a member index.
   func isMemberIndex(_ token: Token) -> Bool {
     (token.kind == .int)

--- a/Sources/FrontEnd/TypeChecking/ConstraintSolver.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSolver.swift
@@ -754,10 +754,7 @@ struct ConstraintSolver {
       typeAssumptions: typeAssumptions.optimized(),
       bindingAssumptions: bindingAssumptions,
       penalties: penalties,
-      diagnostics: diagnostics
-        + stale.map {
-          Diagnostic.error(staleConstraint: $0, at: .eliminateFIXME)
-        })
+      diagnostics: diagnostics + stale.map(Diagnostic.error(staleConstraint:)))
   }
 
   /// Creates an ambiguous solution.

--- a/Sources/FrontEnd/TypeChecking/ConstraintSolver.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSolver.swift
@@ -910,8 +910,8 @@ extension TypeChecker {
         else { return .incomparable }
 
         // Rank the candidates.
-        let lRefinesR = refines(lhs, rhs, scope: scope, site: program.ast[n].site)
-        let rRefinesL = refines(rhs, lhs, scope: scope, site: program.ast[n].site)
+        let lRefinesR = refines(lhs, rhs, in: scope, anchoringConstraintsAt: program.ast[n].site)
+        let rRefinesL = refines(rhs, lhs, in: scope, anchoringConstraintsAt: program.ast[n].site)
         switch (lRefinesR, rRefinesL) {
         case (true, false):
           if ranking > .equal { return .incomparable }
@@ -950,8 +950,8 @@ extension TypeChecker {
   fileprivate mutating func refines(
     _ l: AnyType,
     _ r: AnyType,
-    scope: AnyScopeID,
-    site: SourceRange
+    in scope: AnyScopeID,
+    anchoringConstraintsAt site: SourceRange
   ) -> Bool {
     // Skolemize the left operand.
     let skolemizedLeft = l.skolemized

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -180,8 +180,8 @@ extension Diagnostic {
     .error("trait requires method '\(name)' with type '\(type)'", at: site)
   }
 
-  static func error(staleConstraint c: any Constraint, at site: SourceRange) -> Diagnostic {
-    .error("stale constraint '\(c)'", at: site)
+  static func error(staleConstraint c: any Constraint) -> Diagnostic {
+    .error("stale constraint '\(c)'", at: c.cause.site)
   }
 
   static func error(

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1000,7 +1000,8 @@ public struct TypeChecker {
               because: [
                 .error(
                   traitRequiresMethod: Name(of: requirement, in: program.ast)!,
-                  withType: declTypes[requirement]!, at: .eliminateFIXME)
+                  withType: declTypes[requirement]!,
+                  at: program.ast[decl].identifier.site)
               ]))
           success = false
         }

--- a/Sources/IR/Analysis/LifetimePass.swift
+++ b/Sources/IR/Analysis/LifetimePass.swift
@@ -31,8 +31,7 @@ public struct LifetimePass: TransformPass {
           // Delete the borrow if it's never used.
           if borrowLifetime.isEmpty {
             if let decl = borrow.binding {
-              diagnostics.append(
-                .unusedBinding(name: decl.name, at: borrow.range ?? .eliminateFIXME))
+              diagnostics.append(.unusedBinding(name: decl.name, at: borrow.site))
             }
             module[block].instructions.remove(at: instruction.address)
             continue
@@ -40,7 +39,10 @@ public struct LifetimePass: TransformPass {
 
           // Insert `end_borrow` after the instruction's last users.
           for lastUse in borrowLifetime.maximalElements {
-            module.insert(EndBorrowInstruction(borrow: borrowID, range: nil), after: lastUse.user)
+            module.insert(
+              EndBorrowInstruction(
+                borrow: borrowID, site: module[lastUse.user].site),
+              after: lastUse.user)
           }
 
         default:

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -96,11 +96,13 @@ public struct Emitter {
       let value = emitR(expr: expr, into: &module)
 
       // Emit stack deallocation.
-      emitStackDeallocs(in: &module)
+      emitStackDeallocs(in: &module, site: expr.site)
 
       // Emit the implicit return statement.
       if expr.type != .never {
-        module.append(ReturnInstruction(value: value), to: insertionBlock!)
+        module.append(
+          ReturnInstruction(value: value, site: expr.site),
+          to: insertionBlock!)
       }
     }
 
@@ -155,23 +157,23 @@ public struct Emitter {
   ) {
     /// A map from object path to its corresponding (sub-)object during destruction.
     var objects: [[Int]: Operand] = [:]
-    /// The type of the initializer, if any.
-    var initializerType: AnyType?
 
     // Emit the initializer, if any.
     if let initializer = decl.initializer {
       objects[[]] = emitR(expr: initializer, into: &module)
-      initializerType = initializer.type
     }
 
     // Allocate storage for each name introduced by the declaration.
     for (path, name) in decl.pattern.subpattern.names {
-      let storage = module.append(AllocStackInstruction(name.decl.type), to: insertionBlock!)[0]
+      let storage = module.append(
+        AllocStackInstruction(name.decl.type, site: name.site),
+        to: insertionBlock!)[0]
       stack.top.allocs.append(storage)
       stack[name.decl] = storage
 
-      if var rhsType = initializerType {
+      if let initializer = decl.initializer {
         // Determine the object corresponding to the current name.
+        var rhsType = initializer.type
         for i in 0 ..< path.count {
           // Make sure the initializer has been destructured deeply enough.
           let subpath = Array(path[0 ..< i])
@@ -183,7 +185,9 @@ public struct Emitter {
           let wholePath = Array(path[0 ..< (i - 1)])
           let whole = objects[wholePath]!
           let parts = module.append(
-            DestructureInstruction(whole, as: layout.storedPropertiesTypes.map({ .object($0) })),
+            DestructureInstruction(
+              whole, as: layout.storedPropertiesTypes.map({ .object($0) }),
+              site: initializer.site),
             to: insertionBlock!)
 
           for j in 0 ..< parts.count {
@@ -193,11 +197,13 @@ public struct Emitter {
 
         // Borrow the storage for initialization corresponding to the current name.
         let target = module.append(
-          BorrowInstruction(.set, .address(name.decl.type), from: storage),
+          BorrowInstruction(.set, .address(name.decl.type), from: storage, site: name.site),
           to: insertionBlock!)[0]
 
         // Store the corresponding (part of) the initializer.
-        module.append(StoreInstruction(objects[path]!, to: target), to: insertionBlock!)
+        module.append(
+          StoreInstruction(objects[path]!, to: target, site: name.site),
+          to: insertionBlock!)
       }
     }
   }
@@ -222,26 +228,26 @@ public struct Emitter {
         let value = emitR(expr: initializer, into: &module)
 
         let exprType = initializer.type
-        let storage = module.append(AllocStackInstruction(exprType), to: insertionBlock!)[0]
+        let storage = module.append(
+          AllocStackInstruction(exprType, site: pattern.site),
+          to: insertionBlock!)[0]
         stack.top.allocs.append(storage)
         source = storage
 
         let target = module.append(
-          BorrowInstruction(.set, .address(exprType), from: storage),
+          BorrowInstruction(.set, .address(exprType), from: storage, site: pattern.site),
           to: insertionBlock!)[0]
-        module.append(StoreInstruction(value, to: target), to: insertionBlock!)
+        module.append(
+          StoreInstruction(value, to: target, site: pattern.site),
+          to: insertionBlock!)
       }
 
       for (path, name) in pattern.subpattern.names {
         stack[name.decl] =
           module.append(
             BorrowInstruction(
-              capability,
-              .address(name.decl.type),
-              from: source,
-              at: path,
-              binding: name.decl,
-              range: name.decl.site),
+              capability, .address(name.decl.type), from: source, at: path, binding: name.decl,
+              site: name.decl.site),
             to: insertionBlock!)[0]
       }
     }
@@ -271,7 +277,7 @@ public struct Emitter {
     let rhs = emitR(expr: stmt.right, into: &module)
     // FIXME: Should request the capability 'set or inout'.
     let lhs = emitL(expr: stmt.left, withCapability: .set, into: &module)
-    _ = module.append(StoreInstruction(rhs, to: lhs), to: insertionBlock!)
+    _ = module.append(StoreInstruction(rhs, to: lhs, site: stmt.site), to: insertionBlock!)
   }
 
   private mutating func emit(brace stmt: BraceStmt.Typed, into module: inout Module) {
@@ -279,7 +285,7 @@ public struct Emitter {
     for s in stmt.stmts {
       emit(stmt: s, into: &module)
     }
-    emitStackDeallocs(in: &module)
+    emitStackDeallocs(in: &module, site: stmt.site)
     stack.pop()
   }
 
@@ -304,8 +310,8 @@ public struct Emitter {
       value = .constant(.void)
     }
 
-    emitStackDeallocs(in: &module)
-    module.append(ReturnInstruction(value: value, range: stmt.site), to: insertionBlock!)
+    emitStackDeallocs(in: &module, site: stmt.site)
+    module.append(ReturnInstruction(value: value, site: stmt.site), to: insertionBlock!)
   }
 
   // MARK: r-values
@@ -316,8 +322,8 @@ public struct Emitter {
     defer {
       // Mark the execution path unreachable if the computed value has type `Never`.
       if expr.type == .never {
-        emitStackDeallocs(in: &module)
-        module.append(UnrechableInstruction(), to: insertionBlock!)
+        emitStackDeallocs(in: &module, site: expr.site)
+        module.append(UnrechableInstruction(site: expr.site), to: insertionBlock!)
       }
     }
 
@@ -348,7 +354,7 @@ public struct Emitter {
 
     let boolType = program.ast.coreType(named: "Bool")!
     return module.append(
-      RecordInstruction(objectType: .object(boolType), operands: [value]),
+      RecordInstruction(objectType: .object(boolType), operands: [value], site: expr.site),
       to: insertionBlock!)[0]
   }
 
@@ -361,7 +367,9 @@ public struct Emitter {
     // If the expression is supposed to return a value, allocate storage for it.
     var resultStorage: Operand?
     if expr.type != .void {
-      resultStorage = module.append(AllocStackInstruction(expr.type), to: insertionBlock!)[0]
+      resultStorage = module.append(
+        AllocStackInstruction(expr.type, site: expr.site),
+        to: insertionBlock!)[0]
       stack.top.allocs.append(resultStorage!)
     }
 
@@ -379,7 +387,9 @@ public struct Emitter {
         var condition = emitL(expr: program[itemExpr], withCapability: .let, into: &module)
         condition =
           module.append(
-            BorrowInstruction(.let, .address(BuiltinType.i(1)), from: condition, at: [0]),
+            BorrowInstruction(
+              .let, .address(BuiltinType.i(1)), from: condition, at: [0],
+              site: program[itemExpr].site),
             to: insertionBlock!)[0]
         condition =
           module.append(
@@ -388,7 +398,8 @@ public struct Emitter {
               calleeConvention: .let,
               callee: .constant(.builtin(BuiltinFunctionRef["i1_copy"]!)),
               argumentConventions: [.let],
-              arguments: [condition]),
+              arguments: [condition],
+              site: program[itemExpr].site),
             to: insertionBlock!)[0]
 
         module.append(
@@ -396,7 +407,7 @@ public struct Emitter {
             condition: condition,
             targetIfTrue: success,
             targetIfFalse: failure,
-            range: nil),
+            site: expr.site),
           to: insertionBlock!)
         insertionBlock = success
 
@@ -415,17 +426,21 @@ public struct Emitter {
       let value = emitR(expr: program[thenExpr], into: &module)
       if let target = resultStorage {
         let target = module.append(
-          BorrowInstruction(.set, .address(expr.type), from: target),
+          BorrowInstruction(
+            .set, .address(expr.type), from: target,
+            site: program[thenExpr].site),
           to: insertionBlock!)[0]
-        module.append(StoreInstruction(value, to: target), to: insertionBlock!)
+        module.append(
+          StoreInstruction(value, to: target, site: program[thenExpr].site),
+          to: insertionBlock!)
       }
-      emitStackDeallocs(in: &module)
+      emitStackDeallocs(in: &module, site: expr.site)
       stack.pop()
 
     case .block:
       fatalError("not implemented")
     }
-    module.append(BranchInstruction(target: continuation), to: insertionBlock!)
+    module.append(BranchInstruction(target: continuation, site: expr.site), to: insertionBlock!)
 
     // Emit the failure branch.
     insertionBlock = alt
@@ -435,11 +450,15 @@ public struct Emitter {
       let value = emitR(expr: program[elseExpr], into: &module)
       if let target = resultStorage {
         let target = module.append(
-          BorrowInstruction(.set, .address(expr.type), from: target),
+          BorrowInstruction(
+            .set, .address(expr.type), from: target,
+            site: program[elseExpr].site),
           to: insertionBlock!)[0]
-        module.append(StoreInstruction(value, to: target), to: insertionBlock!)
+        module.append(
+          StoreInstruction(value, to: target, site: program[elseExpr].site),
+          to: insertionBlock!)
       }
-      emitStackDeallocs(in: &module)
+      emitStackDeallocs(in: &module, site: expr.site)
       stack.pop()
 
     case .block:
@@ -448,13 +467,13 @@ public struct Emitter {
     case nil:
       break
     }
-    module.append(BranchInstruction(target: continuation), to: insertionBlock!)
+    module.append(BranchInstruction(target: continuation, site: expr.site), to: insertionBlock!)
 
     // Emit the value of the expression.
     insertionBlock = continuation
     if let source = resultStorage {
       return module.append(
-        LoadInstruction(LoweredType(lowering: expr.type), from: source),
+        LoadInstruction(LoweredType(lowering: expr.type), from: source, site: expr.site),
         to: insertionBlock!)[0]
     } else {
       return .constant(.void)
@@ -515,7 +534,9 @@ public struct Emitter {
           // The function is a memberwise initializer. In that case, the whole call expression is
           // lowered as a `record` instruction.
           return module.append(
-            RecordInstruction(objectType: .object(expr.type), operands: arguments),
+            RecordInstruction(
+              objectType: .object(expr.type), operands: arguments,
+              site: expr.site),
             to: insertionBlock!)[0]
         }
 
@@ -531,7 +552,9 @@ public struct Emitter {
           switch calleeNameExpr.domain {
           case .none:
             let receiver = module.append(
-              BorrowInstruction(type.capability, .address(type.base), from: stack[receiverDecl!]!),
+              BorrowInstruction(
+                type.capability, .address(type.base), from: stack[receiverDecl!]!,
+                site: expr.site),
               to: insertionBlock!)[0]
             arguments.insert(receiver, at: 0)
 
@@ -549,7 +572,7 @@ public struct Emitter {
           switch calleeNameExpr.domain {
           case .none:
             let receiver = module.append(
-              LoadInstruction(.object(receiverType), from: stack[receiverDecl!]!),
+              LoadInstruction(.object(receiverType), from: stack[receiverDecl!]!, site: expr.site),
               to: insertionBlock!)[0]
             arguments.insert(receiver, at: 0)
 
@@ -583,7 +606,8 @@ public struct Emitter {
         calleeConvention: calleeConvention,
         callee: callee,
         argumentConventions: argumentConventions,
-        arguments: arguments),
+        arguments: arguments,
+        site: expr.site),
       to: insertionBlock!)[0]
   }
 
@@ -614,7 +638,8 @@ public struct Emitter {
     // Emit the constant integer.
     let value = IntegerConstant(bits, bitWidth: bitWidth)
     return module.append(
-      RecordInstruction(objectType: .object(type), operands: [.constant(.integer(value))]),
+      RecordInstruction(
+        objectType: .object(type), operands: [.constant(.integer(value))], site: expr.site),
       to: insertionBlock!)[0]
   }
 
@@ -627,7 +652,8 @@ public struct Emitter {
       // Lookup for a local symbol.
       if let source = stack[declID] {
         return module.append(
-          LoadInstruction(.object(expr.type), from: source), to: insertionBlock!)[0]
+          LoadInstruction(.object(expr.type), from: source, site: expr.site),
+          to: insertionBlock!)[0]
       }
 
       fatalError("not implemented")
@@ -688,7 +714,8 @@ public struct Emitter {
           calleeConvention: .let,
           callee: calleeOperand,
           argumentConventions: [lhsConvention, rhsType.convention],
-          arguments: [lhsOperand, rhsOperand]),
+          arguments: [lhsOperand, rhsOperand],
+          site: program.ast.site(of: expr)),
         to: insertionBlock!)[0]
 
     case .leaf(let expr):
@@ -784,7 +811,9 @@ public struct Emitter {
           switch nameExpr.domain {
           case .none:
             let receiver = module.append(
-              BorrowInstruction(type.capability, .address(type.base), from: stack[receiverDecl!]!),
+              BorrowInstruction(
+                type.capability, .address(type.base), from: stack[receiverDecl!]!,
+                site: nameExpr.site),
               to: insertionBlock!)[0]
             arguments.insert(receiver, at: 0)
 
@@ -802,7 +831,8 @@ public struct Emitter {
           switch nameExpr.domain {
           case .none:
             let receiver = module.append(
-              LoadInstruction(.object(receiverType), from: stack[receiverDecl!]!),
+              LoadInstruction(
+                .object(receiverType), from: stack[receiverDecl!]!, site: nameExpr.site),
               to: insertionBlock!)[0]
             arguments.insert(receiver, at: 0)
 
@@ -849,16 +879,20 @@ public struct Emitter {
 
     default:
       let value = emitR(expr: expr, into: &module)
-      let storage = module.append(AllocStackInstruction(expr.type), to: insertionBlock!)[0]
+      let storage = module.append(
+        AllocStackInstruction(expr.type, site: expr.site),
+        to: insertionBlock!)[0]
       stack.top.allocs.append(storage)
 
       let target = module.append(
-        BorrowInstruction(.set, .address(expr.type), from: storage),
+        BorrowInstruction(.set, .address(expr.type), from: storage, site: expr.site),
         to: insertionBlock!)[0]
-      module.append(StoreInstruction(value, to: target), to: insertionBlock!)
+      module.append(
+        StoreInstruction(value, to: target, site: expr.site),
+        to: insertionBlock!)
 
       return module.append(
-        BorrowInstruction(capability, .address(expr.type), from: storage),
+        BorrowInstruction(capability, .address(expr.type), from: storage, site: expr.site),
         to: insertionBlock!)[0]
     }
   }
@@ -873,7 +907,7 @@ public struct Emitter {
       // Lookup for a local symbol.
       if let source = stack[decl] {
         return module.append(
-          BorrowInstruction(capability, .address(expr.type), from: source),
+          BorrowInstruction(capability, .address(expr.type), from: source, site: expr.site),
           to: insertionBlock!)[0]
       }
 
@@ -905,17 +939,15 @@ public struct Emitter {
           let receiverInstruction = module[id] as? BorrowInstruction
         {
           module[id] = BorrowInstruction(
-            capability,
-            .address(expr.type),
-            from: receiverInstruction.location,
-            at: receiverInstruction.path + [memberIndex])
+            capability, .address(expr.type), from: receiverInstruction.location,
+            at: receiverInstruction.path + [memberIndex],
+            site: expr.site)
           return receiver
         } else {
           let member = BorrowInstruction(
-            capability,
-            .address(expr.type),
-            from: receiver,
-            at: [memberIndex])
+            capability, .address(expr.type), from: receiver,
+            at: [memberIndex],
+            site: expr.site)
           return module.append(member, to: insertionBlock!)[0]
         }
 
@@ -929,9 +961,9 @@ public struct Emitter {
 
   // MARK: Helpers
 
-  private mutating func emitStackDeallocs(in module: inout Module) {
+  private mutating func emitStackDeallocs(in module: inout Module, site: SourceRange) {
     while let alloc = stack.top.allocs.popLast() {
-      module.append(DeallocStackInstruction(alloc), to: insertionBlock!)
+      module.append(DeallocStackInstruction(alloc, site: site), to: insertionBlock!)
     }
   }
 

--- a/Sources/IR/Operands/Instruction/AllocStackInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AllocStackInstruction.swift
@@ -9,12 +9,12 @@ public struct AllocStackInstruction: Instruction {
   /// The binding in source program to which the instruction corresponds, if any.
   public let binding: VarDecl.Typed?
 
-  public let range: SourceRange?
+  public let site: SourceRange
 
-  init(_ allocatedType: AnyType, binding: VarDecl.Typed? = nil, range: SourceRange? = nil) {
+  init(_ allocatedType: AnyType, binding: VarDecl.Typed? = nil, site: SourceRange) {
     self.allocatedType = allocatedType
     self.binding = binding
-    self.range = range
+    self.site = site
   }
 
   public var types: [LoweredType] { [.address(allocatedType)] }

--- a/Sources/IR/Operands/Instruction/BorrowInstruction.swift
+++ b/Sources/IR/Operands/Instruction/BorrowInstruction.swift
@@ -18,7 +18,7 @@ public struct BorrowInstruction: Instruction {
   /// The binding in source program to which the instruction corresponds, if any.
   public let binding: VarDecl.Typed?
 
-  public let range: SourceRange?
+  public let site: SourceRange
 
   init(
     _ capability: AccessEffect,
@@ -26,14 +26,14 @@ public struct BorrowInstruction: Instruction {
     from location: Operand,
     at path: [Int] = [],
     binding: VarDecl.Typed? = nil,
-    range: SourceRange? = nil
+    site: SourceRange
   ) {
     self.borrowedType = borrowedType
     self.capability = capability
     self.location = location
     self.path = path
     self.binding = binding
-    self.range = range
+    self.site = site
   }
 
   public var types: [LoweredType] { [borrowedType] }

--- a/Sources/IR/Operands/Instruction/BranchInstruction.swift
+++ b/Sources/IR/Operands/Instruction/BranchInstruction.swift
@@ -8,11 +8,11 @@ public struct BranchInstruction: Instruction {
   /// The target of the branch.
   public let target: Block.ID
 
-  public let range: SourceRange?
+  public let site: SourceRange
 
-  init(target: Block.ID, range: SourceRange? = nil) {
+  init(target: Block.ID, site: SourceRange) {
     self.target = target
-    self.range = range
+    self.site = site
   }
 
   public var types: [LoweredType] { [] }

--- a/Sources/IR/Operands/Instruction/CallInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CallInstruction.swift
@@ -14,7 +14,7 @@ public struct CallInstruction: Instruction {
 
   public let operands: [Operand]
 
-  public let range: SourceRange?
+  public let site: SourceRange
 
   public init(
     returnType: LoweredType,
@@ -22,12 +22,12 @@ public struct CallInstruction: Instruction {
     callee: Operand,
     argumentConventions: [AccessEffect],
     arguments: [Operand],
-    range: SourceRange? = nil
+    site: SourceRange
   ) {
     self.returnType = returnType
     self.conventions = [calleeConvention] + argumentConventions
     self.operands = [callee] + arguments
-    self.range = range
+    self.site = site
   }
 
   /// Returns whether the instruction is a call to a built-in function.

--- a/Sources/IR/Operands/Instruction/CondBranchInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CondBranchInstruction.swift
@@ -14,7 +14,14 @@ public struct CondBranchInstruction: Instruction {
   /// The target of the branch if `condition` is false.
   public let targetIfFalse: Block.ID
 
-  public let range: SourceRange?
+  public let site: SourceRange
+
+  init(condition: Operand, targetIfTrue: Block.ID, targetIfFalse: Block.ID, site: SourceRange) {
+    self.condition = condition
+    self.targetIfTrue = targetIfTrue
+    self.targetIfFalse = targetIfFalse
+    self.site = site
+  }
 
   public var types: [LoweredType] { [] }
 

--- a/Sources/IR/Operands/Instruction/DeallocStackInstruction.swift
+++ b/Sources/IR/Operands/Instruction/DeallocStackInstruction.swift
@@ -6,11 +6,11 @@ public struct DeallocStackInstruction: Instruction {
   /// The location of the memory being deallocated.
   public let location: Operand
 
-  public let range: SourceRange?
+  public let site: SourceRange
 
-  init(_ location: Operand, range: SourceRange? = nil) {
+  init(_ location: Operand, site: SourceRange) {
     self.location = location
-    self.range = range
+    self.site = site
   }
 
   public var types: [LoweredType] { [] }

--- a/Sources/IR/Operands/Instruction/DeinitInstruction.swift
+++ b/Sources/IR/Operands/Instruction/DeinitInstruction.swift
@@ -6,11 +6,11 @@ public struct DeinitInstruction: Instruction {
   /// The object being deinitialized.
   public let object: Operand
 
-  public let range: SourceRange?
+  public let site: SourceRange
 
-  init(_ object: Operand, range: SourceRange? = nil) {
+  init(_ object: Operand, site: SourceRange) {
     self.object = object
-    self.range = range
+    self.site = site
   }
 
   public var types: [LoweredType] { [] }

--- a/Sources/IR/Operands/Instruction/DestructureInstruction.swift
+++ b/Sources/IR/Operands/Instruction/DestructureInstruction.swift
@@ -9,12 +9,12 @@ public struct DestructureInstruction: Instruction {
   /// The object being destructured.
   public let object: Operand
 
-  public let range: SourceRange?
+  public let site: SourceRange
 
-  init(_ object: Operand, as types: [LoweredType], range: SourceRange? = nil) {
+  init(_ object: Operand, as types: [LoweredType], site: SourceRange) {
     self.types = types
     self.object = object
-    self.range = range
+    self.site = site
   }
 
   public var operands: [Operand] { [object] }

--- a/Sources/IR/Operands/Instruction/EndBorrowInstruction.swift
+++ b/Sources/IR/Operands/Instruction/EndBorrowInstruction.swift
@@ -6,7 +6,12 @@ public struct EndBorrowInstruction: Instruction {
   /// The borrow whose lifetime is ended.
   public let borrow: Operand
 
-  public let range: SourceRange?
+  public let site: SourceRange
+
+  init(borrow: Operand, site: SourceRange) {
+    self.borrow = borrow
+    self.site = site
+  }
 
   public var types: [LoweredType] { [] }
 

--- a/Sources/IR/Operands/Instruction/Instruction.swift
+++ b/Sources/IR/Operands/Instruction/Instruction.swift
@@ -9,8 +9,8 @@ public protocol Instruction {
   /// The operands of the instruction.
   var operands: [Operand] { get }
 
-  /// The site of the code corresponding to that instruction, if any.
-  var range: SourceRange? { get }
+  /// The site of the code corresponding to that instruction.
+  var site: SourceRange { get }
 
   /// Indicates whether the instruction is a terminator.
   ///

--- a/Sources/IR/Operands/Instruction/LoadInstruction.swift
+++ b/Sources/IR/Operands/Instruction/LoadInstruction.swift
@@ -13,18 +13,18 @@ public struct LoadInstruction: Instruction {
   /// A sequence of indices identifying a sub-location of `location`.
   public let path: [Int]
 
-  public let range: SourceRange?
+  public let site: SourceRange
 
   init(
     _ objectType: LoweredType,
     from source: Operand,
     at path: [Int] = [],
-    range: SourceRange? = nil
+    site: SourceRange
   ) {
     self.objectType = objectType
     self.source = source
     self.path = path
-    self.range = range
+    self.site = site
   }
 
   public var types: [LoweredType] { [objectType] }

--- a/Sources/IR/Operands/Instruction/RecordInstruction.swift
+++ b/Sources/IR/Operands/Instruction/RecordInstruction.swift
@@ -12,7 +12,13 @@ public struct RecordInstruction: Instruction {
   /// The operands consumed to initialize the record members.
   public let operands: [Operand]
 
-  public let range: SourceRange?
+  public let site: SourceRange
+
+  init(objectType: LoweredType, operands: [Operand], site: SourceRange) {
+    self.objectType = objectType
+    self.operands = operands
+    self.site = site
+  }
 
   public var types: [LoweredType] { [objectType] }
 
@@ -23,9 +29,4 @@ public struct RecordInstruction: Instruction {
     return !objectType.isAddress
   }
 
-  init(objectType: LoweredType, operands: [Operand], range: SourceRange? = nil) {
-    self.objectType = objectType
-    self.operands = operands
-    self.range = range
-  }
 }

--- a/Sources/IR/Operands/Instruction/ReturnInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ReturnInstruction.swift
@@ -6,11 +6,11 @@ public struct ReturnInstruction: Instruction {
   /// The returned value.
   public let value: Operand
 
-  public let range: SourceRange?
+  public let site: SourceRange
 
-  init(value: Operand = .constant(.void), range: SourceRange? = nil) {
+  init(value: Operand = .constant(.void), site: SourceRange) {
     self.value = value
-    self.range = range
+    self.site = site
   }
 
   public var types: [LoweredType] { [] }

--- a/Sources/IR/Operands/Instruction/StoreInstruction.swift
+++ b/Sources/IR/Operands/Instruction/StoreInstruction.swift
@@ -9,12 +9,12 @@ public struct StoreInstruction: Instruction {
   /// The location at which the object is stored.
   public let target: Operand
 
-  public let range: SourceRange?
+  public let site: SourceRange
 
-  init(_ object: Operand, to target: Operand, range: SourceRange? = nil) {
+  init(_ object: Operand, to target: Operand, site: SourceRange) {
     self.object = object
     self.target = target
-    self.range = range
+    self.site = site
   }
 
   public var types: [LoweredType] { [] }

--- a/Sources/IR/Operands/Instruction/UnreachableInstruction.swift
+++ b/Sources/IR/Operands/Instruction/UnreachableInstruction.swift
@@ -3,7 +3,11 @@ import Core
 /// Marks this execution path as unreachable, causing a fatal error otherwise.
 public struct UnrechableInstruction: Instruction {
 
-  public var range: SourceRange?
+  public var site: SourceRange
+
+  init(site: SourceRange) {
+    self.site = site
+  }
 
   public var types: [LoweredType] { [] }
 

--- a/Tests/ValTests/ASTTests.swift
+++ b/Tests/ValTests/ASTTests.swift
@@ -19,18 +19,18 @@ final class ASTTests: XCTestCase {
 
     // Create a module declarations.
     let input = SourceFile(synthesizedText: "")
-    let site = input.range(input.text.startIndex ..< input.text.endIndex)
     let module = ast.insert(synthesized: ModuleDecl(name: "Val"))
 
     // Create a trait declaration.
     let decl = ast.insert(
       synthesized: ImportDecl(
-        introducerSite: site,
-        identifier: SourceRepresentable(value: "T", range: site),
-        site: site))
+        introducerSite: input.wholeRange,
+        identifier: SourceRepresentable(value: "T", range: input.wholeRange),
+        site: input.wholeRange))
 
     // Create a source declaration set.
-    let source = ast.insert(synthesized: TopLevelDeclSet(decls: [AnyDeclID(decl)], site: site))
+    let source = ast.insert(
+      synthesized: TopLevelDeclSet(decls: [AnyDeclID(decl)], site: input.wholeRange))
     ast[module].addSourceFile(source)
 
     // Subscript the AST for reading with a type-erased ID.
@@ -40,9 +40,8 @@ final class ASTTests: XCTestCase {
   func testCodableRoundtrip() throws {
     var ast = AST()
 
-    // Create a module.
+    // Create a module declarations.
     let input = SourceFile(synthesizedText: "")
-    let site = input.range(input.text.startIndex ..< input.text.endIndex)
     let module = ast.insert(synthesized: ModuleDecl(name: "Val"))
 
     let source = ast.insert(
@@ -51,11 +50,11 @@ final class ASTTests: XCTestCase {
           AnyDeclID(
             ast.insert(
               synthesized: FunctionDecl(
-                introducerSite: site,
-                identifier: SourceRepresentable(value: "foo", range: site),
-                site: site)))
+                introducerSite: input.wholeRange,
+                identifier: SourceRepresentable(value: "foo", range: input.wholeRange),
+                site: input.wholeRange)))
         ],
-        site: site))
+        site: input.wholeRange))
     ast[module].addSourceFile(source)
 
     // Serialize the AST.

--- a/Tests/ValTests/ASTTests.swift
+++ b/Tests/ValTests/ASTTests.swift
@@ -18,17 +18,19 @@ final class ASTTests: XCTestCase {
     var ast = AST()
 
     // Create a module declarations.
+    let input = SourceFile(synthesizedText: "")
+    let site = input.range(input.text.startIndex ..< input.text.endIndex)
     let module = ast.insert(synthesized: ModuleDecl(name: "Val"))
 
     // Create a trait declaration.
     let decl = ast.insert(
       synthesized: ImportDecl(
-        introducerSite: .eliminateFIXME,
-        identifier: SourceRepresentable(value: "T", range: .eliminateFIXME),
-        site: .eliminateFIXME))
+        introducerSite: site,
+        identifier: SourceRepresentable(value: "T", range: site),
+        site: site))
 
     // Create a source declaration set.
-    let source = ast.insert(synthesized: TopLevelDeclSet(decls: [AnyDeclID(decl)]))
+    let source = ast.insert(synthesized: TopLevelDeclSet(decls: [AnyDeclID(decl)], site: site))
     ast[module].addSourceFile(source)
 
     // Subscript the AST for reading with a type-erased ID.
@@ -39,17 +41,21 @@ final class ASTTests: XCTestCase {
     var ast = AST()
 
     // Create a module.
+    let input = SourceFile(synthesizedText: "")
+    let site = input.range(input.text.startIndex ..< input.text.endIndex)
     let module = ast.insert(synthesized: ModuleDecl(name: "Val"))
+
     let source = ast.insert(
       synthesized: TopLevelDeclSet(
         decls: [
           AnyDeclID(
             ast.insert(
               synthesized: FunctionDecl(
-                introducerSite: .eliminateFIXME,
-                identifier: SourceRepresentable(value: "foo", range: .eliminateFIXME),
-                site: .eliminateFIXME)))
-        ]))
+                introducerSite: site,
+                identifier: SourceRepresentable(value: "foo", range: site),
+                site: site)))
+        ],
+        site: site))
     ast[module].addSourceFile(source)
 
     // Serialize the AST.

--- a/Tests/ValTests/ParserTests.swift
+++ b/Tests/ValTests/ParserTests.swift
@@ -51,8 +51,12 @@ final class ParserTests: XCTestCase {
         public let y = 0;
       """)
 
-    let (id, ast) = input.parse(with: Parser.parseSourceFile)
-    XCTAssertEqual(ast[id].decls.count, 4)
+    var program = AST()
+    let module = program.insert(synthesized: ModuleDecl(name: "Main"))
+    var d = Diagnostics()
+    let translation = try Parser.parse(input, into: module, in: &program, diagnostics: &d)
+
+    XCTAssertEqual(program[translation].decls.count, 4)
   }
 
   // MARK: Declarations


### PR DESCRIPTION
This PR removes the `eliminateFIXME` values that had been used to replace optional source ranges.

Note that we will probably need to determine better source sites for IR instructions during lowering in the future, so as to improve the accuracy of diagnostics and step-debugging.