### PR TITLE
Test lowering of while loops

### DIFF
--- a/Tests/ValTests/TestCases/Lowering/Loops.val
+++ b/Tests/ValTests/TestCases/Lowering/Loops.val
@@ -1,7 +1,13 @@
 //! expect-success
 
+fun foo() {}
+
 public fun main() {
   do {
     let x = true
   } while x
+
+  while true, true {
+    foo()
+  }
 }


### PR DESCRIPTION
The new test is currently crashing the compiler because of a bug in the definite initialization pass.