### PR TITLE
Factor out support for abstract interpretation

### DIFF
--- a/Sources/IR/Analysis/AbstractContext.swift
+++ b/Sources/IR/Analysis/AbstractContext.swift
@@ -1,0 +1,88 @@
+import Utils
+
+/// The evaluation context of an abstract interpreter.
+struct AbstractContext<Domain: AbstractDomain>: Equatable {
+
+  /// The values of the locals.
+  var locals: [FunctionLocal: AbstractValue<Domain>] = [:]
+
+  /// The state of the memory.
+  var memory: [AbstractLocation: AbstractObject<Domain>] = [:]
+
+  /// Creates an empty context.
+  init() {}
+
+  /// Forms a context by merging the contexts in `batch`.
+  init<C: Collection<Self>>(merging batch: C) {
+    if let (h, t) = batch.headAndTail {
+      self = t.reduce(into: h, { $0.merge($1) })
+    } else {
+      self.init()
+    }
+  }
+
+  /// Merges `other` into `self`.
+  mutating func merge(_ other: Self) {
+    // Merge the locals.
+    for (key, lhs) in locals {
+      // Ignore definitions that don't dominate the block.
+      guard let rhs = other.locals[key] else {
+        locals[key] = nil
+        continue
+      }
+
+      // Merge both values conservatively.
+      locals[key] = lhs && rhs
+    }
+
+    // Merge the state of the objects in memory.
+    memory.merge(other.memory, uniquingKeysWith: &&)
+  }
+
+  /// Calls `action` with a projection of the objects at the locations assigned to `local`.
+  ///
+  /// - Requires: `locals[k]` is `.locations`.
+  mutating func forEachObject(
+    at k: FunctionLocal,
+    _ action: (inout AbstractObject<Domain>) -> Void
+  ) {
+    for l in locals[k]!.unwrapLocations()! {
+      withObject(at: l, action)
+    }
+  }
+
+  /// Returns the result calling `action` with a projection of the object at `location`.
+  mutating func withObject<T>(
+    at location: AbstractLocation,
+    _ action: (inout AbstractObject<Domain>) -> T
+  ) -> T {
+    switch location {
+    case .null:
+      preconditionFailure("null location")
+
+    case .argument, .instruction:
+      return action(&memory[location]!)
+
+    case .sublocation(let rootLocation, let path):
+      if path.isEmpty {
+        return action(&memory[location]!)
+      } else {
+        return modifying(&memory[rootLocation]!, { $0.withSubobject(at: path, action) })
+      }
+    }
+  }
+
+}
+
+extension AbstractContext: CustomStringConvertible {
+
+  var description: String {
+    """
+    locals:
+    \(locals.map({ "- \($0): \($1)" }).joined(separator: "\n"))
+    memory:
+    \(memory.map({ "- \($0): \($1)" }).joined(separator: "\n"))
+    """
+  }
+
+}

--- a/Sources/IR/Analysis/AbstractDomain.swift
+++ b/Sources/IR/Analysis/AbstractDomain.swift
@@ -1,0 +1,10 @@
+/// A type representing the possible values of an object in an abstract interpreter.
+///
+/// The values of an abstract domain must form a meet-semilattice whose meet operation represents
+/// the conservative superposition of two abstract values.
+protocol AbstractDomain: Equatable {
+
+  /// Returns `lhs` merged with `rhs`.
+  static func && (l: Self, r: Self) -> Self
+
+}

--- a/Sources/IR/Analysis/AbstractLocation.swift
+++ b/Sources/IR/Analysis/AbstractLocation.swift
@@ -1,0 +1,59 @@
+import Core
+
+/// A memory location in an abstract interpreter.
+enum AbstractLocation: Hashable {
+
+  /// The null location.
+  case null
+
+  /// The location of an argument to a `let`, `inout`, or `set` parameter.
+  case argument(index: Int)
+
+  /// A location produced by an instruction.
+  case instruction(block: Function.Blocks.Address, address: Block.Instructions.Address)
+
+  /// A sub-location rooted at an argument or instruction.
+  ///
+  /// `path[i]` denotes the index of a property in the abstract layout of the object stored at
+  /// `.sublocation(root: r, path: path.prefix(upTo: i))`. For example, if `r` is the location
+  /// identifying storage of type `{{A, B}, C}`, then `sublocation(root: r, path: [0, 1])` is a
+  /// location identifying storage of type `B`.
+  ///
+  /// - Note: Use `appending(_:)` to create instances of this case.
+  /// - Requires: `root` is `.argument` or `.instruction` and `path` is not empty.
+  indirect case sublocation(root: AbstractLocation, path: PartPath)
+
+  /// Returns a new locating created by appending `suffix` to this one.
+  ///
+  /// - Requires: `self` is not `.null`.
+  func appending(_ suffix: PartPath) -> AbstractLocation {
+    if suffix.isEmpty { return self }
+
+    switch self {
+    case .null:
+      preconditionFailure("null location")
+    case .argument, .instruction:
+      return .sublocation(root: self, path: suffix)
+    case .sublocation(let root, let prefix):
+      return .sublocation(root: root, path: prefix + suffix)
+    }
+  }
+
+}
+
+extension AbstractLocation: CustomStringConvertible {
+
+  var description: String {
+    switch self {
+    case .null:
+      return "Null"
+    case .argument(let i):
+      return "A(\(i)"
+    case .instruction(let b, let i):
+      return "L(\(b), \(i))"
+    case .sublocation(let root, let path):
+      return "\(root).\(list: path, joinedBy: ".")"
+    }
+  }
+
+}

--- a/Sources/IR/Analysis/AbstractObject.swift
+++ b/Sources/IR/Analysis/AbstractObject.swift
@@ -1,0 +1,130 @@
+/// An object in an abstract interpreter.
+struct AbstractObject<Domain: AbstractDomain>: Equatable {
+
+  /// The abstract layout of the object.
+  let layout: AbstractTypeLayout
+
+  /// The value of the object.
+  var value: Value
+
+  /// Creates an instance with the given properties.
+  init(layout: AbstractTypeLayout, value: Value) {
+    self.layout = layout
+    self.value = value.canonical
+  }
+
+  /// Returns the result of calling `action` with the sub-object at given `offset`.
+  ///
+  /// - Requires: `i` is a valid index in `layout`.
+  mutating func withSubobject<T>(_ offset: Int, _ action: (inout AbstractObject) -> T) -> T {
+    let n = layout.properties.count
+    precondition(n != 0)
+
+    var parts: [Value]
+    if case .partial(let p) = value {
+      parts = p
+    } else {
+      parts = Array(repeating: value, count: n)
+    }
+
+    var o = AbstractObject(layout: layout[offset], value: parts[offset])
+    defer {
+      parts[offset] = o.value
+      value = .partial(parts).canonical
+    }
+    return action(&o)
+  }
+
+  /// Returns the result of calling `action` with the sub-object at given `path`.
+  ///
+  /// - Requires: `offsets` is a valid path in `self`.
+  mutating func withSubobject<T, Path: Collection<Int>>(
+    at path: Path,
+    _ action: (inout AbstractObject) -> T
+  ) -> T {
+    guard let (i, t) = path.headAndTail else {
+      defer { value = value.canonical }
+      return action(&self)
+    }
+
+    if t.isEmpty {
+      return withSubobject(i, action)
+    } else {
+      return withSubobject(at: t, action)
+    }
+  }
+
+  /// Returns `l` merged with `r`.
+  static func && (l: AbstractObject, r: AbstractObject) -> AbstractObject {
+    precondition(l.layout == r.layout)
+    return AbstractObject(layout: l.layout, value: l.value && r.value)
+  }
+
+  /// The value of an abstract object.
+  enum Value: Equatable {
+
+    /// An object whose parts all have the same value.
+    case full(Domain)
+
+    /// An object whose parts may have different values.
+    ///
+    /// - Requires: The payload is not empty.
+    case partial([Value])
+
+    /// The canonical form of `self`.
+    var canonical: Value {
+      switch self {
+      case .full:
+        return self
+
+      case .partial(var subobjects):
+        var isUniform = true
+        subobjects[0] = subobjects[0].canonical
+        for i in 1 ..< subobjects.count {
+          subobjects[i] = subobjects[i].canonical
+          isUniform = isUniform && subobjects[i] == subobjects[0]
+        }
+        return isUniform ? subobjects[0] : .partial(subobjects)
+      }
+    }
+
+    /// Returns `lhs` merged with `rhs`.
+    static func && (lhs: Value, rhs: Value) -> Value {
+      switch (lhs.canonical, rhs.canonical) {
+      case (.full(let lhs), .full(let rhs)):
+        return .full(lhs && rhs)
+
+      case (.partial(let lhs), .partial(let rhs)):
+        assert(lhs.count == rhs.count)
+        return .partial(zip(lhs, rhs).map(&&))
+
+      case (.partial(let lhs), _):
+        return .partial(lhs.map({ $0 && rhs }))
+
+      case (_, .partial(let rhs)):
+        return .partial(rhs.map({ lhs && $0 }))
+      }
+    }
+
+  }
+
+}
+
+extension AbstractObject: CustomStringConvertible {
+
+  var description: String { "\(layout.type)(\(value))" }
+
+}
+
+extension AbstractObject.Value: CustomStringConvertible {
+
+  var description: String {
+    switch self {
+    case .full(let s):
+      return String(describing: s)
+    case .partial(let s):
+      return "{\(list: s, joinedBy: ", ")}"
+    }
+  }
+
+}

--- a/Sources/IR/Analysis/AbstractValue.swift
+++ b/Sources/IR/Analysis/AbstractValue.swift
@@ -1,0 +1,66 @@
+import Core
+import Utils
+
+/// The value of a register in an abstract interpreter.
+enum AbstractValue<Domain: AbstractDomain>: Equatable {
+
+  /// A non-empty set of locations.
+  case locations(Set<AbstractLocation>)
+
+  /// An object.
+  case object(AbstractObject<Domain>)
+
+  /// Creates a `.object` value with an object of given `value` and `type`, using `program` to
+  /// compute its layout.
+  init(
+    object value: AbstractObject<Domain>.Value,
+    ofType type: AnyType,
+    definedIn program: TypedProgram
+  ) {
+    self = .object(.init(layout: AbstractTypeLayout(of: type, definedIn: program), value: value))
+  }
+
+  /// If `self` is `.locations(l)`, returns `l`; otherwise, returns `nil`.
+  func unwrapLocations() -> Set<AbstractLocation>? {
+    if case .locations(let ls) = self {
+      return ls
+    } else {
+      return nil
+    }
+  }
+
+  /// If `self`is `.object(o)`, returns `o`; otherwise, returns `nil`.
+  func unwrapObject() -> AbstractObject<Domain>? {
+    if case .object(let o) = self {
+      return o
+    } else {
+      return nil
+    }
+  }
+
+  /// Returns `l` merged with `r`.
+  static func && (l: AbstractValue, r: AbstractValue) -> AbstractValue {
+    switch (l, r) {
+    case (.locations(let a), .locations(let b)):
+      return .locations(a.union(b))
+    case (.object(let a), .object(let b)):
+      return .object(a && b)
+    default:
+      unreachable()
+    }
+  }
+
+}
+
+extension AbstractValue: CustomStringConvertible {
+
+  var description: String {
+    switch self {
+    case .locations(let v):
+      return String(describing: v)
+    case .object(let v):
+      return String(describing: v)
+    }
+  }
+
+}


### PR DESCRIPTION
This PR factors out the data structures that will be reused by the different abstract interpreters implementing flow-sensitive IR analysis.