### PR TITLE
Stop translating Val `Int` into C++ `int`.

### DIFF
--- a/Sources/CodeGen/CXX/CXXTranspiler.swift
+++ b/Sources/CodeGen/CXX/CXXTranspiler.swift
@@ -558,12 +558,7 @@ public struct CXXTranspiler {
       return CXXTypeExpr(isReturnType ? "void" : "std::monostate")
 
     case let type as ProductType:
-      // TODO: we should translate this to an "int" struct
-      if type == wholeValProgram.ast.coreType(named: "Int") {
-        return CXXTypeExpr("int")
-      } else {
-        return CXXTypeExpr(type.name.value)
-      }
+      return CXXTypeExpr(type.name.value)
 
     case let type as ParameterType:
       // TODO: convention

--- a/Tests/ValTests/TestCases/CXX/Expr/InfixOperators.val
+++ b/Tests/ValTests/TestCases/CXX/Expr/InfixOperators.val
@@ -1,7 +1,7 @@
 /*! cpp
 void test() {
-  int a = 5;
-  int b = 7;
+  Int a = 5;
+  Int b = 7;
   a = a + b;
   a = a - b;
   a = a + b * 11;

--- a/Tests/ValTests/TestCases/CXX/Expr/PrefixOperators.val
+++ b/Tests/ValTests/TestCases/CXX/Expr/PrefixOperators.val
@@ -1,6 +1,6 @@
 /*! cpp
 void test() {
-  int a = 5;
+  Int a = 5;
   a = +a;
   a = -a;
 }

--- a/Tests/ValTests/TestCases/CXX/FactorialExample.val
+++ b/Tests/ValTests/TestCases/CXX/FactorialExample.val
@@ -1,9 +1,9 @@
 /*! h
-    int factorial(int n);
+    Int factorial(Int n);
     int main();
  */
 /*! cpp
-      int factorial(int n)  {
+      Int factorial(Int n)  {
         return n < 2 ? 1 : n * factorial(n - 1);
       }
  */

--- a/Tests/ValTests/TestCases/CXX/FunIntParam.val
+++ b/Tests/ValTests/TestCases/CXX/FunIntParam.val
@@ -1,5 +1,5 @@
 /*! cpp
-    void myFun(int x)
+    void myFun(Int x)
  */
 public fun myFun(_ x: Int) {
 }

--- a/Tests/ValTests/TestCases/CXX/FunRetInt.val
+++ b/Tests/ValTests/TestCases/CXX/FunRetInt.val
@@ -1,5 +1,5 @@
 /*! cpp
-    int myFun()
+    Int myFun()
  */
 public fun myFun() -> Int {
     return 0;

--- a/Tests/ValTests/TestCases/CXX/SimpleType.val
+++ b/Tests/ValTests/TestCases/CXX/SimpleType.val
@@ -4,8 +4,8 @@
 /*! cpp
     class Point {
     public:
-    int x;
-    int y;
+    Int x;
+    Int y;
     // constructor
     };
  */

--- a/Tests/ValTests/TestCases/CXX/Stmt/AssignStmt.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/AssignStmt.val
@@ -1,6 +1,6 @@
 /*! cpp
     void test() {
-    int x = 5;
+    Int x = 5;
     x = 7;
     }
  */

--- a/Tests/ValTests/TestCases/CXX/Stmt/ContinueAndBreak.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/ContinueAndBreak.val
@@ -1,6 +1,6 @@
 /*! cpp
-    int lengthForCollatzSequence(int n) {
-    int count = 0;
+    Int lengthForCollatzSequence(Int n) {
+    Int count = 0;
     while ( true ) {
     if ( atTheEndOfCollatzSequence(n) ) {
     break;

--- a/Tests/ValTests/TestCases/CXX/Stmt/ExpressionFunction.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/ExpressionFunction.val
@@ -1,8 +1,8 @@
 /*! h
-    int returns_value();
+    Int returns_value();
  */
 /*! cpp
-    int returns_value() {
+    Int returns_value() {
     return 13;
     }
  */

--- a/Tests/ValTests/TestCases/CXX/Stmt/ReturnExpr.val
+++ b/Tests/ValTests/TestCases/CXX/Stmt/ReturnExpr.val
@@ -1,8 +1,8 @@
 /*! h
-    int returns_value();
+    Int returns_value();
  */
 /*! cpp
-    int returns_value() {
+    Int returns_value() {
     return 13;
     }
  */


### PR DESCRIPTION
The code will blindly transform all `Int` types into `Int`, even there is no C++ definition for `Int.
This will later be addressed when we translate Val standard library to C++.