### PR TITLE
Update `windows-tag` of Swift in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
           { type: windows, os: windows-latest },
         ]
         swift: [
-          { version: "5.7", windows-branch: "swift-5.8-branch", windows-tag: "5.8-DEVELOPMENT-SNAPSHOT-2023-02-09-a" }
+          { version: "5.7", windows-branch: "development", windows-tag: "DEVELOPMENT-SNAPSHOT-2023-02-14-a" }
         ]
     runs-on: ${{ matrix.host.os }}
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
           { type: windows, os: windows-latest },
         ]
         swift: [
-          { version: "5.7", windows-branch: "swift-5.8-branch", windows-tag: "5.8-DEVELOPMENT-SNAPSHOT-2022-12-29-a" }
+          { version: "5.7", windows-branch: "swift-5.8-branch", windows-tag: "5.8-DEVELOPMENT-SNAPSHOT-2023-02-09-a" }
         ]
     runs-on: ${{ matrix.host.os }}
     steps:


### PR DESCRIPTION
Windows CI fails too often. Perhaps try updating Swift for Windows again?