### PR TITLE
Remove obsolete windows CI steps and reduce duplication with matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,55 +20,43 @@ on:
 
 jobs:
   build:
-    name: Swift 5 on ${{ matrix.host.os }}
+    name: "${{ matrix.host.os }} / ${{ matrix.configuration }} / Swift ${{ matrix.swift.version }}"
     strategy:
       fail-fast: false
       matrix:
         host: [
           { type: macos, os: macos-latest },
-          { type: linux, os: ubuntu-latest, test-options: --enable-code-coverage },
+          { type: linux, os: ubuntu-latest, test-options: "-Xswiftc -enable-testing --enable-code-coverage" },
+        ]
+        configuration: [
+          "debug",
+          "release"
         ]
         swift: [
-          { version: "5.7", windows-branch: "development", windows-tag: "DEVELOPMENT-SNAPSHOT-2023-02-14-a" }
+          { version: "5.7" }
         ]
+
     runs-on: ${{ matrix.host.os }}
+
     steps:
     - name: Setup swift
       uses: swift-actions/setup-swift@v1
-      if: matrix.host.type != 'windows'
       with:
         swift-version: ${{ matrix.swift.version }}
 
-    - name: Setup swift (Windows)
-      uses: compnerd/gha-setup-swift@main
-      if: matrix.host.type == 'windows'
-      with:
-        branch: ${{ matrix.swift.windows-branch }}
-        tag: ${{ matrix.swift.windows-tag }}
+    - run: git config --global core.autocrlf input
 
-    - run: |
-        git config --global core.autocrlf input
     - uses: actions/checkout@v3
 
-    - name: Swift version
-      run: swift --version
+    - run: swift --version
 
-    - name: Build (Debug)
-      run: swift build -v -c debug
-    - name: Test (Debug)
-      run: swift test -v -c debug ${{matrix.host.test-options}}
-    - name: Check code coverage (Debug)
-      uses: mattpolzin/swift-codecov-action@0.7.3
-      if: matrix.host.type == 'linux'
-      with:
-        SORT_ORDER: +cov
-        MINIMUM_COVERAGE: 82
+    - name: Build ${{ matrix.configuration }}
+      run: swift build -v -c ${{ matrix.configuration }}
 
-    - name: Build (Release)
-      run: swift build -v -c release
-    - name: Test (Release)
-      run: swift test -c release -Xswiftc -enable-testing ${{matrix.host.test-options}}
-    - name: Check code coverage (Release)
+    - name: Test ${{ matrix.configuration }}
+      run: swift test -v -c ${{ matrix.configuration }} ${{matrix.host.test-options}}
+
+    - name: Check code coverage
       uses: mattpolzin/swift-codecov-action@0.7.3
       if: matrix.host.type == 'linux'
       with:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -30,8 +30,7 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - name: Swift version
-      run: swift --version
+    - run: swift --version
 
     - name: Check code format
       run: Tools/run-swift-format.sh -d lint


### PR DESCRIPTION
This PR removes now-obsolete Windows CI configuration, and simplifies what remains by making heavier use of the GH actions `matrix` feature.