### PR TITLE
Fix handling of undefined initializers

### DIFF
--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -351,7 +351,8 @@ extension TypeChecker {
       // We're done if we couldn't find any initializer.
       if initCandidates.isEmpty {
         addDiagnostic(.error(undefinedName: initName.value, at: initName.site))
-        return facts.assignErrorType(to: syntax.callee)
+        _ = facts.assignErrorType(to: syntax.callee)
+        return facts.assignErrorType(to: subject)
       }
 
       if let pick = initCandidates.uniqueElement {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -350,7 +350,6 @@ extension TypeChecker {
 
       // We're done if we couldn't find any initializer.
       if initCandidates.isEmpty {
-        addDiagnostic(.error(undefinedName: initName.value, at: initName.site))
         _ = facts.assignErrorType(to: syntax.callee)
         return facts.assignErrorType(to: subject)
       }

--- a/Tests/ValTests/TestCases/TypeChecking/CallInit.val
+++ b/Tests/ValTests/TestCases/TypeChecking/CallInit.val
@@ -1,4 +1,4 @@
-//! expect-success
+//! expect-failure
 
 type A {
 
@@ -10,6 +10,12 @@ type A {
 
 }
 
+fun check<T>(_ x: T) {}
+
 public fun main() {
-  let _ = A(value: 42)
+  let x0 = A(x: 42)
+  check<A>(x0)
+
+  //! @+1 diagnostic type 'A' has no member 'init(self:y:)'
+  let x1 = A(y: 42)
 }


### PR DESCRIPTION
Compiler used to crash when inferring the type of a call to an undefined initializer.