### PR TITLE
Visit the match expression patterns during type inference

### DIFF
--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1643,7 +1643,7 @@ public struct TypeChecker {
 
     // Apply the solution.
     for (id, type) in facts.inferredTypes.storage {
-      exprTypes[id] = solution.typeAssumptions.reify(type, withVariables: .keep)
+      exprTypes[id] = solution.typeAssumptions.reify(type)
     }
     for (name, ref) in solution.bindingAssumptions {
       referredDecls[name] = ref

--- a/Tests/ValTests/TestCases/TypeChecking/MatchExpr.val
+++ b/Tests/ValTests/TestCases/TypeChecking/MatchExpr.val
@@ -1,0 +1,10 @@
+//! expect-success
+
+public fun main() {
+  let a = 42 as Any
+
+  match a {
+    let x: Double {}
+    let y {}
+  }
+}


### PR DESCRIPTION
This PR implements the first step of inferring the type of match expression: visiting the patterns of the match cases and make sure they correspond to the type of the subject.

The changes in the PR do not cover constraint generation for the body of each individual case yet, which should be submitted as a separate patch.