### PR TITLE
Diagnosable sourcefile literals for testing

### DIFF
--- a/Sources/Core/SourceFile.swift
+++ b/Sources/Core/SourceFile.swift
@@ -358,7 +358,7 @@ extension SourceFile {
       // This could be supported, with caveats, but it's not necessarily a good idea.
       precondition(
         text.startIndex == text.base.startIndex && text.endIndex == text.base.endIndex,
-        "Serialization of Val source embedded in Swift string literals is not supported."
+        "Serialization of SourceFile.diagnosableLiteral results is not supported."
       )
       try container.encode(Encoding(url: url, text: text.base))
     }

--- a/Sources/Core/SourceFile.swift
+++ b/Sources/Core/SourceFile.swift
@@ -1,11 +1,8 @@
 import Foundation
 import Utils
 
-/// A Val source file, a synthesized fragment of Val source, or a "source file" embedded in a Swift
-/// string literal.
-///
-/// - Note: Serialization of SourceFiles derived from Swift string literals is not currently
-///   supported.
+/// A Val source file, a synthesized fragment of Val source, or a fragment of Val source embedded in
+/// a Swift string literal.
 public struct SourceFile {
 
   /// The notional stored properties of `self`; distinguished for encoding/decoding purposes.

--- a/Sources/Core/SourceFile.swift
+++ b/Sources/Core/SourceFile.swift
@@ -14,8 +14,6 @@ public struct SourceFile {
   public typealias Index = String.Index
 
   /// The contents of the source file.
-  ///
-  /// - Note: except for
   public var text: Substring { storage.text }
 
   /// The URL of the source file.
@@ -34,12 +32,12 @@ public struct SourceFile {
   /// `swiftFile`, the literal's textual content (the line after the opening quotes) being
   /// startLine.
   ///
-  /// N.B. The text of the instance will literally be what's in the Swift file, including its
+  /// The text of the instance will literally be what's in the Swift file, including its
   /// indentation and any embedded special characters, even if the literal itself is not a raw
   /// literal or has had indentation stripped by the Swift compiler.
-  fileprivate init(diagnosableLiteral text: String, swiftFile: String, startLine: Int)
-    throws
-  {
+  fileprivate init(
+    diagnosableLiteral text: String, swiftFile: String, startLine: Int
+  ) throws {
     let wholeFile = try SourceFile(contentsOf: URL(fileURLWithPath: swiftFile))
     let endLine = startLine + text.lazy.filter(\.isNewline).count
     let fragment = URL(string: "\(wholeFile.url.absoluteString)#L\(startLine)-L\(endLine)")!
@@ -162,9 +160,9 @@ extension SourceFile {
   /// Returns a SourceFile containing the given text of a multiline string literal, such that
   /// diagnostics produced in processing that file will point back to the original Swift source.
   ///
-  /// N.B. The text of the result will literally be what's in the Swift file, including its
+  /// The text of the result will literally be what's in the Swift file, including its
   /// indentation and any embedded special characters, even if the literal itself is not a raw
-  /// literal or has had indentation stripped by the Swift compiler.  It is assumed that the first
+  /// literal or has had indentation stripped by the Swift compiler. It is assumed that the first
   /// line of the string literal's content is two lines below `invocationLine`, which is consistent
   /// with this project's formatting standard.
   ///

--- a/Sources/Core/SourceFile.swift
+++ b/Sources/Core/SourceFile.swift
@@ -34,14 +34,17 @@ public struct SourceFile {
   }
 
   /// Creates an instance for the given `text` embedded in a multiline string literal in the given
-  /// `swiftFile` at `startLine`.
+  /// `swiftFile` at `swiftLine`.
   ///
   /// The actual text processed will be what's read from the file, regardless of what's in `text`.
   /// That means if you're going to use any special characters in the literal, the literal should be
   /// a raw string literal to avoid confusion.
-  fileprivate init(literal text: String, swiftFile: String = #filePath, startLine: Int = #line)
+  fileprivate init(
+    diagnosableLiteral text: String, swiftFile: String = #filePath, swiftLine: Int = #line
+  )
     throws
   {
+    let startLine = swiftLine + 2  // Account for typical source code formatting
     let wholeFile = try SourceFile(contentsOf: URL(fileURLWithPath: swiftFile))
     let endLine = startLine + text.lazy.filter(\.isNewline).count
     let fragment = URL(string: "\(wholeFile.url.absoluteString)#L\(startLine)-L\(endLine)")!
@@ -161,10 +164,12 @@ public struct SourceFile {
 
 extension SourceFile {
 
-  public static func diagnosable(
-    _ text: String, swiftFile: String = #filePath, startLine: Int = #line
+  /// Returns a SourceFile containing the given text of a multiline string literal, such that
+  /// diagnostics produced in processing that file will point back to the original Swift source.
+  public static func diagnosableLiteral(
+    _ multilineLiteralText: String, swiftFile: String = #filePath, startLine: Int = #line
   ) -> SourceFile {
-    try! .init(literal: text, swiftFile: swiftFile, startLine: startLine)
+    try! .init(diagnosableLiteral: multilineLiteralText, swiftFile: swiftFile, swiftLine: startLine)
   }
 
 }

--- a/Tests/ValTests/CaptureCollectorTests.swift
+++ b/Tests/ValTests/CaptureCollectorTests.swift
@@ -6,7 +6,8 @@ import XCTest
 final class CaptureCollectorTests: XCTestCase {
 
   func testFunctionBindings() throws {
-    let source: SourceFile = """
+    let source = SourceFile.diagnosableLiteral(
+      """
       fun f<X, v: Void>[let c = ()](_ p: Any) {
         let _ = free   // captured
         let _ = X      // bound
@@ -14,7 +15,7 @@ final class CaptureCollectorTests: XCTestCase {
         let _ = c      // bound
         let _ = p      // bound
       }
-      """
+      """)
 
     var ast = AST()
     var diagnostics = DiagnosticSet()

--- a/Tests/ValTests/ParserTests.swift
+++ b/Tests/ValTests/ParserTests.swift
@@ -19,11 +19,12 @@ final class ParserTests: XCTestCase {
   // MARK: Unit tests
 
   func testParse() throws {
-    let input: SourceFile = """
+    let input = SourceFile.diagnosableLiteral(
+      """
       public fun main() {
         print("Hello, World!")
       }
-      """
+      """)
 
     var a = AST()
     var d = DiagnosticSet()
@@ -32,7 +33,8 @@ final class ParserTests: XCTestCase {
   }
 
   func testSourceFile() throws {
-    let input: SourceFile = """
+    let input = SourceFile.diagnosableLiteral(
+      """
         ;;
         import Foo
 
@@ -41,7 +43,7 @@ final class ParserTests: XCTestCase {
 
         let x = "Hello!"
         public let y = 0;
-      """
+      """)
 
     var a = AST()
     var d = DiagnosticSet()


### PR DESCRIPTION
During testing, allows unexpected diagnostic reports from Val source code in Swift multiline string literals to point back at the exact place in the original String literal where the problem occurred.

If you insert errors into the source that's now constructed with `SourceFile.diagnosableLiteral` you can see the results for yourself.