### PR TITLE
Create an abstraction representing built-in functions

### DIFF
--- a/Library/Core/Double.val
+++ b/Library/Core/Double.val
@@ -1,7 +1,7 @@
 /// A double-precision, floating-point value.
 public type Double {
 
-  var value: Builtin.f64
+  var value: Builtin.double
 
 }
 
@@ -10,7 +10,7 @@ public conformance Double: ExpressibleByIntegerLiteral {}
 public conformance Double: Copyable {
 
   public fun copy() -> Self {
-    Double(value: Builtin.f64_copy(value))
+    Double(value: Builtin.double_copy(value))
   }
 
 }

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -123,11 +123,11 @@ public struct BuiltinFunction: Equatable {
 
 }
 
-/// A function that parses and instance of `T` by consuming elements from a stream of substrings
-/// or returns `nil` if such instance cannot be parsed.
+/// A function that parses an instance of `T` by consuming a prefix of `tokens`, or returns `nil` 
+/// if such instance cannot be parsed.
 ///
-/// - Note: The stream may have been modified even if the function returns `nil`.
-private typealias Parser<T> = (inout ArraySlice<Substring>) -> T?
+/// - Note: a prefix of `tokens` may have been consumed even if the function returns `nil`.
+private typealias Parser<T> = (_ tokens: inout ArraySlice<Substring>) -> T?
 
 /// Returns a parser that consumes an element equal to `s` and returns `.some(s)`, or returns
 /// `.some(nil)` if such an element can't be consumed.

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -18,7 +18,7 @@ import Utils
 ///     icmp ne i32 -> Builtin.icmp_ne_i32
 ///     fmul fast double -> Builtin.fmul_fast_double
 ///
-/// An exception is made for converting and instructions: the keyword `to` following the first
+/// An exception is made for conversion instructions: the keyword `to` following the first
 /// argument of the instruction and preceeding the resulting type is omitted from the  built-in
 /// function name. For example:
 ///

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -110,6 +110,12 @@ public struct BuiltinFunction: Equatable {
         named: stem, [],
         typed: LambdaType(^s, to: ^d))
 
+    case "zeroinitializer":
+      guard let t = builtinType(from: &tokens) else { return nil }
+      self.init(
+        named: stem, [],
+        typed: LambdaType(to: ^t))
+
     default:
       return nil
     }

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -12,7 +12,7 @@ import Utils
 /// LLVM's `add i64` instruction.
 ///
 /// The name of a built-in function is given by the name of its corresponding LLVM instruction
-/// concatenated with all its generic parameters, separated by an underscore. For example:
+/// concatenated with all its generic parameters, separated by underscores. For example:
 ///
 ///     add i64 -> Builtin.add_i64
 ///     icmp ne i32 -> Builtin.icmp_ne_i32

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -57,7 +57,7 @@ public struct BuiltinFunction: Equatable {
     guard let stem = tokens.popFirst().map(String.init(_:)) else { return nil }
     switch stem {
     case "copy":
-      guard let t = builtinType(from: &tokens) else { return nil }
+      guard let t = builtinType(&tokens) else { return nil }
       self.init(
         named: stem, [],
         typed: LambdaType(^t, to: ^t))
@@ -75,7 +75,7 @@ public struct BuiltinFunction: Equatable {
         typed: LambdaType(^t, ^t, to: ^t))
 
     case "urem", "srem", "and", "or", "xor":
-      guard let t = builtinType(from: &tokens) else { return nil }
+      guard let t = builtinType(&tokens) else { return nil }
       self.init(
         named: stem, [],
         typed: LambdaType(^t, ^t, to: ^t))
@@ -111,7 +111,7 @@ public struct BuiltinFunction: Equatable {
         typed: LambdaType(^s, to: ^d))
 
     case "zeroinitializer":
-      guard let t = builtinType(from: &tokens) else { return nil }
+      guard let t = builtinType(&tokens) else { return nil }
       self.init(
         named: stem, [],
         typed: LambdaType(to: ^t))
@@ -158,12 +158,12 @@ private func one(of choices: [String]) -> Parser<String> {
 }
 
 /// Returns a built-in type parsed from `stream`.
-private func builtinType(from stream: inout ArraySlice<Substring>) -> BuiltinType? {
+private func builtinType(_ stream: inout ArraySlice<Substring>) -> BuiltinType? {
   stream.popFirst().flatMap(BuiltinType.init(_:))
 }
 
 /// Returns the longest sequence of floating-point math flags that can be parsed from `stream`.
-private func mathFlags(from stream: inout ArraySlice<Substring>) -> [String] {
+private func mathFlags(_ stream: inout ArraySlice<Substring>) -> [String] {
   var result: [String] = []
   while let x = stream.first {
     guard

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -51,7 +51,7 @@ public struct BuiltinFunction: Equatable {
   /// Creates an instance by parsing it from `s` or returns `nil` if `s` isn't a valid built-in
   /// function name.
   public init?(parsing s: String) {
-    var tokens = s.split(separator: "_").suffix(from: 0)
+    var tokens = s.split(separator: "_")[...]
 
     /// The first token is the stem identifier.
     guard let stem = tokens.popFirst().flatMap(String.init(_:)) else { return nil }

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -53,67 +53,67 @@ public struct BuiltinFunction: Equatable {
   public init?(parsing s: String) {
     var tokens = s.split(separator: "_")[...]
 
-    // The first token is the stem identifier.
-    guard let stem = tokens.popFirst().map(String.init(_:)) else { return nil }
-    switch stem {
+    // The first token is the LLVM instruction name.
+    guard let instruction = tokens.popFirst().map(String.init(_:)) else { return nil }
+    switch instruction {
     case "copy":
       guard let t = builtinType(&tokens) else { return nil }
       self.init(
-        named: stem, [],
+        named: instruction, [],
         typed: LambdaType(^t, to: ^t))
 
     case "add", "sub", "mul", "shl":
       guard let (p, t) = integerArithmeticParameters(&tokens) else { return nil }
       self.init(
-        named: stem, [p.0, p.1].compactMap({ $0 }),
+        named: instruction, [p.0, p.1].compactMap({ $0 }),
         typed: LambdaType(^t, ^t, to: ^t))
 
     case "udiv", "sdiv", "lshr", "ashr":
       guard let (p, t) = (maybe("exact") ++ builtinType)(&tokens) else { return nil }
       self.init(
-        named: stem, p.map({ [$0] }) ?? [],
+        named: instruction, p.map({ [$0] }) ?? [],
         typed: LambdaType(^t, ^t, to: ^t))
 
     case "urem", "srem", "and", "or", "xor":
       guard let t = builtinType(&tokens) else { return nil }
       self.init(
-        named: stem, [],
+        named: instruction, [],
         typed: LambdaType(^t, ^t, to: ^t))
 
     case "icmp":
       guard let (p, t) = integerComparisonParameters(&tokens) else { return nil }
       self.init(
-        named: stem, [p],
+        named: instruction, [p],
         typed: LambdaType(^t, ^t, to: .builtin(.i(1))))
 
     case "trunc", "zext", "sext", "uitofp", "sitofp":
       guard let (s, d) = (builtinType ++ builtinType)(&tokens) else { return nil }
       self.init(
-        named: stem, [],
+        named: instruction, [],
         typed: LambdaType(^s, to: ^d))
 
     case "fadd", "fsub", "fmul", "fdiv", "frem":
       guard let (p, t) = floatingPointArithmeticParameters(&tokens) else { return nil }
       self.init(
-        named: stem, p,
+        named: instruction, p,
         typed: LambdaType(^t, ^t, to: ^t))
 
     case "fcmp":
       guard let (p, t) = floatingPointComparisonParameters(&tokens) else { return nil }
       self.init(
-        named: stem, p.0 + [p.1],
+        named: instruction, p.0 + [p.1],
         typed: LambdaType(^t, ^t, to: .builtin(.i(1))))
 
     case "fptrunc", "fpext", "fptoui", "fptosi":
       guard let (s, d) = (builtinType ++ builtinType)(&tokens) else { return nil }
       self.init(
-        named: stem, [],
+        named: instruction, [],
         typed: LambdaType(^s, to: ^d))
 
     case "zeroinitializer":
       guard let t = builtinType(&tokens) else { return nil }
       self.init(
-        named: stem, [],
+        named: instruction, [],
         typed: LambdaType(to: ^t))
 
     default:

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -53,7 +53,7 @@ public struct BuiltinFunction: Equatable {
   public init?(parsing s: String) {
     var tokens = s.split(separator: "_")[...]
 
-    /// The first token is the stem identifier.
+    // The first token is the stem identifier.
     guard let stem = tokens.popFirst().map(String.init(_:)) else { return nil }
     switch stem {
     case "copy":

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -54,7 +54,7 @@ public struct BuiltinFunction: Equatable {
     var tokens = s.split(separator: "_")[...]
 
     /// The first token is the stem identifier.
-    guard let stem = tokens.popFirst().flatMap(String.init(_:)) else { return nil }
+    guard let stem = tokens.popFirst().map(String.init(_:)) else { return nil }
     switch stem {
     case "copy":
       guard let t = builtinType(from: &tokens) else { return nil }

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -24,7 +24,7 @@ import Utils
 ///
 ///     trunc i64 ... to i32 -> Builtin.trunc_i64_i32
 ///
-/// Supported operations include all arithmetic and comparison instructions on built-in integral
+/// Supported operations include all LLVM arithmetic and comparison instructions on built-in integral
 /// and floating-point numbers as well as conversions from and to these types.
 public struct BuiltinFunction: Equatable {
 

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -18,9 +18,8 @@ import Utils
 ///     icmp ne i32 -> Builtin.icmp_ne_i32
 ///     fmul fast double -> Builtin.fmul_fast_double
 ///
-/// An exception is made for conversion instructions: the keyword `to` following the first
-/// argument of the instruction and preceeding the resulting type is omitted from the  built-in
-/// function name. For example:
+/// An exception is made for LLVM conversion instructions: we omit the keyword `to` that appears
+/// between the first argument and result type. For example:
 ///
 ///     trunc i64 ... to i32 -> Builtin.trunc_i64_i32
 ///

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -28,8 +28,8 @@ import Utils
 /// and floating-point numbers as well as conversions from and to these types.
 public struct BuiltinFunction: Equatable {
 
-  /// The stem identifier of the function.
-  public let baseName: String
+  /// The name of the notional generic function of which `self` is an instance.
+  public let llvmInstruction: String
 
   /// The generic parameters of the function.
   public let genericParameters: [String]
@@ -38,8 +38,8 @@ public struct BuiltinFunction: Equatable {
   public let type: LambdaType
 
   /// Creates an instance with the given properties.
-  private init(baseName: String, genericParameters: [String], type: LambdaType) {
-    self.baseName = baseName
+  private init(llvmInstruction: String, genericParameters: [String], type: LambdaType) {
+    self.llvmInstruction = llvmInstruction
     self.genericParameters = genericParameters
     self.type = type
   }
@@ -47,7 +47,7 @@ public struct BuiltinFunction: Equatable {
   /// Creates an instance by parsing it from `s` or returns `nil` if `s` isn't a valid built-in
   /// function name.
   public init?(parsing s: String) {
-    let make = Self.init(baseName:genericParameters:type:)
+    let make = Self.init(llvmInstruction:genericParameters:type:)
     var tokens = s.split(separator: "_")[...]
 
     // The first token is the LLVM instruction name.

--- a/Sources/Core/BuiltinFunction.swift
+++ b/Sources/Core/BuiltinFunction.swift
@@ -1,0 +1,191 @@
+import Utils
+
+/// A function representing an IR instruction in Val source code.
+///
+/// Built-in functions implement basis operations on built-in types, such as `Builtin.i64`, with
+/// the same semantics as their corresponding LLVM instruction.
+///
+/// LLVM instructions are "generic" in the sense that they can typically be parameterized by types
+/// and flags. For example, `add i32` and `add i64` represent the integer addition parameterized
+/// for 32-bit and 64-bit integer values, respectively. In Val, this parameterization is encoded
+/// directly into the name of a built-in function. For example, `Builtin.add_i64` corresponds to
+/// LLVM's `add i64` instruction.
+///
+/// The name of a built-in function is given by the name of its corresponding LLVM instruction
+/// concatenated with all its generic parameters, separated by an underscore. For example:
+///
+///     add i64 -> Builtin.add_i64
+///     icmp ne i32 -> Builtin.icmp_ne_i32
+///     fmul fast double -> Builtin.fmul_fast_double
+///
+/// An exception is made for converting and instructions: the keyword `to` following the first
+/// argument of the instruction and preceeding the resulting type is omitted from the  built-in
+/// function name. For example:
+///
+///     trunc i64 ... to i32 -> Builtin.trunc_i64_i32
+///
+/// Supported operations include all arithmetic and comparison instructions on built-in integral
+/// and floating-point numbers as well as conversions from and to these types.
+public struct BuiltinFunction: Equatable {
+
+  /// The stem identifier of the function.
+  public let baseName: String
+
+  /// The generic parameters of the function.
+  public let genericParameters: [String]
+
+  /// The type of the function.
+  public let type: LambdaType
+
+  /// Creates an instance with the given properties.
+  public init(
+    named baseName: String,
+    _ genericParameters: [String],
+    typed type: LambdaType
+  ) {
+    self.baseName = baseName
+    self.genericParameters = genericParameters
+    self.type = type
+  }
+
+  /// Creates an instance by parsing it from `s` or returns `nil` if `s` isn't a valid built-in
+  /// function name.
+  public init?(parsing s: String) {
+    var tokens = s.split(separator: "_").suffix(from: 0)
+
+    /// The first token is the stem identifier.
+    guard let stem = tokens.popFirst().flatMap(String.init(_:)) else { return nil }
+    switch stem {
+    case "copy":
+      guard let t = builtinType(from: &tokens) else { return nil }
+      self.init(
+        named: stem, [],
+        typed: LambdaType(^t, to: ^t))
+
+    case "add", "sub", "mul", "shl":
+      guard let (p, t) = integerArithmeticParameters(&tokens) else { return nil }
+      self.init(
+        named: stem, [p.0, p.1].compactMap({ $0 }),
+        typed: LambdaType(^t, ^t, to: ^t))
+
+    case "udiv", "sdiv", "lshr", "ashr":
+      guard let (p, t) = (maybe("exact") ++ builtinType)(&tokens) else { return nil }
+      self.init(
+        named: stem, p.map({ [$0] }) ?? [],
+        typed: LambdaType(^t, ^t, to: ^t))
+
+    case "urem", "srem", "and", "or", "xor":
+      guard let t = builtinType(from: &tokens) else { return nil }
+      self.init(
+        named: stem, [],
+        typed: LambdaType(^t, ^t, to: ^t))
+
+    case "icmp":
+      guard let (p, t) = integerComparisonParameters(&tokens) else { return nil }
+      self.init(
+        named: stem, [p],
+        typed: LambdaType(^t, ^t, to: .builtin(.i(1))))
+
+    case "trunc", "zext", "sext", "uitofp", "sitofp":
+      guard let (s, d) = (builtinType ++ builtinType)(&tokens) else { return nil }
+      self.init(
+        named: stem, [],
+        typed: LambdaType(^s, to: ^d))
+
+    case "fadd", "fsub", "fmul", "fdiv", "frem":
+      guard let (p, t) = floatingPointArithmeticParameters(&tokens) else { return nil }
+      self.init(
+        named: stem, p,
+        typed: LambdaType(^t, ^t, to: ^t))
+
+    case "fcmp":
+      guard let (p, t) = floatingPointComparisonParameters(&tokens) else { return nil }
+      self.init(
+        named: stem, p.0 + [p.1],
+        typed: LambdaType(^t, ^t, to: .builtin(.i(1))))
+
+    case "fptrunc", "fpext", "fptoui", "fptosi":
+      guard let (s, d) = (builtinType ++ builtinType)(&tokens) else { return nil }
+      self.init(
+        named: stem, [],
+        typed: LambdaType(^s, to: ^d))
+
+    default:
+      return nil
+    }
+  }
+
+}
+
+/// A function that parses and instance of `T` by consuming elements from a stream of substrings
+/// or returns `nil` if such instance cannot be parsed.
+///
+/// - Note: The stream may have been modified even if the function returns `nil`.
+private typealias Parser<T> = (inout ArraySlice<Substring>) -> T?
+
+/// Returns a parser that consumes an element equal to `s` and returns `.some(s)`, or returns
+/// `.some(nil)` if such an element can't be consumed.
+private func maybe(_ s: String) -> Parser<String?> {
+  { (stream: inout ArraySlice<Substring>) -> String?? in
+    if let t = stream.first, t == s {
+      stream.removeFirst()
+      return .some(s)
+    } else {
+      return .some(nil)
+    }
+  }
+}
+
+/// Returns a parser that returns the result of applying `a` and then `b` or `nil` if either `a`
+/// or `b` returns `nil`.
+private func ++ <A, B>(_ a: @escaping Parser<A>, _ b: @escaping Parser<B>) -> Parser<(A, B)> {
+  { (stream: inout ArraySlice<Substring>) -> (A, B)? in
+    a(&stream).flatMap({ (x) in b(&stream).map({ (x, $0) }) })
+  }
+}
+
+/// Returns a parser that returns an elements in `choices` if an equal value can be consumed.
+private func one(of choices: [String]) -> Parser<String> {
+  { (stream: inout ArraySlice<Substring>) -> String? in
+    stream.popFirst().flatMap({ (x) in choices.first(where: { $0 == x }) })
+  }
+}
+
+/// Returns a built-in type parsed from `stream`.
+private func builtinType(from stream: inout ArraySlice<Substring>) -> BuiltinType? {
+  stream.popFirst().flatMap(BuiltinType.init(_:))
+}
+
+/// Returns the longest sequence of floating-point math flags that can be parsed from `stream`.
+private func mathFlags(from stream: inout ArraySlice<Substring>) -> [String] {
+  var result: [String] = []
+  while let x = stream.first {
+    guard
+      let y = ["afn", "arcp", "contract", "fast", "ninf", "nnan", "nsz", "reassoc"]
+        .first(where: { $0 == x })
+    else { break }
+    stream.removeFirst()
+    result.append(y)
+  }
+  return result
+}
+
+/// Parses the generic parameters of an integer arithmetic function.
+private let integerArithmeticParameters = maybe("nuw") ++ maybe("nsw") ++ builtinType
+
+/// Parses the generic parameters of `icmp`.
+private let integerComparisonParameters =
+  one(of: ["eq", "ne", "ugt", "uge", "ult", "ule", "sgt", "sge", "slt", "sle"])
+  ++ builtinType
+
+/// Parses the generic parameters of an floating-point arithmetic function.
+private let floatingPointArithmeticParameters = mathFlags ++ builtinType
+
+/// Parses the generic parameters of `fcmp`.
+private let floatingPointComparisonParameters =
+  mathFlags
+  ++ one(of: [
+    "oeq", "ogt", "oge", "olt", "ole", "one", "ord", "ueq", "ugt", "uge", "ult", "ule", "une",
+    "uno", "true", "false",
+  ])
+  ++ builtinType

--- a/Sources/Core/Types/BuiltinSymbols.swift
+++ b/Sources/Core/Types/BuiltinSymbols.swift
@@ -53,9 +53,9 @@ public enum BuiltinSymbols {
     to: .void)
 
   // Double-precision floating-point copy.
-  public static let f64_copy = LambdaType(
-    from: (.let, .f64),
-    to: .builtin(.f64))
+  public static let double_copy = LambdaType(
+    from: (.let, .double),
+    to: .builtin(.double))
 
   /// Returns the type of the built-in function with the given name.
   public static subscript(_ name: String) -> LambdaType? {
@@ -73,7 +73,7 @@ public enum BuiltinSymbols {
     case "i64_trunc_to_i32": return Self.i64_trunc_to_i32
     case "i64_print": return Self.i64_print
 
-    case "f64_copy": return Self.f64_copy
+    case "double_copy": return Self.double_copy
 
     default:
       return nil

--- a/Sources/Core/Types/BuiltinType.swift
+++ b/Sources/Core/Types/BuiltinType.swift
@@ -7,8 +7,17 @@ public enum BuiltinType: TypeProtocol {
   /// and does not specify signedness.
   case i(Int)
 
+  /// A built-in 16-bit floating-point type (specifically, "binary16" in IEEE 754).
+  case half
+
+  /// A built-in 32-bit floating-point type (specifically, "binary32" in IEEE 754).
+  case float
+
   /// A built-in 64-bit floating-point type (specifically, "binary64" in IEEE 754).
   case double
+
+  /// A built-in 128-bit floating-point type (specifically, "binary128" in IEEE 754).
+  case fp128
 
   /// A built-in raw pointer pointer.
   case pointer
@@ -26,8 +35,14 @@ extension BuiltinType: CustomStringConvertible {
     switch self {
     case .i(let bitWidth):
       return "i\(bitWidth)"
+    case .half:
+      return "half"
+    case .float:
+      return "float"
     case .double:
       return "double"
+    case .fp128:
+      return "fp128"
     case .pointer:
       return "Pointer"
     case .module:
@@ -39,14 +54,20 @@ extension BuiltinType: CustomStringConvertible {
 
 extension BuiltinType: LosslessStringConvertible {
 
-  public init?(_ description: String) {
+  public init?<S: StringProtocol>(_ description: S) {
     switch description {
-    case "Builtin":
-      self = .module
+    case "half":
+      self = .half
+    case "float":
+      self = .float
     case "double":
       self = .double
+    case "fp128":
+      self = .fp128
     case "Pointer":
       self = .pointer
+    case "Builtin":
+      self = .module
 
     case _ where description.starts(with: "i"):
       if let bitWidth = Int(description.dropFirst()) {

--- a/Sources/Core/Types/BuiltinType.swift
+++ b/Sources/Core/Types/BuiltinType.swift
@@ -8,7 +8,7 @@ public enum BuiltinType: TypeProtocol {
   case i(Int)
 
   /// A built-in 64-bit floating-point type (specifically, "binary64" in IEEE 754).
-  case f64
+  case double
 
   /// A built-in raw pointer pointer.
   case pointer
@@ -26,8 +26,8 @@ extension BuiltinType: CustomStringConvertible {
     switch self {
     case .i(let bitWidth):
       return "i\(bitWidth)"
-    case .f64:
-      return "f64"
+    case .double:
+      return "double"
     case .pointer:
       return "Pointer"
     case .module:
@@ -43,8 +43,8 @@ extension BuiltinType: LosslessStringConvertible {
     switch description {
     case "Builtin":
       self = .module
-    case "f64":
-      self = .f64
+    case "double":
+      self = .double
     case "Pointer":
       self = .pointer
 

--- a/Sources/Core/Types/BuiltinType.swift
+++ b/Sources/Core/Types/BuiltinType.swift
@@ -19,8 +19,8 @@ public enum BuiltinType: TypeProtocol {
   /// A built-in 128-bit floating-point type (specifically, "binary128" in IEEE 754).
   case fp128
 
-  /// A built-in raw pointer pointer.
-  case pointer
+  /// A built-in opaque pointer.
+  case ptr
 
   /// The type of the built-in module.
   case module
@@ -43,8 +43,8 @@ extension BuiltinType: CustomStringConvertible {
       return "double"
     case .fp128:
       return "fp128"
-    case .pointer:
-      return "Pointer"
+    case .ptr:
+      return "ptr"
     case .module:
       return "Builtin"
     }
@@ -64,8 +64,8 @@ extension BuiltinType: LosslessStringConvertible {
       self = .double
     case "fp128":
       self = .fp128
-    case "Pointer":
-      self = .pointer
+    case "ptr":
+      self = .ptr
     case "Builtin":
       self = .module
 

--- a/Sources/Core/Types/LambdaType.swift
+++ b/Sources/Core/Types/LambdaType.swift
@@ -46,6 +46,13 @@ public struct LambdaType: TypeProtocol, CallableType {
     flags = fs
   }
 
+  /// Creates the type of a function accepting `inputs` as `let` parameters and returning `output`.
+  public init(_ inputs: AnyType..., to output: AnyType) {
+    self.init(
+      inputs: inputs.map({ (t) in .init(type: ^ParameterType(convention: .let, bareType: t)) }),
+      output: ^output)
+  }
+
   /// Creates the type of the `let` implementation of `method`; fails if `method` doesn't have a
   /// let capability.
   public init?(letImplOf method: MethodType) {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -218,7 +218,7 @@ extension TypeChecker {
       let lhsType = inferType(of: lhs, in: scope, expecting: nil, updating: &facts)
       facts.append(
         EqualityConstraint(
-          lhsType, .builtin(.pointer),
+          lhsType, .builtin(.ptr),
           because: ConstraintCause(.cast, at: syntax.site)))
     }
 

--- a/Sources/Utils/Operators.swift
+++ b/Sources/Utils/Operators.swift
@@ -1,3 +1,5 @@
+/// Concatenation
 infix operator ++ : AdditionPrecedence
 
+/// Type-erasure
 prefix operator ^

--- a/Sources/Utils/Operators.swift
+++ b/Sources/Utils/Operators.swift
@@ -1,1 +1,3 @@
+infix operator ++ : AdditionPrecedence
+
 prefix operator ^

--- a/Tests/ValTests/BuiltinFunctionTests.swift
+++ b/Tests/ValTests/BuiltinFunctionTests.swift
@@ -162,6 +162,14 @@ final class BuiltinFunctionTests: XCTestCase {
       createInstanceWithType: expectedType)
   }
 
+  func testZeroInitializer() throws {
+    let expectedType = LambdaType(to: .builtin(.i(64)))
+    try assertParse(
+      stems: ["zeroinitializer"],
+      parameterizedBy: [["i64"]],
+      createInstanceWithType: expectedType)
+  }
+
   /// For each element in `stems` and `parameters`, assert that parsing a built-in functions named
   /// after their concatenation creates an instance with the same stem and parameters, and whose
   /// type is `expectedType`.

--- a/Tests/ValTests/BuiltinFunctionTests.swift
+++ b/Tests/ValTests/BuiltinFunctionTests.swift
@@ -1,0 +1,191 @@
+import Core
+import Utils
+import XCTest
+
+final class BuiltinFunctionTests: XCTestCase {
+
+  func testInvalid() {
+    XCTAssertNil(BuiltinFunction(parsing: "add"))
+  }
+
+  func testIntegerArithmetic() throws {
+    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
+    try assertParse(
+      stems: ["add", "sub", "mul"],
+      parameterizedBy: [["i64"], ["nuw", "i64"], ["nsw", "i64"], ["nuw", "nsw", "i64"]],
+      createInstanceWithType: expectedType)
+  }
+
+  func testIntegerDivision() throws {
+    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
+    try assertParse(
+      stems: ["udiv", "sdiv"],
+      parameterizedBy: [["i64"], ["exact", "i64"]],
+      createInstanceWithType: expectedType)
+  }
+
+  func testIntegerShiftLeft() throws {
+    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
+    try assertParse(
+      stems: ["shl"],
+      parameterizedBy: [["i64"], ["nuw", "i64"], ["nsw", "i64"], ["nuw", "nsw", "i64"]],
+      createInstanceWithType: expectedType)
+  }
+
+  func testIntegerShiftRight() throws {
+    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
+    try assertParse(
+      stems: ["lshr", "ashr"],
+      parameterizedBy: [["i64"], ["exact", "i64"]],
+      createInstanceWithType: expectedType)
+  }
+
+  func testIntegerRemainder() throws {
+    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
+    try assertParse(
+      stems: ["urem", "srem"],
+      parameterizedBy: [["i64"]],
+      createInstanceWithType: expectedType)
+  }
+
+  func testIntegerLogic() throws {
+    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(64)))
+    try assertParse(
+      stems: ["and", "or", "xor"],
+      parameterizedBy: [["i64"]],
+      createInstanceWithType: expectedType)
+  }
+
+  func testIntegerComparison() throws {
+    let expectedType = LambdaType(.builtin(.i(64)), .builtin(.i(64)), to: .builtin(.i(1)))
+    try assertParse(
+      stems: ["icmp"],
+      parameterizedBy: [
+        ["eq", "i64"],
+        ["ne", "i64"],
+        ["ugt", "i64"],
+        ["uge", "i64"],
+        ["ult", "i64"],
+        ["ule", "i64"],
+        ["sgt", "i64"],
+        ["sge", "i64"],
+        ["slt", "i64"],
+        ["sle", "i64"]
+      ],
+      createInstanceWithType: expectedType)
+  }
+
+  func testIntegerTruncate() throws {
+    let expectedType = LambdaType(.builtin(.i(64)), to: .builtin(.i(32)))
+    try assertParse(
+      stems: ["trunc"],
+      parameterizedBy: [["i64", "i32"]],
+      createInstanceWithType: expectedType)
+  }
+
+  func testIntegerExtend() throws {
+    let expectedType = LambdaType(.builtin(.i(32)), to: .builtin(.i(64)))
+    try assertParse(
+      stems: ["zext", "sext"],
+      parameterizedBy: [["i32", "i64"]],
+      createInstanceWithType: expectedType)
+  }
+
+  func testIntegerToFloat() throws {
+    let expectedType = LambdaType(.builtin(.i(64)), to: .builtin(.double))
+    try assertParse(
+      stems: ["uitofp", "sitofp"],
+      parameterizedBy: [["i64", "double"]],
+      createInstanceWithType: expectedType)
+  }
+
+  func testFloatArithmetic() throws {
+    let expectedType = LambdaType(.builtin(.double), .builtin(.double), to: .builtin(.double))
+    try assertParse(
+      stems: ["fadd", "fsub", "fmul", "fdiv", "frem"],
+      parameterizedBy: [
+        ["double"],
+        ["fast", "double"],
+        ["ninf", "nnan", "double"]
+      ],
+      createInstanceWithType: expectedType)
+  }
+
+  func testFloatComparison() throws {
+    let expectedType = LambdaType(.builtin(.double), .builtin(.double), to: .builtin(.i(1)))
+    try assertParse(
+      stems: ["fcmp"],
+      parameterizedBy: [
+        ["oeq", "double"],
+        ["ogt", "double"],
+        ["oge", "double"],
+        ["olt", "double"],
+        ["ole", "double"],
+        ["one", "double"],
+        ["ord", "double"],
+        ["ueq", "double"],
+        ["ugt", "double"],
+        ["uge", "double"],
+        ["ult", "double"],
+        ["ule", "double"],
+        ["une", "double"],
+        ["uno", "double"],
+        ["true", "double"],
+        ["false", "double"],
+        ["fast", "false", "double"],
+        ["ninf", "nnan", "false", "double"]
+      ],
+      createInstanceWithType: expectedType)
+  }
+
+  func testFloatTruncate() throws {
+    let expectedType = LambdaType(.builtin(.double), to: .builtin(.float))
+    try assertParse(
+      stems: ["fptrunc"],
+      parameterizedBy: [["double", "float"]],
+      createInstanceWithType: expectedType)
+  }
+
+  func testFloatExtend() throws {
+    let expectedType = LambdaType(.builtin(.float), to: .builtin(.double))
+    try assertParse(
+      stems: ["fpext"],
+      parameterizedBy: [["float", "double"]],
+      createInstanceWithType: expectedType)
+  }
+
+  func testFloatToInteger() throws {
+    let expectedType = LambdaType(.builtin(.float), to: .builtin(.i(64)))
+    try assertParse(
+      stems: ["fptoui", "fptosi"],
+      parameterizedBy: [["float", "i64"]],
+      createInstanceWithType: expectedType)
+  }
+
+  /// For each element in `stems` and `parameters`, assert that parsing a built-in functions named
+  /// after their concatenation creates an instance with the same stem and parameters, and whose
+  /// type is `expectedType`.
+  private func assertParse(
+    stems: [String],
+    parameterizedBy parameters: [[String]],
+    createInstanceWithType expectedType: LambdaType,
+    file: StaticString = #file,
+    line: UInt = #line
+  ) throws {
+    for s in stems {
+      for p in parameters {
+        let f = try XCTUnwrap(
+          BuiltinFunction(parsing: "\(s)_\(list: p, joinedBy: "_")"),
+          file: file, line: line)
+
+        XCTAssertEqual(f.baseName, s, file: file, line: line)
+        XCTAssertEqual(f.type, expectedType, file: file, line: line)
+        XCTAssert(
+          zip(f.genericParameters, p).allSatisfy({ $0 == $1 }),
+          "\(f.genericParameters) is not equal to \(p)",
+          file: file, line: line)
+      }
+    }
+  }
+
+}

--- a/Tests/ValTests/BuiltinFunctionTests.swift
+++ b/Tests/ValTests/BuiltinFunctionTests.swift
@@ -186,7 +186,7 @@ final class BuiltinFunctionTests: XCTestCase {
           BuiltinFunction(parsing: "\(s)_\(list: p, joinedBy: "_")"),
           file: file, line: line)
 
-        XCTAssertEqual(f.baseName, s, file: file, line: line)
+        XCTAssertEqual(f.llvmInstruction, s, file: file, line: line)
         XCTAssertEqual(f.type, expectedType, file: file, line: line)
         XCTAssert(
           zip(f.genericParameters, p).allSatisfy({ $0 == $1 }),


### PR DESCRIPTION
This PR creates an abstraction to represent built-in functions in the compiler.
This abstraction is not used during type checking or lowering yet, to avoid bloating the size of the patch.