### PR TITLE
Properly serialize/deserialize source files

### DIFF
--- a/Sources/Core/SourceFile.swift
+++ b/Sources/Core/SourceFile.swift
@@ -7,26 +7,30 @@ import Utils
 ///   are both synthesized.
 public struct SourceFile {
 
+  /// The notional stored properties of `self`; distinguished for encoding/decoding purposes.
+  ///
+  /// - Note: the instance is owned by a global dictionary, `Storage.allInstances`.
+  private unowned let storage: Storage
+
   /// A position in the source text.
   public typealias Index = String.Index
 
   /// The contents of the source file.
-  public let text: String
+  public var text: String { storage.text }
 
   /// The URL of the source file.
-  public let url: URL
+  public var url: URL { storage.url }
 
   /// The start position of each line.
   ///
   /// - Invariant: always starts with `contents.startIndex` and ends with `contents.endIndex`, even
   ///   if there's no final newline.
-  public let lineStarts: [Index]
+  public var lineStarts: [Index] { storage.lineStarts }
 
-  /// Creates a source file with the contents of the specifide URL.
-  public init(contentsOf url: URL) throws {
-    self.url = url
-    self.text = url.scheme == "synthesized" ? "" : try String(contentsOf: url)
-    self.lineStarts = text.lineBoundaries()
+  /// Creates an instance representing the file at `filePath`.
+  public init(contentsOf filePath: URL) throws {
+    let storage = try Storage(filePath) { try String(contentsOf: filePath) }
+    self.storage = storage
   }
 
   /// The name of the source file, sans path qualification or extension.
@@ -39,11 +43,10 @@ public struct SourceFile {
     range(text.startIndex ..< text.endIndex)
   }
 
-  /// Creates a source file with the specified contents, creating a unique random URL.
+  /// Creates a source file with the specified contents and a unique random `url`.
   public init(synthesizedText text: String) {
-    self.url = URL(string: "synthesized://\(UUID().uuidString)")!
-    self.text = text
-    self.lineStarts = text.lineBoundaries()
+    let storage = Storage(URL(string: "synthesized://\(UUID().uuidString)")!) { text }
+    self.storage = storage
   }
 
   /// Returns the contents of the file in the specified range.
@@ -128,15 +131,67 @@ extension SourceFile: Hashable {
 
 extension SourceFile: Codable {
 
+  /// The state that must be maintained on behalf of `SourceFile`s while they are encoded.
+  struct EncodingState {
+
+    /// Creates an empty instance.
+    public init() {}
+
+    /// A mapping from the identity of a `SourceFile`'s storage to a pair, (`id`, `s`), where `id`
+    /// is the serialized representation of `SourceFile` instances having that `storage`, and `s`
+    /// is the storage itself.
+    fileprivate var allInstances: [ObjectIdentifier: (id: Int, storage: Storage)] = [:]
+
+    /// Returns the corresponding state that should be used to decode the `SourceFile` values whose
+    /// encoding updated the value of `self`.
+    func decodingState() -> DecodingState {
+      DecodingState(allInstances: allInstances.values.sorted { $0.id < $1.id }.map(\.storage))
+    }
+
+  }
+
+  /// The state that must be maintained on behalf of `SourceFile`s while they are decoded.
+  struct DecodingState: Codable {
+
+    /// Creates an empty instance.
+    ///
+    /// Empty instances are stored in a `StatefulDecoder`, and are eventually replaced during the
+    /// decoding of an `AST`.
+    public init() { allInstances = [] }
+
+    /// Creates an instance containing `allInstances`
+    fileprivate init(allInstances: [Storage]) { self.allInstances = allInstances }
+
+    /// The values that will be used to reconstitute `SourceFile`s.
+    ///
+    /// The ID serialized for a `SourceFile` is used as an index into `allInstances` to find the
+    /// corresponding `storage`.
+    fileprivate let allInstances: [Storage]
+  }
+
   public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
-    let url = try container.decode(URL.self)
-    try self.init(contentsOf: url)
+    let id = try container.decode(Int.self)
+    storage = decoder[state: AST.DecodingState.self].allInstances[id]
   }
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
-    try container.encode(url)
+
+    try modifying(&encoder[state: AST.EncodingState.self]) { state in
+      // provisional ID in case `storage` isn't found in `state`.
+      var id = state.allInstances.count
+
+      try modifying(&state.allInstances[ObjectIdentifier(storage)]) { v in
+        if let v1 = v {
+          id = v1.id  // found: revise the ID.
+        } else {
+          v = (id: id, storage: self.storage)  // not found: remember storage for later encoding.
+        }
+        try container.encode(id)
+      }
+    }
+
   }
 
 }
@@ -169,4 +224,68 @@ where S.Element == URL {
     }
   }
   return result
+}
+
+extension SourceFile {
+
+  /// The shared, immutable storage of a `SourceFile`.
+  ///
+  /// `unowned Storage` can be used safely anywhere, because every `Storage` instance is owned by a
+  /// threadsafe global dictionary, `Storage.allInstances,` and never deallocated.
+  public final class Storage: Codable, FactoryInitializable {
+
+    /// The URL of the source file.
+    fileprivate let url: URL
+
+    /// The contents of the source file.
+    fileprivate let text: String
+
+    /// The start position of each line.
+    ///
+    /// - Invariant: always starts with `contents.startIndex` and ends with `contents.endIndex`, even
+    ///   if there's no final newline.
+    fileprivate let lineStarts: [Index]
+
+    /// Creates an instance with the given properties.
+    private init(url: URL, text: String) {
+      self.url = url
+      self.text = text
+      self.lineStarts = text.lineBoundaries()
+    }
+
+    /// The owner of all instances of `Storage`.
+    private static var allInstances = SharedMutable<[URL: Storage]>([:])
+
+    /// Creates an alias to the instance with the given `url` if it exists, or creates a new
+    /// instance having the given `url` and the text resulting from `makeText()`.
+    fileprivate convenience init(_ url: URL, makeText: () throws -> String) rethrows {
+      self.init(
+        aliasing: try Self.allInstances.modify { (c: inout [URL: Storage]) -> Storage in
+          try modifying(&c[url]) { v in
+            let r = try v ?? Storage(url: url, text: makeText())
+            v = r
+            return r
+          }
+        })
+    }
+
+    /// The data that is encoded/decoded for each instance of `self`.
+    private struct Encoding: Codable {
+      let url: URL
+      let text: String
+    }
+
+    public required convenience init(from decoder: Decoder) throws {
+      let container = try decoder.singleValueContainer()
+      let e = try container.decode(Encoding.self)
+      self.init(e.url) { e.text }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+      try container.encode(Encoding(url: url, text: text))
+    }
+
+  }
+
 }

--- a/Sources/Utils/FactoryInitializable.swift
+++ b/Sources/Utils/FactoryInitializable.swift
@@ -1,0 +1,35 @@
+/// Classes whose initializers actually create derived classes
+public protocol FactoryInitializable {
+  /// The type of the least-derived class declared to be FactoryInitializable.
+  ///
+  /// - Warning: Do not define this in your FactoryInitializable type!
+  associatedtype FactoryBase: AnyObject, FactoryInitializable = Self
+  // This associatedtype is a trick that captures `Self` at the point where
+  // `FactoryInitializable` enters a class hierarchy; in other contexts, `Self`
+  // refers to the most-derived type.
+}
+
+extension FactoryInitializable where Self: AnyObject {
+  /// Optimally “creates” an instance that is just another reference to `me`.
+  ///
+  /// - Requires: `me is Self`.
+  ///
+  /// Taking `FactoryBase` as a parameter prevents, at compile-time, the
+  /// category of bugs where `me` is not derived from the least-derived ancestor
+  /// of `Self` conforming to `FactoryInitializable`.
+  ///
+  /// However, there are still ways `me` might not be derived from `Self`.  If
+  /// you have factory initializers at more than one level of your class
+  /// hierarchy and you can't control exactly what is passed here, use
+  /// `init(aliasing:)` instead.
+  public init(unsafelyAliasing me: FactoryBase) {
+    self = unsafeDowncast(me, to: Self.self)
+  }
+
+  /// Safely “creates” an instance that is just another reference to `me`.
+  ///
+  /// - Requires: `me is Self`.
+  public init(aliasing me: FactoryBase) {
+    self = me as! Self
+  }
+}

--- a/Sources/Utils/SharedMutable.swift
+++ b/Sources/Utils/SharedMutable.swift
@@ -1,0 +1,29 @@
+import Dispatch
+
+/// A threadsafe shared mutable wrapper for a `WrappedType` instance.
+public class SharedMutable<WrappedType> {
+  /// The synchronization mechanism that makes `self` threadsafe.
+  private let mutex = DispatchQueue(label: "org.val-lang.\(WrappedType.self)")
+
+  /// The (thread-unsafe) stored instance.
+  private var storage: WrappedType
+
+  /// Creates an instance storing `wrapped`.
+  public init(_ wrapped: WrappedType) {
+    self.storage = wrapped
+  }
+
+  /// Thread-safely accesses the wrapped instance.
+  public var wrapped: WrappedType {
+    get { mutex.sync { storage } }
+    set { mutex.sync { storage = newValue } }
+  }
+
+  /// Returns the result of thread-safely applying `modification` to the wrapped instance.
+  public func modify<R>(applying modification: (inout WrappedType) throws -> R) rethrows -> R {
+    try mutex.sync {
+      let r = try modification(&storage)
+      return r
+    }
+  }
+}

--- a/Sources/Utils/StatefulCoder.swift
+++ b/Sources/Utils/StatefulCoder.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+/// A key used to access the coding state of encoders/decoders.
+private let stateKey = CodingUserInfoKey(rawValue: UUID().uuidString)!
+
+/// An object that flattens values into—or reconstitutes values from—a serialized `Encoding`,
+/// maintaing state across the (de)serialization of individual parts.
+///
+/// - Note: this protocol matches Foundation's `XXXEncoder`/`XXXDecoder` types,
+///   which—confusingly—do not themselves conform to the `Encoder`/`Decoder` protocols.
+public protocol StatefulCoder {
+
+  /// The complete result of serializing anything with `self`.
+  associatedtype Encoding = Data
+
+  /// The storage vehicle for state.
+  var userInfo: [CodingUserInfoKey: Any] { get set }
+
+}
+
+extension StatefulCoder {
+
+  /// Injects initialState into `self` for use as mutable storage during encoding/decoding.
+  public mutating func setState<T>(_ initialState: T) {
+    userInfo[stateKey] = Box(initialState)
+  }
+
+}
+
+/// An object that flattens values into a serialized `Encoding`, maintaing state across the
+/// serialization of individual parts.
+///
+/// - Note: this protocol matches Foundation's `XXXEncoder` types, which—confusingly—do not
+///   themselves conform to the `Encoder` protocol.
+public protocol StatefulEncoder: StatefulCoder {
+
+  /// Returns a serialized representation of `subject`.
+  func encode<T>(_ subject: T) throws -> Encoding where T: Encodable
+
+}
+
+extension StatefulEncoder {
+
+  /// Returns a serialized representation of `subject`, using `startState` as the initial encoding
+  /// state.
+  public mutating func encode<T, State>(_ value: T, startState: State) throws -> Encoding
+  where T: Encodable {
+    setState(startState)
+    defer { setState(0) }  // Discard state, just in case `self` persists.
+    return try encode(value)
+  }
+
+}
+
+/// An object that reconstitutes values from a serialized `Encoding`, maintaing state across the
+/// deserialization of individual parts.
+///
+/// - Note: this protocol matches Foundation's `XXXEncoder` types, which—confusingly—do not
+///   themselves conform to the `Encoder` protocol.
+public protocol StatefulDecoder: StatefulCoder {
+
+  /// Returns the `T` value that was serialized into `archive`.
+  func decode<T>(_ type: T.Type, from archive: Encoding) throws -> T where T: Decodable
+
+}
+
+extension StatefulDecoder {
+
+  /// Returns the `T` value that was serialized into `archive`, using `startState` as the initial
+  /// decoding state.
+  public mutating func decode<T, State>(_ type: T.Type, from encodedT: Encoding, startState: State)
+    throws -> T where T: Decodable
+  {
+    setState(startState)
+    defer { setState(0) }  // Discard state, just in case `self` persists.
+    return try decode(type, from: encodedT)
+  }
+
+}
+
+extension Encoder {
+
+  /// Accesses the previously-injected encoding state of type `T`.
+  ///
+  /// - Precondition: `self` is the product of some `StatefulEncoder` `e` on which `e.setState(s)`
+  ///   has been called, where `s` has type `T`.
+  public subscript<T>(state state: T.Type) -> T {
+    get { (userInfo[stateKey]! as! Box<T>).wrapped }
+    nonmutating set { (userInfo[stateKey]! as! Box<T>).wrapped = newValue }
+    nonmutating _modify { yield &(userInfo[stateKey]! as! Box<T>).wrapped }
+  }
+
+}
+
+extension Decoder {
+
+  /// Accesses the previously-injected decoding state of type `T`.
+  ///
+  /// - Precondition: `self` is the product of some `StatefulDecoder` `e` on which `e.setState(s)`
+  ///   has been called, where `s` has type `T`.
+  public subscript<T>(state state: T.Type) -> T {
+    get { (userInfo[stateKey]! as! Box<T>).wrapped }
+    nonmutating set { (userInfo[stateKey]! as! Box<T>).wrapped = newValue }
+    nonmutating _modify { yield &(userInfo[stateKey]! as! Box<T>).wrapped }
+  }
+
+}
+
+// Conformances for known types.
+
+extension JSONEncoder: StatefulEncoder {}
+extension JSONDecoder: StatefulDecoder {}
+extension PropertyListEncoder: StatefulEncoder {}
+extension PropertyListDecoder: StatefulDecoder {}
+
+/// A (thread-unsafe) shared mutable wrapper for a `WrappedType` instance.
+///
+/// An immutable `Box` reference is stored in encoders/decoders as a hack to create mutability where
+/// it is otherwise unavailable.
+private final class Box<WrappedType> {
+
+  /// Creates an instance containing `contents`
+  init(_ contents: WrappedType) { self.wrapped = contents }
+
+  /// The wrapped instance.
+  var wrapped: WrappedType
+
+}

--- a/Sources/ValCommand/ValCommand.swift
+++ b/Sources/ValCommand/ValCommand.swift
@@ -135,7 +135,7 @@ public struct ValCommand: ParsableCommand {
     // Handle `--emit raw-ast`.
     if outputType == .rawAST {
       let url = outputURL ?? URL(fileURLWithPath: "ast.json")
-      let encoder = JSONEncoder()
+      let encoder = JSONEncoder().forAST
       try encoder.encode(ast).write(to: url, options: .atomic)
       return finalize(logging: diagnostics, to: &errorLog)
     }

--- a/Tests/ValTests/ASTTests.swift
+++ b/Tests/ValTests/ASTTests.swift
@@ -58,11 +58,11 @@ final class ASTTests: XCTestCase {
     ast[module].addSourceFile(source)
 
     // Serialize the AST.
-    let encoder = JSONEncoder()
+    let encoder = JSONEncoder().forAST
     let serialized = try encoder.encode(ast)
 
     // Deserialize the AST.
-    let decoder = JSONDecoder()
+    let decoder = JSONDecoder().forAST
     let deserialized = try decoder.decode(AST.self, from: serialized)
 
     // Deserialized AST should containt a function `foo`.


### PR DESCRIPTION
`SourceFile` contents are now serialized separately from the AST, with the AST just recording an integer ID for each distinct source file.  The lifetime of contents are now maintained by a threadsafe global dictionary.
  
I apologize in advance for the fact that the constituent commits are not particularly meaningful.  I will try to reorganize if any reviewer wants me to; otherwise it should probably be squashed.
