### PR TITLE
Fix printed format of Diagnostic so it is recognized by IDE(mac)s.

### DIFF
--- a/Sources/Core/Diagnostic.swift
+++ b/Sources/Core/Diagnostic.swift
@@ -61,7 +61,7 @@ extension Diagnostic: CustomStringConvertible {
     let prefix: String
     let l = site.first()
     let (line, column) = l.lineAndColumn
-    prefix = "\(l.file.url):\(line):\(column): "
+    prefix = "\(l.file.url.standardizedFileURL.path):\(line):\(column): "
     return prefix + "\(level): \(message)"
   }
 


### PR DESCRIPTION
Fixes #326.  Please don't fight me on this; capturing these so they show up nicely in XCode is a separate step and must be done explicitly.