### PR TITLE
Fix specialization

### DIFF
--- a/Sources/Core/Types/AnyType.swift
+++ b/Sources/Core/Types/AnyType.swift
@@ -130,28 +130,6 @@ public struct AnyType: TypeProtocol {
 
   public var skolemized: AnyType { base.skolemized }
 
-  /// Returns a copy of this type with generic parameters keying `subtitutions` replaced by their
-  /// corresponding value.
-  public func specialized(_ substitutions: [NodeID<GenericParameterDecl>: AnyType]) -> AnyType {
-    func _impl(type: AnyType) -> TypeTransformAction {
-      // Substitute parameters.
-      if let base = GenericTypeParameterType(type),
-        let decl = NodeID<GenericParameterDecl>(base.decl)
-      {
-        return .stepOver(substitutions[decl, default: type])
-      }
-
-      // Don't visit the interior of `type` if it doesn't contain generic type parameters.
-      if type[.hasGenericTypeParameter] {
-        return .stepInto(type)
-      } else {
-        return .stepOver(type)
-      }
-    }
-
-    return transform(_impl(type:))
-  }
-
   public func transformParts(_ transformer: (AnyType) -> TypeTransformAction) -> AnyType {
     AnyType(wrapped.transformParts(transformer))
   }

--- a/Sources/Core/Types/AssociatedTypeType.swift
+++ b/Sources/Core/Types/AssociatedTypeType.swift
@@ -6,9 +6,9 @@ public struct AssociatedTypeType: TypeProtocol {
   /// The declaration that introduces the associated type in the parent trait.
   public let decl: NodeID<AssociatedTypeDecl>
 
-  /// The domain of an associated type.
+  /// The type whose `self` is member.
   ///
-  /// The domain is either an associated type, a conformance lens, or a generic type parameter.
+  /// `domain` is either an associated type, a conformance lens, or a generic type parameter.
   public let domain: AnyType
 
   /// The name of the associated type.
@@ -30,30 +30,6 @@ public struct AssociatedTypeType: TypeProtocol {
   }
 
   public var flags: TypeFlags { .isCanonical }
-
-  /// An array whose `i+1`-th element is the parent type of the `i`-th element. `components[0]` is
-  /// always `self`.
-  public var components: [AnyType] {
-    var current = ^self
-    var result = [current]
-
-    while true {
-      switch current.base {
-      case is GenericTypeParameterType:
-        return result
-
-      case let type as AssociatedTypeType:
-        current = type.domain
-        result.append(type.domain)
-
-      case let type as ConformanceLensType:
-        current = type.subject
-
-      default:
-        unreachable()
-      }
-    }
-  }
 
 }
 

--- a/Sources/Core/Types/GenericTypeParameterType.swift
+++ b/Sources/Core/Types/GenericTypeParameterType.swift
@@ -4,32 +4,20 @@ import Utils
 public struct GenericTypeParameterType: TypeProtocol {
 
   /// The declaration that introduces the parameter.
-  ///
-  /// - Note: The ID may denote the declaration of a generic type parameter or associated type.
-  public let decl: AnyDeclID
+  public let decl: NodeID<GenericParameterDecl>
 
   /// The name of the parameter.
   public let name: Incidental<String>
 
   /// Creates an instance denoting the generic type parameter declared by `decl`.
-  public init(_ decl: NodeID<AssociatedTypeDecl>, ast: AST) {
-    self.init(decl: AnyDeclID(decl), name: ast[decl].baseName)
-  }
-
-  /// Creates an instance denoting the generic type parameter declared by `decl`.
   public init(_ decl: NodeID<GenericParameterDecl>, ast: AST) {
-    self.init(decl: AnyDeclID(decl), name: ast[decl].baseName)
+    self.decl = decl
+    self.name = Incidental(ast[decl].baseName)
   }
 
   /// Creates an instance denoting the `Self` parameter of `trait`.
   public init(selfParameterOf trait: NodeID<TraitDecl>, in ast: AST) {
     self.init(ast[trait].selfParameterDecl, ast: ast)
-  }
-
-  /// Creates an instance denoting the generic type parameter declared by `decl`.
-  private init(decl: AnyDeclID, name: String) {
-    self.decl = decl
-    self.name = Incidental(name)
   }
 
   public var flags: TypeFlags { [.isCanonical, .hasGenericTypeParameter] }

--- a/Sources/Core/Types/InstantiatedType.swift
+++ b/Sources/Core/Types/InstantiatedType.swift
@@ -19,16 +19,4 @@ public struct InstantiatedType: Hashable {
     self.constraints = constraints
   }
 
-  /// Returns a copy of this type with generic type parameters keying `subtitutions` replaced by
-  /// their corresponding value.
-  public func specialized(_ substitutions: [NodeID<GenericParameterDecl>: AnyType]) -> Self {
-    .init(
-      shape: shape.specialized(substitutions),
-      constraints:
-        ConstraintSet(
-          constraints.map({ (c) -> Constraint in
-            c.modifyingTypes({ $0.specialized(substitutions) })
-          })))
-  }
-
 }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -47,6 +47,36 @@ public struct TypeChecker {
 
   // MARK: Type system
 
+  /// Returns a copy of `genericType` where occurrences of generic parameters keying `subtitutions`
+  /// are replaced by their corresponding value, performing any necessary name lookup in `scope`.
+  private mutating func specialized(
+    _ genericType: AnyType,
+    applying substitutions: [GenericTypeParameterType: AnyType],
+    in scope: AnyScopeID
+  ) -> AnyType {
+    func _impl(t: AnyType) -> TypeTransformAction {
+      switch t.base {
+      case let p as GenericTypeParameterType:
+        return .stepOver(substitutions[p] ?? t)
+
+      case let t as AssociatedTypeType:
+        let d = t.domain.transform(_impl)
+
+        let candidates = lookup(program.ast[t.decl].baseName, memberOf: d, in: scope)
+        if let c = candidates.uniqueElement {
+          return .stepOver(MetatypeType(realize(decl: c))?.instance ?? .error)
+        } else {
+          return .stepOver(.error)
+        }
+
+      default:
+        return .stepInto(t)
+      }
+    }
+
+    return genericType.transform(_impl(t:))
+  }
+
   /// Returns whether `lhs` is canonically equivalent to `rhs`.
   public func areEquivalent(_ lhs: AnyType, _ rhs: AnyType) -> Bool {
     canonicalize(type: lhs) == canonicalize(type: rhs)
@@ -845,7 +875,9 @@ public struct TypeChecker {
     to trait: TraitType
   ) -> Bool {
     let conformingType = realizeSelfTypeExpr(in: decl)!.instance
-    let selfType = ^GenericTypeParameterType(selfParameterOf: trait.decl, in: program.ast)
+    let g = GenericTypeParameterType(selfParameterOf: trait.decl, in: program.ast)
+    let specialization = [g: conformingType]
+
     var success = true
 
     // Get the set of generic parameters defined by `trait`.
@@ -865,67 +897,10 @@ public struct TypeChecker {
       case FunctionDecl.self:
         // Make sure the requirement is well-typed.
         let requirement = NodeID<FunctionDecl>(j)!
-        var requirementType = canonicalize(type: realize(functionDecl: requirement))
-
-        /// Substitute `Self` by the conforming type in `type`.
-        func substituteSelf(type: AnyType) -> TypeTransformAction {
-          switch type.base {
-          case selfType:
-            // `type` is `Self`.
-            return .stepOver(conformingType)
-
-          case let t as AssociatedTypeType:
-            // We only care about associated types rooted at `Self`. Others can be assumed to be
-            // rooted at some generic type parameter declared by the requirement.
-            let components = t.components
-            if components.last != selfType { return .stepOver(type) }
-
-            let scope = AnyScopeID(decl)
-            let replacement =
-              components
-              .dropLast(1)
-              .reversed()
-              .reduce(
-                into: conformingType,
-                { (r, c) in
-                  if r.isError { return }
-
-                  switch c.base {
-                  case let c as AssociatedTypeType:
-                    let candidates = lookup(
-                      program.ast[c.decl].baseName, memberOf: r, in: scope)
-
-                    // Name is ambiguous if there's more than one candidate.
-                    if candidates.count != 1 {
-                      r = .error
-                      return
-                    }
-
-                    // Name should refer to a type.
-                    let candidateValue = realize(decl: candidates.first!)
-                    guard let type = (candidateValue.base as? MetatypeType)?.instance else {
-                      r = .error
-                      return
-                    }
-
-                    // FIXME: If `type` is a bound generic type, substitute generic type parameters.
-                    r = type
-
-                  case is ConformanceLensType:
-                    fatalError("not implemented")
-
-                  default:
-                    unreachable()
-                  }
-                })
-            return .stepOver(replacement)
-
-          default:
-            return .stepInto(type)
-          }
-        }
-
-        requirementType = requirementType.transform(substituteSelf(type:))
+        let requirementType = specialized(
+          canonicalize(type: realize(functionDecl: requirement)),
+          applying: specialization,
+          in: AnyScopeID(decl))
         if requirementType.isError { continue }
 
         // Search for candidate implementations.


### PR DESCRIPTION
`AnyType.specialized` had a bug that create ill-formed associated types.