### PR TITLE
Remve testcode

### DIFF
--- a/Sources/Core/SourceFile.swift
+++ b/Sources/Core/SourceFile.swift
@@ -33,6 +33,12 @@ public struct SourceFile {
     self.storage = storage
   }
 
+  /// Creates a source file with the specified contents and a unique random `url`.
+  public init(synthesizedText text: String) {
+    let storage = Storage(URL(string: "synthesized://\(UUID().uuidString)")!) { text }
+    self.storage = storage
+  }
+
   /// The name of the source file, sans path qualification or extension.
   public var baseName: String {
     url.deletingPathExtension().lastPathComponent
@@ -41,12 +47,6 @@ public struct SourceFile {
   /// A range covering the whole contents of this instance.
   public var wholeRange: SourceRange {
     range(text.startIndex ..< text.endIndex)
-  }
-
-  /// Creates a source file with the specified contents and a unique random `url`.
-  public init(synthesizedText text: String) {
-    let storage = Storage(URL(string: "synthesized://\(UUID().uuidString)")!) { text }
-    self.storage = storage
   }
 
   /// Returns the contents of the file in the specified range.

--- a/Sources/Core/SourceFile.swift
+++ b/Sources/Core/SourceFile.swift
@@ -116,6 +116,14 @@ public struct SourceFile {
 
 }
 
+extension SourceFile: ExpressibleByStringLiteral {
+
+  public init(stringLiteral text: String) {
+    self.init(synthesizedText: text)
+  }
+
+}
+
 extension SourceFile: Hashable {
 
   public func hash(into hasher: inout Hasher) {

--- a/Tests/ValTests/CaptureCollectorTests.swift
+++ b/Tests/ValTests/CaptureCollectorTests.swift
@@ -8,8 +8,7 @@ final class CaptureCollectorTests: XCTestCase {
   func testFunctionBindings() throws {
     var ast = AST()
     let module = ast.insert(synthesized: ModuleDecl(name: "main"))
-    let source = testCode(
-      """
+    let source: SourceFile = """
       fun f<X, v: Void>[let c = ()](_ p: Any) {
         let _ = free   // captured
         let _ = X      // bound
@@ -17,7 +16,7 @@ final class CaptureCollectorTests: XCTestCase {
         let _ = c      // bound
         let _ = p      // bound
       }
-      """)
+      """
 
     var diagnostics = Diagnostics()
     _ = try Parser.parse(source, into: module, in: &ast, diagnostics: &diagnostics)

--- a/Tests/ValTests/LexerTests.swift
+++ b/Tests/ValTests/LexerTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class LexerTests: XCTestCase {
 
   func testBool() {
-    let input = testCode("true false")
+    let input: SourceFile = "true false"
     assert(
       tokenize(input),
       matches: [
@@ -16,7 +16,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testDecimalInteger() {
-    let input = testCode("0 001 42 00 1_234 1_2__34__")
+    let input: SourceFile = "0 001 42 00 1_234 1_2__34__"
     assert(
       tokenize(input),
       matches: [
@@ -31,7 +31,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testHexadecimalInteger() {
-    let input = testCode("0x0123 0xabcdef 0x__0_a_ 0xg 0x")
+    let input: SourceFile = "0x0123 0xabcdef 0x__0_a_ 0xg 0x"
     assert(
       tokenize(input),
       matches: [
@@ -47,7 +47,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testOctalInteger() {
-    let input = testCode("0o0123 0o__0_6_ 0o8 0o")
+    let input: SourceFile = "0o0123 0o__0_6_ 0o8 0o"
     assert(
       tokenize(input),
       matches: [
@@ -62,7 +62,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testBinaryInteger() {
-    let input = testCode("0b01 0b__0_1_ 0b8 0b")
+    let input: SourceFile = "0b01 0b__0_1_ 0b8 0b"
     assert(
       tokenize(input),
       matches: [
@@ -77,7 +77,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testFloatingPoint() {
-    let input = testCode("0.0 001.00 0.1_2__34__ 1e1_000 1.12e+123 3.45E-6 1. 1e")
+    let input: SourceFile = "0.0 001.00 0.1_2__34__ 1e1_000 1.12e+123 3.45E-6 1. 1e"
     assert(
       tokenize(input),
       matches: [
@@ -96,7 +96,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testString() {
-    let input = testCode(#""" "a 0+ " "a\nb" "a\"" "abc "#)
+    let input: SourceFile = #""" "a 0+ " "a\nb" "a\"" "abc "#
     assert(
       tokenize(input),
       matches: [
@@ -110,12 +110,11 @@ final class LexerTests: XCTestCase {
   }
 
   func testKeywords() {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       any break catch conformance continue deinit do else extension for fun if import in infix init
       inout let match namespace nil operator postfix prefix property public return set sink some
       spawn static subscript trait try type typealias var where while yield yielded
-      """)
+      """
 
     assert(
       tokenize(input),
@@ -167,7 +166,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testIdentifiers() {
-    let input = testCode("foo éléphant _bar _1_2_3 _")
+    let input: SourceFile = "foo éléphant _bar _1_2_3 _"
     assert(
       tokenize(input),
       matches: [
@@ -181,7 +180,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testBackquotedIdentifier() {
-    let input = testCode("`type` `foo` `a_b_` `12`")
+    let input: SourceFile = "`type` `foo` `a_b_` `12`"
     assert(
       tokenize(input),
       matches: [
@@ -196,7 +195,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testAttributes() {
-    let input = testCode("@implicitcopy @_foo @2")
+    let input: SourceFile = "@implicitcopy @_foo @2"
     assert(
       tokenize(input),
       matches: [
@@ -209,7 +208,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testOperators() {
-    let input = testCode("= -> * / % +- == != ~> >! <? >> &|^ ... ..< | &")
+    let input: SourceFile = "= -> * / % +- == != ~> >! <? >> &|^ ... ..< | &"
     assert(
       tokenize(input),
       matches: [
@@ -238,7 +237,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testCastOperators() {
-    let input = testCode("is as as!")
+    let input: SourceFile = "is as as!"
     assert(
       tokenize(input),
       matches: [
@@ -250,7 +249,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testPunctuation() {
-    let input = testCode(",;.: ::")
+    let input: SourceFile = ",;.: ::"
     assert(
       tokenize(input),
       matches: [
@@ -264,7 +263,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testDelimiters() {
-    let input = testCode("()[]{}<>")
+    let input: SourceFile = "()[]{}<>"
     assert(
       tokenize(input),
       matches: [
@@ -281,8 +280,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testComments() {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       // line comment
       // line comment with block start /*
       /* Block comment
@@ -291,7 +289,7 @@ final class LexerTests: XCTestCase {
       /**** /* Nested block */ */
       a = /* not c, but */ b
       /**** /* Unterminated */
-      """)
+      """
 
     assert(
       tokenize(input),
@@ -305,7 +303,7 @@ final class LexerTests: XCTestCase {
   }
 
   func testInvalid() {
-    let input = testCode("\0")
+    let input: SourceFile = "\0"
     assert(
       tokenize(input),
       matches: [TokenSpecification(.invalid, "\0")],

--- a/Tests/ValTests/ParserTests.swift
+++ b/Tests/ValTests/ParserTests.swift
@@ -23,12 +23,11 @@ final class ParserTests: XCTestCase {
   // MARK: Unit tests
 
   func testParse() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       public fun main() {
         print("Hello, World!")
       }
-      """)
+      """
 
     var program = AST()
     let module = program.insert(synthesized: ModuleDecl(name: "Main"))
@@ -39,8 +38,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testSourceFile() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
         ;;
         import Foo
 
@@ -49,7 +47,7 @@ final class ParserTests: XCTestCase {
 
         let x = "Hello!"
         public let y = 0;
-      """)
+      """
 
     var program = AST()
     let module = program.insert(synthesized: ModuleDecl(name: "Main"))
@@ -62,7 +60,7 @@ final class ParserTests: XCTestCase {
   // MARK: Declarations
 
   func testModuleMember() throws {
-    let input = testCode("public operator infix| : disjunction")
+    let input: SourceFile = "public operator infix| : disjunction"
     let (declID, ast) = try input.parse(with: Parser.parseDecl)
     let decl = try XCTUnwrap(ast[declID] as? OperatorDecl)
     XCTAssertEqual(decl.name.value, "|")
@@ -70,100 +68,95 @@ final class ParserTests: XCTestCase {
   }
 
   func testImportDecl() throws {
-    let input = testCode("import Foo")
+    let input: SourceFile = "import Foo"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseImportDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.baseName, "Foo")
   }
 
   func testNamespaceDecl() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       namespace A {
         ;;
         let x = "Hello!"
         public let y = 0;
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseNamespaceDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.members.count, 2)
   }
 
   func testNamespaceMember() throws {
-    let input = testCode("fun foo() {}")
+    let input: SourceFile = "fun foo() {}"
     let (declID, _) = try input.parse(inContext: .namespaceBody, with: Parser.parseDecl)
     XCTAssertNotNil(declID)
   }
 
   func testNamespaceMemberPublic() throws {
-    let input = testCode("public fun foo() {}")
+    let input: SourceFile = "public fun foo() {}"
     let (declID, ast) = try input.parse(inContext: .namespaceBody, with: Parser.parseDecl)
     let decl = try XCTUnwrap(ast[declID] as? FunctionDecl)
     XCTAssertEqual(decl.accessModifier?.value, .public)
   }
 
   func testTypeAliasDecl() throws {
-    let input = testCode("typealias A = B")
+    let input: SourceFile = "typealias A = B"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseTypeAliasDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.identifier.value, "A")
   }
 
   func testTypeAliasDeclWithGenericClause() throws {
-    let input = testCode("typealias A<T> = B<T>")
+    let input: SourceFile = "typealias A<T> = B<T>"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseTypeAliasDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.genericClause)
   }
 
   func testProductTypeDecl() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       type A {
         var x: Int; var y: Int
         fun foo() -> Int { x.copy() }
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseProductTypeDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.members.count, 4)  // 3 explicit decls + 1 implicit memberwise init
   }
 
   func testProductTypeDeclWithGenericClause() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       type A<T, U> {
               var x: Int; var y: Int
         fun foo() -> Int { x.copy() }
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseProductTypeDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.genericClause)
   }
 
   func testProductTypeDeclWithConformances() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       type A: Foo, Bar {
         var x: Int; var y: Int
         fun foo() -> Int { x.copy() }
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseProductTypeDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.conformances)
   }
 
   func testProductTypeDeclWithGenericClauseAndConformances() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       type A<T>: Foo {
         var x: Int
         fun foo() -> Int { x.copy() }
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseProductTypeDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.genericClause)
@@ -171,27 +164,27 @@ final class ParserTests: XCTestCase {
   }
 
   func testProductTypeMember() throws {
-    let input = testCode("var x: Int")
+    let input: SourceFile = "var x: Int"
     let (declID, _) = try input.parse(inContext: .productBody, with: Parser.parseDecl)
     XCTAssertNotNil(declID)
   }
 
   func testProductTypeMemberPublic() throws {
-    let input = testCode("public var x: Int")
+    let input: SourceFile = "public var x: Int"
     let (declID, ast) = try input.parse(inContext: .productBody, with: Parser.parseDecl)
     let decl = try XCTUnwrap(ast[declID] as? BindingDecl)
     XCTAssertEqual(decl.accessModifier?.value, .public)
   }
 
   func testProductTypeMemberStatic() throws {
-    let input = testCode("static var x: Int")
+    let input: SourceFile = "static var x: Int"
     let (declID, ast) = try input.parse(inContext: .productBody, with: Parser.parseDecl)
     let decl = try XCTUnwrap(ast[declID] as? BindingDecl)
     XCTAssertEqual(decl.memberModifier?.value, .static)
   }
 
   func testProductTypeMemberPublicStatic() throws {
-    let input = testCode("public static var x: Int")
+    let input: SourceFile = "public static var x: Int"
     let (declID, ast) = try input.parse(inContext: .productBody, with: Parser.parseDecl)
     let decl = try XCTUnwrap(ast[declID] as? BindingDecl)
     XCTAssertEqual(decl.accessModifier?.value, .public)
@@ -199,65 +192,61 @@ final class ParserTests: XCTestCase {
   }
 
   func testTraitDecl() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       trait A {
         type B
         property b: B { let }
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseTraitDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.members.count, 3)  // 2 explicit decls + 1 implicit `Self` parameter
   }
 
   func testTraitDeclWithRefinements() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       trait A: Foo {
         type B
         property b: B { let }
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseTraitDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.refinements.count, 1)
   }
 
   func testMethodBundleRequirement() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       fun foo() -> T {
         let
         inout
       }
-      """)
+      """
     let (declID, ast) = try input.parse(inContext: .traitBody, with: Parser.parseDecl)
     let decl = try XCTUnwrap(ast[declID] as? MethodDecl)
     XCTAssertEqual(decl.impls.count, 2)
   }
 
   func testSubscriptRequirement() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       subscript foo(): T {
         let
         inout
       }
-      """)
+      """
     let (declID, ast) = try input.parse(inContext: .traitBody, with: Parser.parseDecl)
     let decl = try XCTUnwrap(ast[declID] as? SubscriptDecl)
     XCTAssertEqual(decl.impls.count, 2)
   }
 
   func testPropertyRequirement() throws {
-    let input = testCode("property foo: T { let }")
+    let input: SourceFile = "property foo: T { let }"
     let (declID, _) = try input.parse(inContext: .traitBody, with: Parser.parseDecl)
     XCTAssertNotNil(declID)
   }
 
   func testAssociatedTypeDecl() throws {
-    let input = testCode("type Foo")
+    let input: SourceFile = "type Foo"
     let (declID, ast) = try input.parseWithDeclPrologue(
       inContext: .traitBody,
       with: Parser.parseAssociatedTypeDecl)
@@ -266,7 +255,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testAssociatedTypeDeclWithConformances() throws {
-    let input = testCode("type Foo: Bar, Ham")
+    let input: SourceFile = "type Foo: Bar, Ham"
     let (declID, ast) = try input.parseWithDeclPrologue(
       inContext: .traitBody,
       with: Parser.parseAssociatedTypeDecl)
@@ -275,7 +264,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testAssociatedTypeDeclWithWhereClause() throws {
-    let input = testCode("type Foo where Foo.Bar == Ham")
+    let input: SourceFile = "type Foo where Foo.Bar == Ham"
     let (declID, ast) = try input.parseWithDeclPrologue(
       inContext: .traitBody,
       with: Parser.parseAssociatedTypeDecl)
@@ -284,7 +273,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testAssociatedTypeDeclWithWithDefault() throws {
-    let input = testCode("type Foo = X")
+    let input: SourceFile = "type Foo = X"
     let (declID, ast) = try input.parseWithDeclPrologue(
       inContext: .traitBody,
       with: Parser.parseAssociatedTypeDecl)
@@ -293,7 +282,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testAssociatedValueDecl() throws {
-    let input = testCode("value foo")
+    let input: SourceFile = "value foo"
     let (declID, ast) = try input.parseWithDeclPrologue(
       inContext: .traitBody,
       with: Parser.parseAssociatedValueDecl)
@@ -302,7 +291,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testAssociatedValueDeclWithWhereClause() throws {
-    let input = testCode("value foo where @value foo > bar")
+    let input: SourceFile = "value foo where @value foo > bar"
     let (declID, ast) = try input.parseWithDeclPrologue(
       inContext: .traitBody,
       with: Parser.parseAssociatedValueDecl)
@@ -311,7 +300,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testAssociatedValueDeclWithDefault() throws {
-    let input = testCode("value foo = 42")
+    let input: SourceFile = "value foo = 42"
     let (declID, ast) = try input.parseWithDeclPrologue(
       inContext: .traitBody,
       with: Parser.parseAssociatedValueDecl)
@@ -320,59 +309,55 @@ final class ParserTests: XCTestCase {
   }
 
   func testConformanceDecl() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       conformance A: Foo {
         public fun bar() {}
         fun foo() -> Int { x.copy() }
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseConformanceDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.members.count, 2)
   }
 
   func testConformanceDeclWithWhereClause() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       conformance A: Foo where A.Bar == Ham {
         public fun bar() {}
         fun foo() -> Int { x.copy() }
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseConformanceDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.whereClause)
   }
 
   func testExtensionDecl() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       extension A {
         type B {}; property z: Int { x }
         fun foo() -> Int { x.copy() }
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseExtensionDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.members.count, 3)
   }
 
   func testExtensionDeclWithWhereClause() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       extension A where Foo: Bar {
         type B {}; property z: Int { x }
         fun foo() -> Int { x.copy() }
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseExtensionDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.whereClause)
   }
 
   func testExtensionMember() throws {
-    let input = testCode("public static fun forty_two() -> Int { 42 }")
+    let input: SourceFile = "public static fun forty_two() -> Int { 42 }"
     let (declID, ast) = try input.parse(inContext: .extensionBody, with: Parser.parseDecl)
     let decl = try XCTUnwrap(ast[declID] as? FunctionDecl)
     XCTAssertEqual(decl.accessModifier?.value, .public)
@@ -380,28 +365,28 @@ final class ParserTests: XCTestCase {
   }
 
   func testBindingDecl() throws {
-    let input = testCode("let (foo, bar)")
+    let input: SourceFile = "let (foo, bar)"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseBindingDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(ast[decl.pattern].introducer.value, .let)
   }
 
   func testBindingDeclWithInitializer() throws {
-    let input = testCode("let (foo, bar) = (true, ham())")
+    let input: SourceFile = "let (foo, bar) = (true, ham())"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseBindingDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.initializer)
   }
 
   func testMemberwiseInitDecl() throws {
-    let input = testCode("memberwise init")
+    let input: SourceFile = "memberwise init"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseMemberwiseInitDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.introducer.value, .memberwiseInit)
   }
 
   func testInitDecl() throws {
-    let input = testCode("init() {}")
+    let input: SourceFile = "init() {}"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseInitDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.introducer.value, .`init`)
@@ -409,7 +394,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testInitDeclGeneric() throws {
-    let input = testCode("init<T>() {}")
+    let input: SourceFile = "init<T>() {}"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseInitDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.introducer.value, .`init`)
@@ -418,7 +403,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionDecl() throws {
-    let input = testCode("fun foo() {}")
+    let input: SourceFile = "fun foo() {}"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseFunctionOrMethodDecl)
     let decl = try XCTUnwrap(ast[declID] as? FunctionDecl)
     XCTAssertEqual(decl.identifier?.value, "foo")
@@ -426,7 +411,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionDeclWithCaptureList() throws {
-    let input = testCode("fun foo[let x = 42]() {}")
+    let input: SourceFile = "fun foo[let x = 42]() {}"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseFunctionOrMethodDecl)
     let decl = try XCTUnwrap(ast[declID] as? FunctionDecl)
     XCTAssertEqual(decl.explicitCaptures.count, 1)
@@ -434,7 +419,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionDeclWithExprBody() throws {
-    let input = testCode("fun id<T: Sinkable>(_ x: T) -> T { x }")
+    let input: SourceFile = "fun id<T: Sinkable>(_ x: T) -> T { x }"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseFunctionOrMethodDecl)
     let decl = try XCTUnwrap(ast[declID] as? FunctionDecl)
     if case .expr = decl.body {
@@ -444,7 +429,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testPostifxFunctionDecl() throws {
-    let input = testCode("fun postfix+ () -> T { x }")
+    let input: SourceFile = "fun postfix+ () -> T { x }"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseFunctionOrMethodDecl)
     let decl = try XCTUnwrap(ast[declID] as? FunctionDecl)
     XCTAssertEqual(decl.notation?.value, .postfix)
@@ -452,20 +437,19 @@ final class ParserTests: XCTestCase {
   }
 
   func testMethodBundle() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       fun foo() {
         let  { self.copy() }
         sink { self }
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseFunctionOrMethodDecl)
     let decl = try XCTUnwrap(ast[declID] as? MethodDecl)
     XCTAssertEqual(decl.impls.count, 2)
   }
 
   func testFunctionDeclSignature() throws {
-    let input = testCode("()")
+    let input: SourceFile = "()"
     let signature = try XCTUnwrap(
       input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
     XCTAssertEqual(signature.parameters.count, 0)
@@ -474,7 +458,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionDeclSignatureWithParameters() throws {
-    let input = testCode("(_ foo: Foo, bar: Bar = .default)")
+    let input: SourceFile = "(_ foo: Foo, bar: Bar = .default)"
     let signature = try XCTUnwrap(
       input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
     XCTAssertEqual(signature.parameters.count, 2)
@@ -483,7 +467,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionDeclSignatureWithEffect() throws {
-    let input = testCode("(_ foo: Foo) inout")
+    let input: SourceFile = "(_ foo: Foo) inout"
     let signature = try XCTUnwrap(
       input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
     XCTAssertEqual(signature.parameters.count, 1)
@@ -492,7 +476,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionDeclSignatureWithOutput() throws {
-    let input = testCode("(_ foo: Foo) -> C")
+    let input: SourceFile = "(_ foo: Foo) -> C"
     let signature = try XCTUnwrap(
       input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
     XCTAssertEqual(signature.parameters.count, 1)
@@ -501,7 +485,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionDeclSignatureWithOutputAndEffect() throws {
-    let input = testCode("(_ foo: Foo) sink -> C")
+    let input: SourceFile = "(_ foo: Foo) sink -> C"
     let signature = try XCTUnwrap(
       input.parse(with: Parser.parseFunctionDeclSignature(in:)).element)
     XCTAssertEqual(signature.parameters.count, 1)
@@ -510,7 +494,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionDeclIdentifier() throws {
-    let input = testCode("fun foo")
+    let input: SourceFile = "fun foo"
     let identifier = try XCTUnwrap(
       input.parse(with: Parser.parseFunctionDeclHead(in:)).element)
     XCTAssertEqual(identifier.stem.value, "foo")
@@ -518,7 +502,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionDeclOperator() throws {
-    let input = testCode("fun postfix++")
+    let input: SourceFile = "fun postfix++"
     let identifier = try XCTUnwrap(
       input.parse(with: Parser.parseFunctionDeclHead(in:)).element)
     XCTAssertEqual(identifier.stem.value, "++")
@@ -526,7 +510,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionDeclBodyBlock() throws {
-    let input = testCode("{}")
+    let input: SourceFile = "{}"
     let (body, _) = try apply(Parser.functionDeclBody, on: input)
     if case .block = body {
     } else {
@@ -535,7 +519,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionDeclBodyExpr() throws {
-    let input = testCode("{ 0x2a }")
+    let input: SourceFile = "{ 0x2a }"
     let (body, _) = try apply(Parser.functionDeclBody, on: input)
     if case .expr = body {
     } else {
@@ -544,20 +528,19 @@ final class ParserTests: XCTestCase {
   }
 
   func testMethodDeclBody() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       {
         let  { self.copy() }
         sink { self }
       }
-      """)
+      """
     let (body, _) = try apply(Parser.methodDeclBody, on: input)
     let impls = try XCTUnwrap(body)
     XCTAssertEqual(impls.count, 2)
   }
 
   func testMethodImplBlock() throws {
-    let input = testCode("let { }")
+    let input: SourceFile = "let { }"
     let (declID, ast) = try apply(Parser.methodImpl, on: input)
     let decl = try XCTUnwrap(ast[declID])
     if case .block = decl.body {
@@ -567,7 +550,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testMethodImplExpr() throws {
-    let input = testCode("let { foo }")
+    let input: SourceFile = "let { foo }"
     let (declID, ast) = try apply(Parser.methodImpl, on: input)
     let decl = try XCTUnwrap(ast[declID])
     if case .expr = decl.body {
@@ -577,7 +560,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testPropertyDecl() throws {
-    let input = testCode("property foo: T { T() }")
+    let input: SourceFile = "property foo: T { T() }"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parsePropertyDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.identifier?.value, "foo")
@@ -586,7 +569,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testSubscriptDecl() throws {
-    let input = testCode("subscript foo(): T { T() }")
+    let input: SourceFile = "subscript foo(): T { T() }"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseSubscriptDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.identifier?.value, "foo")
@@ -595,7 +578,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testSubscriptDeclAnonymous() throws {
-    let input = testCode("subscript (): T { T() }")
+    let input: SourceFile = "subscript (): T { T() }"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseSubscriptDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNil(decl.identifier)
@@ -604,7 +587,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testSubscriptDeclWithCaptureList() throws {
-    let input = testCode("subscript foo[let x = 42](): T { T() }")
+    let input: SourceFile = "subscript foo[let x = 42](): T { T() }"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseSubscriptDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.explicitCaptures.count, 1)
@@ -613,48 +596,47 @@ final class ParserTests: XCTestCase {
   }
 
   func testSubscriptDeclWithBlockBody() throws {
-    let input = testCode("subscript foo<T: Foo>(_ x: T): T { yield x }")
+    let input: SourceFile = "subscript foo<T: Foo>(_ x: T): T { yield x }"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseSubscriptDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.impls.count, 1)
   }
 
   func testSubscriptDeclWithExprBody() throws {
-    let input = testCode("subscript foo<T: Foo>(_ x: T): T { x }")
+    let input: SourceFile = "subscript foo<T: Foo>(_ x: T): T { x }"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseSubscriptDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.impls.count, 1)
   }
 
   func testSubscriptBundle() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       subscript foo(): T {
         let  { T() }
         sink { T() }
       }
-      """)
+      """
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseSubscriptDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.impls.count, 2)
   }
 
   func testSubscriptDeclSignature() throws {
-    let input = testCode("(): T")
+    let input: SourceFile = "(): T"
     let signature = try XCTUnwrap(
       input.parse(with: Parser.parseSubscriptDeclSignature(in:)).element)
     XCTAssertEqual(signature.parameters.count, 0)
   }
 
   func testSubscriptDeclSignatureWithParameters() throws {
-    let input = testCode("(_ foo: Foo, bar: Bar = .default): T")
+    let input: SourceFile = "(_ foo: Foo, bar: Bar = .default): T"
     let signature = try XCTUnwrap(
       input.parse(with: Parser.parseSubscriptDeclSignature(in:)).element)
     XCTAssertEqual(signature.parameters.count, 2)
   }
 
   func testSubscriptDeclBodyBlock() throws {
-    let input = testCode("{ yield x }")
+    let input: SourceFile = "{ yield x }"
     let (body, ast) = try input.parse(
       inContext: .subscriptBody,
       with: { (state) in try Parser.parseSubscriptDeclBody(in: &state, asNonStaticMember: true) })
@@ -670,7 +652,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testSubscriptDeclBodyExpr() throws {
-    let input = testCode("{ 0x2a }")
+    let input: SourceFile = "{ 0x2a }"
     let (body, ast) = try input.parse(
       inContext: .subscriptBody,
       with: { (state) in try Parser.parseSubscriptDeclBody(in: &state, asNonStaticMember: true) })
@@ -686,13 +668,12 @@ final class ParserTests: XCTestCase {
   }
 
   func testSubscriptDeclBodyBundle() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       {
         let  { self.copy() }
         sink { self }
       }
-      """)
+      """
     let (body, _) = try input.parse(
       inContext: .subscriptBody,
       with: { (state) in try Parser.parseSubscriptDeclBody(in: &state, asNonStaticMember: true) })
@@ -701,49 +682,49 @@ final class ParserTests: XCTestCase {
   }
 
   func testParameterDecl() throws {
-    let input = testCode("_ foo")
+    let input: SourceFile = "_ foo"
     let (declID, ast) = try apply(Parser.parameterDecl, on: input)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.baseName, "foo")
   }
 
   func testParameterDeclWithAnnotation() throws {
-    let input = testCode("_ foo: T")
+    let input: SourceFile = "_ foo: T"
     let (declID, ast) = try apply(Parser.parameterDecl, on: input)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.annotation)
   }
 
   func testParameterDeclWithDefault() throws {
-    let input = testCode("_ foo: T = T()")
+    let input: SourceFile = "_ foo: T = T()"
     let (declID, ast) = try apply(Parser.parameterDecl, on: input)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.defaultValue)
   }
 
   func testParameterIntefaceLabelAndName() throws {
-    let input = testCode("for name")
+    let input: SourceFile = "for name"
     let interface = try XCTUnwrap(try apply(Parser.parameterInterface, on: input).element)
     XCTAssertEqual(interface.label?.value, "for")
     XCTAssertEqual(interface.name.value, "name")
   }
 
   func testParameterIntefaceUnderscoreAndName() throws {
-    let input = testCode("_ name")
+    let input: SourceFile = "_ name"
     let interface = try XCTUnwrap(try apply(Parser.parameterInterface, on: input).element)
     XCTAssertNil(interface.label)
     XCTAssertEqual(interface.name.value, "name")
   }
 
   func testParameterIntefaceOnlyName() throws {
-    let input = testCode("name")
+    let input: SourceFile = "name"
     let interface = try XCTUnwrap(try apply(Parser.parameterInterface, on: input).element)
     XCTAssertEqual(interface.label?.value, "name")
     XCTAssertEqual(interface.name.value, "name")
   }
 
   func testOperatorDecl() throws {
-    let input = testCode("operator infix+")
+    let input: SourceFile = "operator infix+"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseOperatorDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.notation.value, .infix)
@@ -751,7 +732,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testOperatorDeclWithPredecenceGroup() throws {
-    let input = testCode("operator infix+ : addition")
+    let input: SourceFile = "operator infix+ : addition"
     let (declID, ast) = try input.parseWithDeclPrologue(with: Parser.parseOperatorDecl)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.notation.value, .infix)
@@ -759,58 +740,58 @@ final class ParserTests: XCTestCase {
   }
 
   func testGenericClause() throws {
-    let input = testCode("<T>")
+    let input: SourceFile = "<T>"
     let clause = try XCTUnwrap(try apply(Parser.genericClause, on: input).element)
     XCTAssertEqual(clause.value.parameters.count, 1)
   }
 
   func testGenericClauseWithMultipleParameters() throws {
-    let input = testCode("<T, n: Int>")
+    let input: SourceFile = "<T, n: Int>"
     let clause = try XCTUnwrap(try apply(Parser.genericClause, on: input).element)
     XCTAssertEqual(clause.value.parameters.count, 2)
   }
 
   func testGenericClauseWithMultipleParametersSansHint() throws {
-    let input = testCode("<T, n: Int>")
+    let input: SourceFile = "<T, n: Int>"
     let clause = try XCTUnwrap(try apply(Parser.genericClause, on: input).element)
     XCTAssertEqual(clause.value.parameters.count, 2)
   }
 
   func testCaptureList() throws {
-    let input = testCode("[let x = a, var y = true]")
+    let input: SourceFile = "[let x = a, var y = true]"
     let list = try XCTUnwrap(try apply(Parser.captureList, on: input).element)
     XCTAssertEqual(list.count, 2)
   }
 
   func testGenericClauseWithWhereClause() throws {
-    let input = testCode("<T: Foo where T.Bar == {}>")
+    let input: SourceFile = "<T: Foo where T.Bar == {}>"
     let clause = try XCTUnwrap(try apply(Parser.genericClause, on: input).element)
     XCTAssertNotNil(clause.value.whereClause)
   }
 
   func testGenericParameter() throws {
-    let input = testCode("T")
+    let input: SourceFile = "T"
     let (declID, ast) = try apply(Parser.genericParameter, on: input)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.baseName, "T")
   }
 
   func testGenericParameterWithConformances() throws {
-    let input = testCode("T: Foo & Bar")
+    let input: SourceFile = "T: Foo & Bar"
     let (declID, ast) = try apply(Parser.genericParameter, on: input)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.conformances.count, 2)
   }
 
   func testGenericParameterWithDefault() throws {
-    let input = testCode("T = U")
+    let input: SourceFile = "T = U"
     let (declID, ast) = try apply(Parser.genericParameter, on: input)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertNotNil(decl.defaultValue)
   }
 
   func testGenericParameterWithConformancesAndDefault() throws {
-    let input = testCode("T: Int = 0o52")
+    let input: SourceFile = "T: Int = 0o52"
     let (declID, ast) = try apply(Parser.genericParameter, on: input)
     let decl = try XCTUnwrap(ast[declID])
     XCTAssertEqual(decl.conformances.count, 1)
@@ -818,7 +799,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testConformanceList() throws {
-    let input = testCode(": Foo, Bar, Ham")
+    let input: SourceFile = ": Foo, Bar, Ham"
     let list = try XCTUnwrap(try apply(Parser.conformanceList, on: input).element)
     XCTAssertEqual(list.count, 3)
   }
@@ -826,13 +807,13 @@ final class ParserTests: XCTestCase {
   // MARK: Value expressions
 
   func testExpr() throws {
-    let input = testCode("(foo().bar[] + 42, ham++, !baz)")
+    let input: SourceFile = "(foo().bar[] + 42, ham++, !baz)"
     let (exprID, _) = try input.parse(with: Parser.parseExpr(in:))
     XCTAssertEqual(exprID?.kind, .init(TupleExpr.self))
   }
 
   func testInfixExpr() throws {
-    let input = testCode("foo == 2 & true")
+    let input: SourceFile = "foo == 2 & true"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let sequence = try XCTUnwrap(ast[exprID] as? SequenceExpr)
     XCTAssertEqual(sequence.head.kind, .init(NameExpr.self))
@@ -845,34 +826,34 @@ final class ParserTests: XCTestCase {
   }
 
   func testCastExprUp() throws {
-    let input = testCode("foo as T")
+    let input: SourceFile = "foo as T"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let cast = try XCTUnwrap(ast[exprID] as? CastExpr)
     XCTAssertEqual(cast.kind, .up)
   }
 
   func testCastExprDown() throws {
-    let input = testCode("foo as! T")
+    let input: SourceFile = "foo as! T"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let cast = try XCTUnwrap(ast[exprID] as? CastExpr)
     XCTAssertEqual(cast.kind, .down)
   }
 
   func testCastExprBuiltinPointerConversion() throws {
-    let input = testCode("foo as!! T")
+    let input: SourceFile = "foo as!! T"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let cast = try XCTUnwrap(ast[exprID] as? CastExpr)
     XCTAssertEqual(cast.kind, .builtinPointerConversion)
   }
 
   func testInoutExpr() throws {
-    let input = testCode("&foo")
+    let input: SourceFile = "&foo"
     let (exprID, _) = try input.parse(with: Parser.parseExpr(in:))
     XCTAssertEqual(exprID?.kind, .init(InoutExpr.self))
   }
 
   func testPrefixExpr() throws {
-    let input = testCode("+foo")
+    let input: SourceFile = "+foo"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let call = try XCTUnwrap(ast[exprID] as? FunctionCallExpr)
     XCTAssertEqual(call.arguments.count, 0)
@@ -889,7 +870,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testPostfixExpr() throws {
-    let input = testCode("foo+")
+    let input: SourceFile = "foo+"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let call = try XCTUnwrap(ast[exprID] as? FunctionCallExpr)
     XCTAssertEqual(call.arguments.count, 0)
@@ -908,7 +889,7 @@ final class ParserTests: XCTestCase {
   // MARK: Compound expressions
 
   func testLabeledMemberExpr() throws {
-    let input = testCode("a.b.c")
+    let input: SourceFile = "a.b.c"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     var expr = try XCTUnwrap(ast[exprID] as? NameExpr)
     XCTAssertEqual(expr.name.value.stem, "c")
@@ -922,7 +903,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testIndexedMemberExpr() throws {
-    let input = testCode("foo.12")
+    let input: SourceFile = "foo.12"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? TupleMemberExpr)
     XCTAssertEqual(expr.index, 12)
@@ -932,7 +913,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testStaticValueMemberExpr() throws {
-    let input = testCode("{ A, B }.meta")
+    let input: SourceFile = "{ A, B }.meta"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? NameExpr)
     XCTAssertEqual(expr.name.value.stem, "meta")
@@ -945,7 +926,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testConformanceLensTypeExpr() throws {
-    let input = testCode("{ T, U }::Baz")
+    let input: SourceFile = "{ T, U }::Baz"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? ConformanceLensTypeExpr)
     XCTAssertEqual(expr.subject.kind, .init(TupleTypeExpr.self))
@@ -953,7 +934,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testConformanceLensExprWithMember() throws {
-    let input = testCode("T::P.A")
+    let input: SourceFile = "T::P.A"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? NameExpr)
     XCTAssertEqual(expr.name.value.stem, "A")
@@ -968,14 +949,14 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionCallExprWithoutArguments() throws {
-    let input = testCode("foo()")
+    let input: SourceFile = "foo()"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? FunctionCallExpr)
     XCTAssertEqual(expr.arguments.count, 0)
   }
 
   func testFunctionCallExpr() throws {
-    let input = testCode("foo(42, label: true)")
+    let input: SourceFile = "foo(42, label: true)"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? FunctionCallExpr)
     XCTAssertEqual(expr.arguments.count, 2)
@@ -987,26 +968,26 @@ final class ParserTests: XCTestCase {
   }
 
   func testFunctionCallExprNewlineBeforeLParen() throws {
-    let input = testCode("foo \n (42, label: true)")
+    let input: SourceFile = "foo \n (42, label: true)"
     let (exprID, _) = try input.parse(with: Parser.parseExpr(in:))
     XCTAssertEqual(exprID?.kind, .init(NameExpr.self))
   }
 
   func testFunctionCallExprNewlineAfterLParen() throws {
-    let input = testCode("foo ( \n 42, label: true)")
+    let input: SourceFile = "foo ( \n 42, label: true)"
     let (exprID, _) = try input.parse(with: Parser.parseExpr(in:))
     XCTAssertEqual(exprID?.kind, .init(FunctionCallExpr.self))
   }
 
   func testSubscriptCallExprWithoutArguments() throws {
-    let input = testCode("foo[]")
+    let input: SourceFile = "foo[]"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? SubscriptCallExpr)
     XCTAssertEqual(expr.arguments.count, 0)
   }
 
   func testSubscriptCallExpr() throws {
-    let input = testCode("foo[42, label: true]")
+    let input: SourceFile = "foo[42, label: true]"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? SubscriptCallExpr)
     XCTAssertEqual(expr.arguments.count, 2)
@@ -1020,82 +1001,82 @@ final class ParserTests: XCTestCase {
   // MARK: Primary expressions
 
   func testTrueLiteral() throws {
-    let input = testCode("true")
+    let input: SourceFile = "true"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? BooleanLiteralExpr)
     XCTAssertEqual(expr.value, true)
   }
 
   func testFalseLiteral() throws {
-    let input = testCode("false")
+    let input: SourceFile = "false"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? BooleanLiteralExpr)
     XCTAssertEqual(expr.value, false)
   }
 
   func testDecimalLiteral() throws {
-    let input = testCode("4_2_")
+    let input: SourceFile = "4_2_"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? IntegerLiteralExpr)
     XCTAssertEqual(expr.value, "42")
   }
 
   func testBinaryLiteral() throws {
-    let input = testCode("0b10_10_10")
+    let input: SourceFile = "0b10_10_10"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? IntegerLiteralExpr)
     XCTAssertEqual(expr.value, "0b101010")
   }
 
   func testOctalLiteral() throws {
-    let input = testCode("0o5_2_")
+    let input: SourceFile = "0o5_2_"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? IntegerLiteralExpr)
     XCTAssertEqual(expr.value, "0o52")
   }
 
   func testHexadecimalLiteral() throws {
-    let input = testCode("0x2_a_")
+    let input: SourceFile = "0x2_a_"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? IntegerLiteralExpr)
     XCTAssertEqual(expr.value, "0x2a")
   }
 
   func testFloatingPointLiteral() throws {
-    let input = testCode("4.2e+1")
+    let input: SourceFile = "4.2e+1"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? FloatLiteralExpr)
     XCTAssertEqual(expr.value, "4.2e+1")
   }
 
   func testStringLiteral() throws {
-    let input = testCode(#""Val""#)
+    let input: SourceFile = #""Val""#
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? StringLiteralExpr)
     XCTAssertEqual(expr.value, "Val")
   }
 
   func testNilLiteralExpr() throws {
-    let input = testCode("nil")
+    let input: SourceFile = "nil"
     let (exprID, _) = try input.parse(with: Parser.parseExpr(in:))
     XCTAssertEqual(exprID?.kind, .init(NilLiteralExpr.self))
   }
 
   func testSpawnExprInline() throws {
-    let input = testCode("spawn foo")
+    let input: SourceFile = "spawn foo"
     let (exprID, _) = try input.parse(with: Parser.parseExpr(in:))
     XCTAssertEqual(exprID?.kind, .init(SpawnExpr.self))
   }
 
   func testSpawnExprInlineWithCaptureList() throws {
-    let input = testCode("spawn[let x = a] foo")
+    let input: SourceFile = "spawn[let x = a] foo"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? SpawnExpr)
     XCTAssertEqual(ast[expr.decl].explicitCaptures.count, 1)
   }
 
   func testSpawnExprInlineWithEffect() throws {
-    let input = testCode("spawn[var x = a] inout foo")
+    let input: SourceFile = "spawn[var x = a] inout foo"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? SpawnExpr)
     XCTAssertEqual(ast[expr.decl].explicitCaptures.count, 1)
@@ -1103,48 +1084,48 @@ final class ParserTests: XCTestCase {
   }
 
   func testSpawnExprBlock() throws {
-    let input = testCode("spawn -> T { return foo }")
+    let input: SourceFile = "spawn -> T { return foo }"
     let (exprID, _) = try input.parse(with: Parser.parseExpr(in:))
     XCTAssertEqual(exprID?.kind, .init(SpawnExpr.self))
   }
 
   func testBufferLiteral() throws {
-    let input = testCode("[]")
+    let input: SourceFile = "[]"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? BufferLiteralExpr)
     XCTAssert(expr.elements.isEmpty)
   }
 
   func testBufferLiteralWithOneElement() throws {
-    let input = testCode("[a]")
+    let input: SourceFile = "[a]"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? BufferLiteralExpr)
     XCTAssertEqual(expr.elements.count, 1)
   }
 
   func testBufferLiteralWithMultipleElements() throws {
-    let input = testCode("[a, b, c]")
+    let input: SourceFile = "[a, b, c]"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? BufferLiteralExpr)
     XCTAssertEqual(expr.elements.count, 3)
   }
 
   func testMapLiteral() throws {
-    let input = testCode("[:]")
+    let input: SourceFile = "[:]"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? MapLiteralExpr)
     XCTAssert(expr.elements.isEmpty)
   }
 
   func testMapLiteralWithMultipleElements() throws {
-    let input = testCode("[a: 0, b: 1, c: 2]")
+    let input: SourceFile = "[a: 0, b: 1, c: 2]"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? MapLiteralExpr)
     XCTAssertEqual(expr.elements.count, 3)
   }
 
   func testPrimaryDeclRefSansHint() throws {
-    let input = testCode("foo<T, size: 42>")
+    let input: SourceFile = "foo<T, size: 42>"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? NameExpr)
     XCTAssertEqual(expr.name.value.stem, "foo")
@@ -1157,7 +1138,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testImplicitMemberRef() throws {
-    let input = testCode(".foo")
+    let input: SourceFile = ".foo"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? NameExpr)
     XCTAssertEqual(expr.name.value.stem, "foo")
@@ -1165,41 +1146,40 @@ final class ParserTests: XCTestCase {
   }
 
   func testLambdaExpr() throws {
-    let input = testCode("fun (x) { x.foo() }")
+    let input: SourceFile = "fun (x) { x.foo() }"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? LambdaExpr)
     XCTAssertTrue(ast[expr.decl].isInExprContext)
   }
 
   func testMatchExpr() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       match foo {
         let (x, y) where x == y { 0 }
         _ { 1 }
       }
-      """)
+      """
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? MatchExpr)
     XCTAssertEqual(expr.cases.count, 2)
   }
 
   func testConditionalExpr() throws {
-    let input = testCode("if true { }")
+    let input: SourceFile = "if true { }"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? CondExpr)
     XCTAssertEqual(expr.condition.count, 1)
   }
 
   func testConditionalExprWithMultipleConditions() throws {
-    let input = testCode("if let x = foo, x > 0 { }")
+    let input: SourceFile = "if let x = foo, x > 0 { }"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? CondExpr)
     XCTAssertEqual(expr.condition.count, 2)
   }
 
   func testConditionalExprBlockThenNoElse() throws {
-    let input = testCode("if true { }")
+    let input: SourceFile = "if true { }"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? CondExpr)
 
@@ -1212,7 +1192,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testConditionalExprBlockThenBlockElse() throws {
-    let input = testCode("if true { } else { }")
+    let input: SourceFile = "if true { } else { }"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? CondExpr)
 
@@ -1228,7 +1208,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testConditionalExprExprThenExprElse() throws {
-    let input = testCode("if true { 1 } else { 2 }")
+    let input: SourceFile = "if true { 1 } else { 2 }"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? CondExpr)
 
@@ -1244,7 +1224,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testConditionalExprExprElseIfElse() throws {
-    let input = testCode("if true { 1 } else if false { 2 } else { 3 }")
+    let input: SourceFile = "if true { 1 } else if false { 2 } else { 3 }"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? CondExpr)
 
@@ -1256,20 +1236,20 @@ final class ParserTests: XCTestCase {
   }
 
   func testParenthesizedExpr() throws {
-    let input = testCode("(42)")
+    let input: SourceFile = "(42)"
     let (exprID, _) = try input.parse(with: Parser.parseExpr(in:))
     XCTAssertEqual(exprID?.kind, .init(IntegerLiteralExpr.self))
   }
 
   func testTupleExpr() throws {
-    let input = testCode("()")
+    let input: SourceFile = "()"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? TupleExpr)
     XCTAssertEqual(expr.elements.count, 0)
   }
 
   func testTupleExprWithOneElement() throws {
-    let input = testCode("(42,)")
+    let input: SourceFile = "(42,)"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? TupleExpr)
     XCTAssertEqual(expr.elements.count, 1)
@@ -1280,21 +1260,21 @@ final class ParserTests: XCTestCase {
   }
 
   func testTupleExprWithMultipleElements() throws {
-    let input = testCode("((n, m), number: 42)")
+    let input: SourceFile = "((n, m), number: 42)"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? TupleExpr)
     XCTAssertEqual(expr.elements.count, 2)
   }
 
   func testTupleTypeExpr() throws {
-    let input = testCode("{}")
+    let input: SourceFile = "{}"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? TupleTypeExpr)
     XCTAssertEqual(expr.elements.count, 0)
   }
 
   func testTupleTypeExprWithOneElement() throws {
-    let input = testCode("{ T }")
+    let input: SourceFile = "{ T }"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? TupleTypeExpr)
     XCTAssertEqual(expr.elements.count, 1)
@@ -1305,21 +1285,21 @@ final class ParserTests: XCTestCase {
   }
 
   func testTupleTypeExprWithMultipleElements() throws {
-    let input = testCode("{ { T, U }, number: V }")
+    let input: SourceFile = "{ { T, U }, number: V }"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? TupleTypeExpr)
     XCTAssertEqual(expr.elements.count, 2)
   }
 
   func testLambdaOrParenthesizedTypeExpr() throws {
-    let input = testCode("((A) -> (B)) -> C")
+    let input: SourceFile = "((A) -> (B)) -> C"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? LambdaTypeExpr)
     XCTAssertEqual(expr.output.kind, .init(NameExpr.self))
   }
 
   func testLambdaTypeExpr() throws {
-    let input = testCode("[{ A, B }] (T, by: U) inout -> T")
+    let input: SourceFile = "[{ A, B }] (T, by: U) inout -> T"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? LambdaTypeExpr)
     XCTAssertEqual(expr.receiverEffect?.value, .inout)
@@ -1329,7 +1309,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testTypeErasedLambdaTypeExpr() throws {
-    let input = testCode("(T, by: U) inout -> T")
+    let input: SourceFile = "(T, by: U) inout -> T"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? LambdaTypeExpr)
     XCTAssertEqual(expr.receiverEffect?.value, .inout)
@@ -1339,7 +1319,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testThinLambdaTypeExpr() throws {
-    let input = testCode("[] () -> Int")
+    let input: SourceFile = "[] () -> Int"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? LambdaTypeExpr)
     XCTAssertNil(expr.receiverEffect)
@@ -1349,7 +1329,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testExistentialTypeExpr() throws {
-    let input = testCode("any T & U where T.Key == U.Value")
+    let input: SourceFile = "any T & U where T.Key == U.Value"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? ExistentialTypeExpr)
     XCTAssertEqual(expr.traits.count, 2)
@@ -1357,34 +1337,34 @@ final class ParserTests: XCTestCase {
   }
 
   func testParameterTypeExpr() throws {
-    let input = testCode("sink T")
+    let input: SourceFile = "sink T"
     let (exprID, ast) = try apply(Parser.parameterTypeExpr, on: input)
     let expr = try XCTUnwrap(ast[exprID])
     XCTAssertEqual(expr.convention.value, .sink)
   }
 
   func testImplicitLetParameterTypeExpr() throws {
-    let input = testCode("T")
+    let input: SourceFile = "T"
     let (exprID, ast) = try apply(Parser.parameterTypeExpr, on: input)
     let expr = try XCTUnwrap(ast[exprID])
     XCTAssertEqual(expr.convention.value, .let)
   }
 
   func testStaticArgumentList() throws {
-    let input = testCode("foo<T, size: 40 + two()>")
+    let input: SourceFile = "foo<T, size: 40 + two()>"
     let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
     let expr = try XCTUnwrap(ast[exprID] as? NameExpr)
     XCTAssertEqual(expr.arguments.count, 2)
   }
 
   func testWhereClause() throws {
-    let input = testCode("where T == B, U : A")
+    let input: SourceFile = "where T == B, U : A"
     let clause = try XCTUnwrap(try apply(Parser.whereClause, on: input).element)
     XCTAssertEqual(clause.value.constraints.count, 2)
   }
 
   func testWhereClauseEqualityConstraint() throws {
-    let input = testCode("T == { U, V }")
+    let input: SourceFile = "T == { U, V }"
     let constraint = try XCTUnwrap(try apply(Parser.typeConstraint, on: input).element)
     if case .equality(let lhs, let rhs) = constraint.value {
       XCTAssertEqual(lhs.kind, .init(NameExpr.self))
@@ -1395,7 +1375,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testWhereClauseConformanceConstraint() throws {
-    let input = testCode("T : U & V")
+    let input: SourceFile = "T : U & V"
     let constraint = try XCTUnwrap(try apply(Parser.typeConstraint, on: input).element)
     if case .conformance(let lhs, _) = constraint.value {
       XCTAssertEqual(lhs.kind, .init(NameExpr.self))
@@ -1405,7 +1385,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testWhereClauseValueConstraint() throws {
-    let input = testCode("@value x > 2")
+    let input: SourceFile = "@value x > 2"
     let constraint = try XCTUnwrap(try apply(Parser.valueConstraint, on: input).element)
     if case .value(let exprID) = constraint.value {
       XCTAssertEqual(exprID.kind, .init(SequenceExpr.self))
@@ -1415,7 +1395,7 @@ final class ParserTests: XCTestCase {
   }
 
   // func testWhereClauseValueConstraintSansHint() throws {
-  //   let input = testCode(  "x > 2")
+  //   let input: SourceFile = "x > 2"
   //   let constraint = try XCTUnwrap(try apply(Parser.valueConstraint, on: input).element)
   //   if case .value(let exprID) = constraint.value {
   //     XCTAssertEqual(exprID.kind, .init(SequenceExpr.self))
@@ -1425,7 +1405,7 @@ final class ParserTests: XCTestCase {
   // }
 
   func testTraitComposition() throws {
-    let input = testCode("T & U & V")
+    let input: SourceFile = "T & U & V"
     let list = try XCTUnwrap(try apply(Parser.traitComposition, on: input).element)
     XCTAssertEqual(list.count, 3)
   }
@@ -1433,7 +1413,7 @@ final class ParserTests: XCTestCase {
   // MARK: Patterns
 
   func testBindingPattern() throws {
-    let input = testCode("let (first: foo, second: (bar, _))")
+    let input: SourceFile = "let (first: foo, second: (bar, _))"
     let (p, ast) = try input.parse(with: Parser.parseBindingPattern(in:))
     let pattern = try XCTUnwrap(ast[p])
     XCTAssertEqual(pattern.introducer.value, .let)
@@ -1449,35 +1429,35 @@ final class ParserTests: XCTestCase {
   }
 
   func testBindingPatternWithAnnotation() throws {
-    let input = testCode("inout x: T)")
+    let input: SourceFile = "inout x: T)"
     let (p, ast) = try input.parse(with: Parser.parseBindingPattern(in:))
     let pattern = try XCTUnwrap(ast[p])
     XCTAssertNotNil(pattern.annotation)
   }
 
   func testExprPattern() throws {
-    let input = testCode("foo")
+    let input: SourceFile = "foo"
     let (patternID, ast) = try apply(Parser.exprPattern, on: input)
     let pattern = try XCTUnwrap(ast[patternID] as? ExprPattern)
     XCTAssertEqual(pattern.expr.kind, .init(NameExpr.self))
   }
 
   func testNamePattern() throws {
-    let input = testCode("foo")
+    let input: SourceFile = "foo"
     let (patternID, ast) = try apply(Parser.namePattern, on: input)
     let pattern = try XCTUnwrap(ast[patternID])
     XCTAssertEqual(ast[pattern.decl].baseName, "foo")
   }
 
   func testTuplePattern() throws {
-    let input = testCode("()")
+    let input: SourceFile = "()"
     let (patternID, ast) = try apply(Parser.tuplePattern, on: input)
     let pattern = try XCTUnwrap(ast[patternID])
     XCTAssertEqual(pattern.elements.count, 0)
   }
 
   func testTuplePatternWithOneElement() throws {
-    let input = testCode("(_)")
+    let input: SourceFile = "(_)"
     let (patternID, ast) = try apply(Parser.tuplePattern, on: input)
     let pattern = try XCTUnwrap(ast[patternID])
     XCTAssertEqual(pattern.elements.count, 1)
@@ -1488,115 +1468,114 @@ final class ParserTests: XCTestCase {
   }
 
   func testTuplePatternWithMultipleElements() throws {
-    let input = testCode("((n, m), number: 42)")
+    let input: SourceFile = "((n, m), number: 42)"
     let (patternID, ast) = try apply(Parser.tuplePattern, on: input)
     let pattern = try XCTUnwrap(ast[patternID])
     XCTAssertEqual(pattern.elements.count, 2)
   }
 
   func testWildcardPattern() throws {
-    let input = testCode("_")
+    let input: SourceFile = "_"
     XCTAssertNotNil(try apply(Parser.wildcardPattern, on: input))
   }
 
   // MARK: Statements
 
   func testAssignStmt() throws {
-    let input = testCode("foo = bar")
+    let input: SourceFile = "foo = bar"
     let (stmtID, ast) = try apply(Parser.stmt, on: input)
     XCTAssert(ast[stmtID] is AssignStmt)
   }
 
   func testBraceStmtEmpty() throws {
-    let input = testCode("{}")
+    let input: SourceFile = "{}"
     XCTAssertNotNil(try apply(Parser.braceStmt, on: input).element)
   }
 
   func testBraceStmtWithSemicolons() throws {
-    let input = testCode("{; ;;}")
+    let input: SourceFile = "{; ;;}"
     let (stmtID, ast) = try apply(Parser.braceStmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID])
     XCTAssertEqual(stmt.stmts.count, 0)
   }
 
   func testBraceStmtWithElements() throws {
-    let input = testCode(
-      """
+    let input: SourceFile = """
       {
         var x = 0; var y = 1
         print(x + y)
       }
-      """)
+      """
     let (stmtID, ast) = try apply(Parser.braceStmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID])
     XCTAssertEqual(stmt.stmts.count, 3)
   }
 
   func testDiscardStmt() throws {
-    let input = testCode("_ = foo()")
+    let input: SourceFile = "_ = foo()"
     XCTAssertNotNil(try apply(Parser.discardStmt, on: input).element)
   }
 
   func testDoWhileStmt() throws {
-    let input = testCode("do {} while true")
+    let input: SourceFile = "do {} while true"
     XCTAssertNotNil(try apply(Parser.doWhileStmt, on: input).element)
   }
 
   func testWhileStmt() throws {
-    let input = testCode("while true {}")
+    let input: SourceFile = "while true {}"
     let (stmtID, ast) = try apply(Parser.whileStmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID])
     XCTAssertEqual(stmt.condition.count, 1)
   }
 
   func testWhileStmtWithMultipleConditions() throws {
-    let input = testCode("while let x = foo(), x > 0 {}")
+    let input: SourceFile = "while let x = foo(), x > 0 {}"
     let (stmtID, ast) = try apply(Parser.whileStmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID])
     XCTAssertEqual(stmt.condition.count, 2)
   }
 
   func testForStmt() throws {
-    let input = testCode("for let x in array {}")
+    let input: SourceFile = "for let x in array {}"
     XCTAssertNotNil(try apply(Parser.forStmt, on: input))
   }
 
   func testForStmtWithFilter() throws {
-    let input = testCode("for let x in array where x > 2 {}")
+    let input: SourceFile = "for let x in array where x > 2 {}"
     let (stmtID, ast) = try apply(Parser.forStmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID])
     XCTAssertNotNil(stmt.filter)
   }
 
   func testReturnStmt() throws {
-    let input = testCode("return")
+    let input: SourceFile = "return"
     XCTAssertNotNil(try apply(Parser.returnStmt, on: input, context: .functionBody))
   }
 
   func testReturnStmtWithValue() throws {
-    let input = testCode("return 42")
+    let input: SourceFile = "return 42"
     let (stmtID, ast) = try apply(Parser.returnStmt, on: input, context: .functionBody)
     let stmt = try XCTUnwrap(ast[stmtID])
     XCTAssertNotNil(stmt.value)
   }
 
   func testYieldStmt() throws {
-    let input = testCode("yield &foo.bar")
+    let input: SourceFile = "yield &foo.bar"
     XCTAssertNotNil(try apply(Parser.yieldStmt, on: input, context: .subscriptBody))
   }
 
   func testBreak() throws {
-    let input = testCode("break")
+    let input: SourceFile = "break"
     XCTAssertNotNil(try apply(Parser.breakStmt, on: input, context: .loopBody))
   }
 
   func testContinue() throws {
-    let input = testCode("continue")
+    let input: SourceFile = "continue"
     XCTAssertNotNil(try apply(Parser.continueStmt, on: input, context: .loopBody))
   }
 
   func testConditionalBinding() throws {
-    let input = testCode("var x = foo() else return")
+    let input: SourceFile = "var x = foo() else return"
     let (stmtID, ast) = try apply(
       Parser.conditionalBindingStmt, on: input, context: .functionBody)
     let stmt = try XCTUnwrap(ast[stmtID])
@@ -1607,7 +1586,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testConditionalBindingBlock() throws {
-    let input = testCode("var x = foo() else { bar(); return }")
+    let input: SourceFile = "var x = foo() else { bar(); return }"
     let (stmtID, ast) = try apply(
       Parser.conditionalBindingStmt, on: input, context: .functionBody)
     let stmt = try XCTUnwrap(ast[stmtID])
@@ -1618,7 +1597,7 @@ final class ParserTests: XCTestCase {
   }
 
   func testConditionalBindingExpr() throws {
-    let input = testCode("var x = foo() else fatal_error()")
+    let input: SourceFile = "var x = foo() else fatal_error()"
     let (stmtID, ast) = try apply(Parser.conditionalBindingStmt, on: input)
     let stmt = try XCTUnwrap(ast[stmtID])
     if case .expr = stmt.fallback {
@@ -1628,26 +1607,24 @@ final class ParserTests: XCTestCase {
   }
 
   func testConditionalBindingFallback() throws {
-    let input = testCode("return")
-    XCTAssertNotNil(
-      try apply(
-        Parser.conditionalBindingStmt, on: input, context: .functionBody))
+    let input: SourceFile = "return"
+    XCTAssertNotNil(try apply(Parser.conditionalBindingStmt, on: input, context: .functionBody))
   }
 
   func testDeclStmt() throws {
-    let input = testCode("typealias X = A")
+    let input: SourceFile = "typealias X = A"
     XCTAssertNotNil(try apply(Parser.declStmt, on: input))
   }
 
   func testExprStmt() throws {
-    let input = testCode("foo()")
+    let input: SourceFile = "foo()"
     XCTAssertNotNil(try apply(Parser.exprStmt, on: input))
   }
 
   // MARK: Operators
 
   func testTakeOperator() throws {
-    let input = testCode("+ & == | < <= > >=")
+    let input: SourceFile = "+ & == | < <= > >="
     var context = ParserState(ast: AST(), lexer: Lexer(tokenizing: input))
     XCTAssertEqual(context.takeOperator()?.value, "+")
     XCTAssertEqual(context.takeOperator()?.value, "&")
@@ -1662,14 +1639,14 @@ final class ParserTests: XCTestCase {
   // MARK: Attributes
 
   func testDeclAttribute() throws {
-    let input = testCode("@attr")
+    let input: SourceFile = "@attr"
     let attribute = try XCTUnwrap(input.parse(with: Parser.parseDeclAttribute).element)
     XCTAssertEqual(attribute.value.name.value, "@attr")
     XCTAssertEqual(attribute.value.arguments.count, 0)
   }
 
   func testDeclAttributeWithArguments() throws {
-    let input = testCode(#"@attr(8, "Val")"#)
+    let input: SourceFile = #"@attr(8, "Val")"#
     let attribute = try XCTUnwrap(input.parse(with: Parser.parseDeclAttribute).element)
     XCTAssertEqual(attribute.value.name.value, "@attr")
     XCTAssertEqual(attribute.value.arguments.count, 2)

--- a/Tests/ValTests/SourceFileTests.swift
+++ b/Tests/ValTests/SourceFileTests.swift
@@ -4,14 +4,13 @@ import XCTest
 final class SourceFileTests: XCTestCase {
 
   func testLocationConversion() {
-    let source = testCode(
-      """
+    let source: SourceFile = """
       import Greetings
 
       public fun main() {
         print("Hello, World!")
       }
-      """)
+      """
 
     for position in source.text.indices {
       let x = source.position(position)

--- a/Tests/ValTests/Utils/TestFile.swift
+++ b/Tests/ValTests/Utils/TestFile.swift
@@ -1,6 +1,0 @@
-import Core
-
-/// Returns a synthesized source file having the given `contents`.
-func testCode(_ contents: String) -> SourceFile {
-  SourceFile(synthesizedText: contents)
-}


### PR DESCRIPTION
Using `testCode(_:)` instead of `SourceFile.init(synthesized:)` doesn't seem to improve call sites so much, yet it costs an additional free function that can only be used in the `ValTests` target. It is also not obvious what the result of this function is; it doesn't actually test anything, it only creates a source file with the given text.

The changes make `SourceFile` conform to `ExpressibleByStringLiteral` so that we can write:
```swift
let s: SourceFile = """
  import Foo
  fun main() {}
  """
```