### PR TITLE
Rename 'TypeChecker.decl(_:named)' to 'decl(in:named:)'

### DIFF
--- a/Sources/FrontEnd/TypeChecking/ConstraintSolver.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSolver.swift
@@ -424,7 +424,7 @@ struct ConstraintSolver {
     }
 
     let matches = checker.lookup(goal.memberName.stem, memberOf: goal.subject, in: scope)
-      .compactMap({ checker.decl($0, named: goal.memberName) })
+      .compactMap({ checker.decl(in: $0, named: goal.memberName) })
 
     // Generate the list of candidates.
     let candidates = matches.compactMap({ (match) -> OverloadConstraint.Candidate? in

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1798,10 +1798,10 @@ public struct TypeChecker {
     let matches: [AnyDeclID]
     if let t = parentType {
       matches = lookup(name.value.stem, memberOf: t, in: lookupScope)
-        .compactMap({ decl($0, named: name.value) })
+        .compactMap({ decl(in: $0, named: name.value) })
     } else {
       matches = lookup(unqualified: name.value.stem, in: lookupScope)
-        .compactMap({ decl($0, named: name.value) })
+        .compactMap({ decl(in: $0, named: name.value) })
     }
 
     // Diagnose undefined symbols.
@@ -3467,7 +3467,7 @@ public struct TypeChecker {
   /// if no such implementation exists.
   ///
   /// - Requires: The base name of `d` is equal to `n.stem`
-  mutating func decl(_ d: AnyDeclID, named n: Name) -> AnyDeclID? {
+  mutating func decl(in d: AnyDeclID, named n: Name) -> AnyDeclID? {
     if !n.labels.isEmpty && (n.labels != labels(d)) {
       return nil
     }


### PR DESCRIPTION
Implements #299