### PR TITLE
Rename 'inScope:' to 'in:'

### DIFF
--- a/Sources/FrontEnd/TypeChecking/ConstraintSolver.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSolver.swift
@@ -127,7 +127,7 @@ struct ConstraintSolver {
       postpone(goal)
 
     case is ProductType, is TupleType:
-      let conformedTraits = checker.conformedTraits(of: goal.subject, inScope: scope) ?? []
+      let conformedTraits = checker.conformedTraits(of: goal.subject, in: scope) ?? []
       let nonConforming = goal.traits.subtracting(conformedTraits)
 
       if !nonConforming.isEmpty {
@@ -163,7 +163,7 @@ struct ConstraintSolver {
     if goal.subject.base is TypeVariable {
       postpone(goal)
     } else {
-      let conformedTraits = checker.conformedTraits(of: goal.subject, inScope: scope) ?? []
+      let conformedTraits = checker.conformedTraits(of: goal.subject, in: scope) ?? []
 
       if conformedTraits.contains(goal.literalTrait) {
         // Add a penalty if `L` isn't `D`.
@@ -426,7 +426,7 @@ struct ConstraintSolver {
 
     // Search for non-static members with the specified name.
     let allMatches = checker.lookup(
-      goal.memberName.stem, memberOf: goal.subject, inScope: scope)
+      goal.memberName.stem, memberOf: goal.subject, in: scope)
     let nonStaticMatches = allMatches.filter({ decl in
       checker.program.isNonStaticMember(decl)
     })

--- a/Sources/FrontEnd/TypeChecking/GenericEnvironment.swift
+++ b/Sources/FrontEnd/TypeChecking/GenericEnvironment.swift
@@ -42,7 +42,7 @@ struct GenericEnvironment {
       case let conformance as ConformanceConstraint:
         var allTraits: Set<TraitType> = []
         for trait in conformance.traits {
-          guard let bases = checker.conformedTraits(of: ^trait, inScope: scope)
+          guard let bases = checker.conformedTraits(of: ^trait, in: scope)
           else { return nil }
           allTraits.formUnion(bases)
         }


### PR DESCRIPTION
See #284 