### PR TITLE
Replace 'Builtin.terminate' by 'abort'

### DIFF
--- a/Library/Core/Process.val
+++ b/Library/Core/Process.val
@@ -1,4 +1,8 @@
 /// Terminates the program abnormally.
+@_lowered_name("abort")
+public fun abort() -> Never
+
+/// Terminates the program abnormally.
 public fun fatal_error() -> Never {
-  Builtin.terminate()
+  abort()
 }

--- a/Sources/Core/Types/BuiltinSymbols.swift
+++ b/Sources/Core/Types/BuiltinSymbols.swift
@@ -2,10 +2,6 @@
 // swift-format-ignore: AlwaysUseLowerCamelCase
 public enum BuiltinSymbols {
 
-  /// Terminates the program abnormally.
-  public static let terminate = LambdaType(
-    to: .never)
-
   /// 1-bit integer copy.
   public static let i1_copy = LambdaType(
     from: (.let, .i(1)),
@@ -64,8 +60,6 @@ public enum BuiltinSymbols {
   /// Returns the type of the built-in function with the given name.
   public static subscript(_ name: String) -> LambdaType? {
     switch name {
-    case "terminate": return Self.terminate
-
     case "i1_copy": return Self.i1_copy
 
     case "i32_copy": return Self.i32_copy


### PR DESCRIPTION
LLVM doesn't have a `terminate` instruction, so it's likely we'll have to import a C or C++ function to implement that feature. The current PR replaces the `Builtin.terminate` by an abort function exposed through a FFI.