### PR TITLE
Refactor type inference for function calls

### DIFF
--- a/Sources/Core/Constraints/FunctionCallConstraint.swift
+++ b/Sources/Core/Constraints/FunctionCallConstraint.swift
@@ -1,44 +1,65 @@
 import Utils
 
-/// A constraint `F(P1, ..., Pn) -> R` specifying that `F` is the type of a callable object that
-/// has parameters `Pi` and returns `R`.
+/// A constraint `F(A1, ..., An) -> R` specifying that `F` is the type of a callable object that
+/// returns instances of `R` when called with arguments of types `A1, ..., An`.
 public struct FunctionCallConstraint: Constraint, Hashable {
+
+  /// The label, type, and site of an argument passed to a callable object.
+  public struct Argument: Hashable {
+
+    /// The label of the argument.
+    public let label: SourceRepresentable<String>?
+
+    /// The type of the argument.
+    public fileprivate(set) var type: AnyType
+
+    /// The site from which the argument's value was parsed.
+    public let site: SourceRange
+
+    /// Creates an instance with the given properties.
+    public init(label: SourceRepresentable<String>?, type: AnyType, site: SourceRange) {
+      self.label = label
+      self.type = type
+      self.site = site
+    }
+
+  }
 
   /// A type assumed to be callable.
   public private(set) var callee: AnyType
 
-  /// The expected parameters of `callee`.
-  public private(set) var parameters: [CallableTypeParameter]
+  /// The arguments passed to `callee`.
+  public private(set) var arguments: [Argument]
 
   /// The expected return type of `callee`.
   public private(set) var returnType: AnyType
 
   public let origin: ConstraintOrigin
 
-  /// Creates a constraint requiring `calleeType` to be the type of a callable object with the
-  /// given parameters and return type.
+  /// Creates a constraint requiring `callee` to be the type of a callable object that accepts
+  /// given `arguments` and returns `returnType`.
   public init(
-    _ calleeType: AnyType,
-    takes parameters: [CallableTypeParameter],
-    andReturns returnType: AnyType,
+    _ callee: AnyType,
+    accepts arguments: [Argument],
+    returns returnType: AnyType,
     origin: ConstraintOrigin
   ) {
-    self.callee = calleeType
-    self.parameters = parameters
+    self.callee = callee
+    self.arguments = arguments
     self.returnType = returnType
     self.origin = origin
   }
 
   /// The expected labels of `callee`.
-  public var labels: LazyMapSequence<[CallableTypeParameter], String?> {
-    parameters.lazy.map(\.label)
+  public var labels: LazyMapSequence<[Argument], String?> {
+    arguments.lazy.map(\.label?.value)
   }
 
   public mutating func modifyTypes(_ transform: (AnyType) -> AnyType) {
     update(&callee, with: transform)
     update(&returnType, with: transform)
-    for i in 0 ..< parameters.count {
-      update(&parameters[i].type, with: transform)
+    for i in 0 ..< arguments.count {
+      update(&arguments[i].type, with: transform)
     }
   }
 
@@ -46,6 +67,18 @@ public struct FunctionCallConstraint: Constraint, Hashable {
 
 extension FunctionCallConstraint: CustomStringConvertible {
 
-  public var description: String { "(\(callee))(\(list: parameters)) -> \(returnType)" }
+  public var description: String { "(\(callee))(\(list: arguments)) -> \(returnType)" }
+
+}
+
+extension FunctionCallConstraint.Argument: CustomStringConvertible {
+
+  public var description: String {
+    if let l = label {
+      return "\(l.value): \(type)"
+    } else {
+      return "\(type)"
+    }
+  }
 
 }

--- a/Sources/Core/Constraints/FunctionCallConstraint.swift
+++ b/Sources/Core/Constraints/FunctionCallConstraint.swift
@@ -5,7 +5,7 @@ import Utils
 public struct FunctionCallConstraint: Constraint, Hashable {
 
   /// A type assumed to be callable.
-  public private(set) var calleeType: AnyType
+  public private(set) var callee: AnyType
 
   /// The expected parameters of `callee`.
   public private(set) var parameters: [CallableTypeParameter]
@@ -23,7 +23,7 @@ public struct FunctionCallConstraint: Constraint, Hashable {
     andReturns returnType: AnyType,
     origin: ConstraintOrigin
   ) {
-    self.calleeType = calleeType
+    self.callee = calleeType
     self.parameters = parameters
     self.returnType = returnType
     self.origin = origin
@@ -35,7 +35,7 @@ public struct FunctionCallConstraint: Constraint, Hashable {
   }
 
   public mutating func modifyTypes(_ transform: (AnyType) -> AnyType) {
-    update(&calleeType, with: transform)
+    update(&callee, with: transform)
     update(&returnType, with: transform)
     for i in 0 ..< parameters.count {
       update(&parameters[i].type, with: transform)
@@ -46,6 +46,6 @@ public struct FunctionCallConstraint: Constraint, Hashable {
 
 extension FunctionCallConstraint: CustomStringConvertible {
 
-  public var description: String { "\(calleeType)(\(list: parameters)) -> \(returnType)" }
+  public var description: String { "(\(callee))(\(list: parameters)) -> \(returnType)" }
 
 }

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -576,14 +576,14 @@ struct ConstraintSystem {
   ) -> Outcome? {
     let goal = goals[g] as! FunctionCallConstraint
 
-    if goal.calleeType.base is TypeVariable {
+    if goal.callee.base is TypeVariable {
       postpone(g)
       return nil
     }
 
-    guard let callee = goal.calleeType.base as? CallableType else {
+    guard let callee = goal.callee.base as? CallableType else {
       return .failure { (d, m, _) in
-        d.insert(.error(nonCallableType: m.reify(goal.calleeType), at: goal.origin.site))
+        d.insert(.error(nonCallableType: m.reify(goal.callee), at: goal.origin.site))
       }
     }
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -538,7 +538,7 @@ extension TypeChecker {
     case .done(let prefix, let suffix):
       unresolvedComponents = suffix
       lastVisitedComponentType =
-        bind(prefix, appliedWithLabels: suffix.isEmpty ? labels : nil, updating: &state)
+        bind(prefix, appliedWith: suffix.isEmpty ? labels : nil, updating: &state)
     }
 
     // Create the necessary constraints to let the solver resolve the remaining components.
@@ -1092,7 +1092,7 @@ extension TypeChecker {
   ///     expression used as the callee of the call.
   private mutating func bind(
     _ path: [NameResolutionResult.ResolvedComponent],
-    appliedWithLabels labels: [String?]?,
+    appliedWith labels: [String?]?,
     updating state: inout State
   ) -> AnyType {
     for p in path.dropLast() {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -317,7 +317,7 @@ extension TypeChecker {
     }
 
     // Case 2
-    if callee.base is TypeVariable {
+    if (callee.base is TypeVariable) || (callee.base is CallableType) {
       let parameters = parametersMatching(arguments: syntax.arguments, in: scope, updating: &state)
       let returnType = shape ?? ^TypeVariable()
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -300,92 +300,89 @@ extension TypeChecker {
       callee = inferredType(of: syntax.callee, shapedBy: nil, in: scope, updating: &state)
     }
 
-    // The following cases must be considered:
-    //
-    // 1. We failed to infer the type of the callee. We can stop here.
-    // 2. We couldn't infer the exact type of the callee and must rely on bottom-up inference.
-    // 3. We determined the exact type of the callee, and:
-    //   a. it's a lambda or method type. In that case, we can use the parameters to validate the
-    //      arguments' labels and their types.
-    //   b. it's a metatype and the callee is a name expression referring to a nominal type
-    //      declaration. In that case, the call is actually a sugared buffer type expression.
-    //   c. it's any other type. In that case the callee is not callable.
-
-    // Case 1
+    // We failed to infer the type of the callee. We can stop here.
     if callee.isError {
       return state.facts.assignErrorType(to: subject)
     }
 
-    // Case 2
-    if (callee.base is TypeVariable) || (callee.base is CallableType) {
-      let parameters = parametersMatching(arguments: syntax.arguments, in: scope, updating: &state)
+    // The callee has a metatype and is a name expression bound to a nominal type declaration,
+    // meaning that the call is actually a sugared initializer call.
+    if let c = NameExpr.ID(syntax.callee), let d = referredDecls[c]?.decl, isNominalTypeDecl(d) {
+      return inferredType(
+        ofInitializerCall: subject,
+        initializing: MetatypeType(callee)!.instance,
+        in: scope,
+        updating: &state)
+    }
+
+    // The callee has a callable type or its we need inferrence to determine its type. Either way,
+    // constraint the callee and its arguments with a function call constraints.
+    if (callee.base is CallableType) || (callee.base is TypeVariable) {
       let returnType = shape ?? ^TypeVariable()
+
+      var arguments: [FunctionCallConstraint.Argument] = []
+      for a in syntax.arguments {
+        let p = inferredType(
+          of: a.value, shapedBy: ^TypeVariable(), in: scope, updating: &state)
+        arguments.append(.init(label: a.label, type: p, site: ast[a.value].site))
+      }
 
       state.facts.append(
         FunctionCallConstraint(
-          callee, takes: parameters, andReturns: returnType,
+          callee, accepts: arguments, returns: returnType,
           origin: ConstraintOrigin(.callee, at: ast[syntax.callee].site)))
 
       return state.facts.constrain(subject, in: ast, toHaveType: returnType)
     }
 
-    // Case 3a
-    if let callable = callee.base as? CallableType {
-      if parametersMatching(
-        arguments: syntax.arguments, of: syntax.callee, in: scope,
-        shapedBy: callable.inputs, updating: &state)
-      {
-        return state.facts.constrain(subject, in: ast, toHaveType: callable.output)
-      } else {
-        return state.facts.assignErrorType(to: subject)
-      }
-    }
-
-    // Case 3b
-    if let c = NameExpr.ID(syntax.callee),
-      let d = referredDecls[c]?.decl,
-      isNominalTypeDecl(d)
-    {
-      let instance = MetatypeType(callee)!.instance
-      let initName = SourceRepresentable(
-        value: Name(stem: "init", labels: ["self"] + syntax.arguments.map(\.label?.value)),
-        range: ast[c].name.site)
-      let initCandidates = resolve(
-        initName, parameterizedBy: [], memberOf: instance, exposedTo: scope)
-
-      // We're done if we couldn't find any initializer.
-      if initCandidates.isEmpty {
-        _ = state.facts.assignErrorType(to: syntax.callee)
-        return state.facts.assignErrorType(to: subject)
-      }
-
-      if let pick = initCandidates.uniqueElement {
-        // Rebind the callee and constrain its type.
-        let ctor = LambdaType(constructorFormOf: .init(pick.type.shape)!)
-        referredDecls[c] = pick.reference
-        state.facts.assign(^ctor, to: c)
-        state.facts.append(pick.type.constraints)
-
-        // Visit the arguments.
-        if parametersMatching(
-          arguments: syntax.arguments, of: syntax.callee, in: scope,
-          shapedBy: ctor.inputs, updating: &state)
-        {
-          return state.facts.constrain(subject, in: ast, toHaveType: ctor.output)
-        } else {
-          return state.facts.assignErrorType(to: subject)
-        }
-      } else {
-        fatalError("not implemented")
-      }
-    }
-
-    // Case 3c
+    // In any other case, the callee is known to be not callable.
     report(
       .error(
         nonCallableType: state.facts.inferredTypes[syntax.callee]!,
         at: ast[syntax.callee].site))
     return state.facts.assignErrorType(to: subject)
+  }
+
+  /// Returns the inferred type of the initializer call `subject` in `scope`, assuming it returns
+  /// a value of type `instance`.
+  private mutating func inferredType(
+    ofInitializerCall subject: FunctionCallExpr.ID,
+    initializing instance: AnyType,
+    in scope: AnyScopeID,
+    updating state: inout State
+  ) -> AnyType {
+    let callee = NameExpr.ID(ast[subject].callee)!
+    let initName = SourceRepresentable(
+      value: Name(stem: "init", labels: ["self"] + ast[subject].arguments.map(\.label?.value)),
+      range: ast[callee].name.site)
+    let initCandidates = resolve(
+      initName, parameterizedBy: [], memberOf: instance, exposedTo: scope)
+
+    // We're done if we couldn't find any initializer.
+    if initCandidates.isEmpty {
+      _ = state.facts.assignErrorType(to: callee)
+      return state.facts.assignErrorType(to: subject)
+    }
+
+    if let pick = initCandidates.uniqueElement {
+      // Rebind the callee and constrain its type.
+      let ctor = LambdaType(constructorFormOf: .init(pick.type.shape)!)
+      referredDecls[callee] = pick.reference
+      state.facts.assign(^ctor, to: callee)
+      state.facts.append(pick.type.constraints)
+
+      // Visit the arguments.
+      if parametersMatching(
+        arguments: ast[subject].arguments, of: ast[subject].callee, in: scope,
+        shapedBy: ctor.inputs, updating: &state)
+      {
+        return state.facts.constrain(subject, in: ast, toHaveType: ctor.output)
+      } else {
+        return state.facts.assignErrorType(to: subject)
+      }
+    } else {
+      fatalError("not implemented")
+    }
   }
 
   private mutating func inferredType(
@@ -1061,21 +1058,10 @@ extension TypeChecker {
     var parameters: [CallableTypeParameter] = []
     parameters.reserveCapacity(arguments.count)
 
-    for i in 0 ..< arguments.count {
-      let argumentExpr = arguments[i].value
-      let parameterType = ^TypeVariable()
-
-      // Infer the type of the argument bottom-up.
-      let argumentType = inferredType(
-        of: argumentExpr, shapedBy: ^TypeVariable(), in: scope, updating: &state)
-
-      state.facts.append(
-        ParameterConstraint(
-          argumentType, parameterType,
-          origin: ConstraintOrigin(.argument, at: ast[argumentExpr].site)))
-
-      let argumentLabel = arguments[i].label?.value
-      parameters.append(CallableTypeParameter(label: argumentLabel, type: parameterType))
+    for a in arguments {
+      let p = inferredType(
+        of: a.value, shapedBy: ^TypeVariable(), in: scope, updating: &state)
+      parameters.append(CallableTypeParameter(label: a.label?.value, type: p))
     }
 
     return parameters

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -84,10 +84,6 @@ extension Diagnostic {
       """, at: site)
   }
 
-  static func error(incompatibleParameterCountAt site: SourceRange) -> Diagnostic {
-    .error("incompatible number of parameters", at: site)
-  }
-
   static func error(
     type l: AnyType, incompatibleWith r: AnyType, at site: SourceRange
   ) -> Diagnostic {

--- a/Tests/ValTests/TestCases/TypeChecking/DefaultFunctionArgument.val
+++ b/Tests/ValTests/TestCases/TypeChecking/DefaultFunctionArgument.val
@@ -1,3 +1,6 @@
-//! expect-success
+//! expect-failure
 
 fun f0(_ a: {}, _ b: {} = ()) {}
+
+//! @+1 diagnostic cannot pass value of type 'Bool' to parameter 'let {}'
+fun f1(_ a: {}, _ b: {} = true) {}


### PR DESCRIPTION
This patch refactors the type inference algorithm for function calls in preparation to support default arguments.

Before the patch, constraint generation would attempt to propagate type information down the AST at function calls to refine the inference of call arguments. This strategy aimed at reducing the size of the generated constraint system. However, it can't apply when the type of the callee must be inferred from context. In this case, the constraint solver will first have to determine the callee's type and then check if the inferred type of the call's arguments match. So that means in general, the constraint solver must be able to propagate type information in both directions. Therefore, implementing top-down propagation during constraint solving involves some amount of code duplication for questionable performance benefits.

With this patch, constraint generation will no longer attempt to propagate type information. Instead, it will pick fresh variables for all call arguments and let the constraint solver infer their types.