### PR TITLE
Refactor conformance enumeration

### DIFF
--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -257,7 +257,7 @@ struct ConstraintSystem {
 
     default:
       missingTraits = goal.traits.subtracting(
-        checker.conformedTraits(of: goal.subject, in: scope) ?? [])
+        checker.conformedTraits(of: goal.subject, in: scope))
     }
 
     if missingTraits.isEmpty {
@@ -286,8 +286,7 @@ struct ConstraintSystem {
       return nil
     }
 
-    let t = checker.conformedTraits(of: goal.subject, in: scope) ?? []
-    if t.contains(goal.literal) {
+    if checker.conformedTraits(of: goal.subject, in: scope).contains(goal.literal) {
       // Add a penalty if `L` isn't `D`.
       penalties += 1
       return .success

--- a/Sources/FrontEnd/TypeChecking/GenericEnvironment.swift
+++ b/Sources/FrontEnd/TypeChecking/GenericEnvironment.swift
@@ -40,11 +40,8 @@ struct GenericEnvironment {
         registerEquivalence(l: equality.left, r: equality.right)
 
       case let conformance as ConformanceConstraint:
-        var allTraits: Set<TraitType> = []
-        for trait in conformance.traits {
-          guard let bases = checker.conformedTraits(of: ^trait, in: scope)
-          else { return nil }
-          allTraits.formUnion(bases)
+        let allTraits: Set<TraitType> = conformance.traits.reduce(into: []) { (r, t) in
+          r.formUnion(checker.conformedTraits(of: ^t, in: scope))
         }
         registerConformance(l: conformance.subject, traits: allTraits)
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1416,12 +1416,12 @@ public struct TypeChecker {
     for member in ast[id].members {
       switch member.kind {
       case AssociatedTypeDecl.self:
-        success &= associatedConstraints(
-          ofType: NodeID(member)!, ofTrait: id, into: &constraints)
+        success &= appendAssociatedTypeConstraints(
+          of: NodeID(member)!, declaredIn: id, to: &constraints)
 
       case AssociatedValueDecl.self:
-        success &= associatedConstraints(
-          ofValue: NodeID(member)!, ofTrait: id, into: &constraints)
+        success &= appendAssociatedValueConstraints(
+          of: NodeID(member)!, declaredIn: id, to: &constraints)
 
       default:
         continue
@@ -1449,12 +1449,12 @@ public struct TypeChecker {
     return e
   }
 
-  /// Evaluates the valid constraints declared in `associatedType`, stores them in `constraints`,
+  /// Evaluates the valid constraints declared in `associatedType`, adds them to `constraints`,
   /// and returns whether they are all well-typed.
-  private mutating func associatedConstraints(
-    ofType associatedType: AssociatedTypeDecl.ID,
-    ofTrait trait: TraitDecl.ID,
-    into constraints: inout [Constraint]
+  private mutating func appendAssociatedTypeConstraints(
+    of associatedType: AssociatedTypeDecl.ID,
+    declaredIn trait: TraitDecl.ID,
+    to constraints: inout [Constraint]
   ) -> Bool {
     // Realize the LHS of the constraint.
     let lhs = realize(decl: associatedType)
@@ -1488,12 +1488,12 @@ public struct TypeChecker {
     return success
   }
 
-  // Evaluates the constraints declared in `associatedValue`, stores them in `constraints` and
-  // returns whether they are all well-typed.
-  private mutating func associatedConstraints(
-    ofValue associatedValue: AssociatedValueDecl.ID,
-    ofTrait trait: TraitDecl.ID,
-    into constraints: inout [Constraint]
+  /// Evaluates the valid constraints declared in `associatedValue`, adds them to `constraints`,
+  /// and returns whether they are all well-typed.
+  private mutating func appendAssociatedValueConstraints(
+    of associatedValue: AssociatedValueDecl.ID,
+    declaredIn trait: TraitDecl.ID,
+    to constraints: inout [Constraint]
   ) -> Bool {
     // Realize the LHS of the constraint.
     if realize(decl: associatedValue).isError { return false }


### PR DESCRIPTION
Before this PR, `TypeChecker.conformedTraits(of:in:)` and `TypeChecker.realize(conformances:in:)` would return `nil` as soon as they encountered an invalid type expression, compelling all call sites to unwrap the result. 
