### PR TITLE
Simplify sequence transformations requiring AST access

### DIFF
--- a/Sources/Core/AST/AST.swift
+++ b/Sources/Core/AST/AST.swift
@@ -105,6 +105,17 @@ public struct AST {
     position.map({ nodes[$0.rawValue].node })
   }
 
+  /// A sequence of concrete nodes projected from an AST.
+  public typealias ConcreteProjectedSequence<T> = LazyMapSequence<
+    LazySequence<T>.Elements,
+    T.Element.Subject
+  > where T: Sequence, T.Element: ConcreteNodeID
+
+  /// Projects a sequence containing the nodes at `positions`.
+  public subscript<T: Sequence>(positions: T) -> ConcreteProjectedSequence<T> {
+    positions.lazy.map({ (n) in self[n] })
+  }
+
   // MARK: Core library
 
   /// Indicates whether the Core library has been loaded.

--- a/Sources/Core/AST/AST.swift
+++ b/Sources/Core/AST/AST.swift
@@ -167,10 +167,7 @@ public struct AST {
 
   /// Returns the IDs of the top-level declarations in the lexical scope of `module`.
   public func topLevelDecls(_ module: NodeID<ModuleDecl>) -> TopLevelDecls {
-    let a = self[module].sources.lazy
-      .map({ self[$0].decls })
-      .joined()
-    return a
+    self[self[module].sources].map(\.decls).joined()
   }
 
   /// Returns the IDs of the named patterns contained in `pattern`.

--- a/Sources/Core/AST/Name.swift
+++ b/Sources/Core/AST/Name.swift
@@ -43,7 +43,7 @@ public struct Name: Hashable, Codable {
     if let notation = ast[decl].notation?.value {
       self.init(stem: stem, notation: notation)
     } else {
-      self.init(stem: stem, labels: ast[decl].parameters.map({ ast[$0].label?.value }))
+      self.init(stem: stem, labels: ast[ast[decl].parameters].map(\.label?.value))
     }
   }
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -3009,13 +3009,12 @@ public struct TypeChecker {
     }
 
     // Create a method bundle.
-    let capabilities = Set(program.ast[id].impls.map({ program.ast[$0].introducer.value }))
+    let capabilities = Set(program.ast[program.ast[id].impls].map(\.introducer.value))
     if capabilities.contains(.inout) && (outputType != receiver) {
-      let range =
-        program.ast[id].output.map({ (output) in
-          program.ast[output].site
-        }) ?? program.ast[id].introducerSite
-      diagnostics.insert(.error(inoutCapableMethodBundleMustReturn: receiver, at: range))
+      diagnostics.insert(
+        .error(
+          inoutCapableMethodBundleMustReturn: receiver,
+          at: program.ast[program.ast[id].output]?.site ?? program.ast[id].introducerSite))
       return .error
     }
 
@@ -3116,7 +3115,7 @@ public struct TypeChecker {
     }
 
     // Create a subscript type.
-    let capabilities = Set(program.ast[id].impls.map({ program.ast[$0].introducer.value }))
+    let capabilities = Set(program.ast[program.ast[id].impls].map(\.introducer.value))
     return ^SubscriptType(
       isProperty: program.ast[id].parameters == nil,
       capabilities: capabilities,
@@ -3494,23 +3493,23 @@ public struct TypeChecker {
   private mutating func labels(_ d: AnyDeclID) -> [String?] {
     switch d.kind {
     case FunctionDecl.self:
-      return program.ast[NodeID<FunctionDecl>(d)!]
-        .parameters
-        .map({ (p) in program.ast[p].label?.value })
+      let i = NodeID<FunctionDecl>(d)!
+      return program.ast[program.ast[i].parameters].map(\.label?.value)
 
     case InitializerDecl.self:
-      return LambdaType(realize(initializerDecl: NodeID(d)!))
-        .map({ (t) in t.inputs.map(\.label) }) ?? []
+      if let t = LambdaType(realize(initializerDecl: NodeID(d)!)) {
+        return t.inputs.map(\.label)
+      } else {
+        return []
+      }
 
     case MethodDecl.self:
-      return program.ast[NodeID<MethodDecl>(d)!]
-        .parameters
-        .map({ (p) in program.ast[p].label?.value })
+      let i = NodeID<MethodDecl>(d)!
+      return program.ast[program.ast[i].parameters].map(\.label?.value)
 
     case SubscriptDecl.self:
-      return program.ast[NodeID<SubscriptDecl>(d)!]
-        .parameters
-        .map({ (ps) in ps.map({ (p) in program.ast[p].label?.value }) }) ?? []
+      let i = NodeID<SubscriptDecl>(d)!
+      return program.ast[program.ast[i].parameters ?? []].map(\.label?.value)
 
     default:
       return []


### PR DESCRIPTION
This PR introduces a subscript on `AST` to project a sequence of nodes given their positions. The goal is to avoid the following recurring pattern, which mostly occurs in the type checker:
```swift
let labels = program.ast[n].parameters.map({ program.ast[$0].label?.value })
```
The new subscript makes it possible to write:
```swift
let labels = program.ast[program.ast[n]].map(\.label?.value)
```

I was hoping for more code reduction, but I think the patch still improves a handful of use sites.