### PR TITLE
ForeignConvertible

### DIFF
--- a/Library/Val/Core/ForeignConvertible.val
+++ b/Library/Val/Core/ForeignConvertible.val
@@ -10,9 +10,9 @@ public trait ForeignConvertible {
   type ForeignRepresentation: ForeignConvertible
 
   /// Creates a new instance from its foreign representation.
-  init(foreign: ForeignRepresentation)
+  init(foreign_value: ForeignRepresentation)
 
   /// Returns the foreign representation of this instance.
-  fun foreign_representation() -> ForeignRepresentation
+  fun foreign_value() -> ForeignRepresentation
 
 }

--- a/Library/Val/Core/ForeignConvertible.val
+++ b/Library/Val/Core/ForeignConvertible.val
@@ -1,0 +1,18 @@
+/// A type that can be converted to and from an a foreign representation.
+///
+/// Types conforming to `ForeignConvertible` can appear in foreign function interfaces (FFI) and
+/// are automatically converted from Val to their foreign representation, or vice versa.
+public trait ForeignConvertible {
+
+  /// The foreign representation of the type.
+  ///
+  /// All built-in types conform to ForeignConvertible.
+  type ForeignRepresentation: ForeignConvertible
+
+  /// Creates a new instance from its foreign representation.
+  init(foreign: ForeignRepresentation)
+
+  /// Returns the foreign representation of this instance.
+  fun foreign_representation() -> ForeignRepresentation
+
+}

--- a/Library/Val/Core/ForeignConvertible.val
+++ b/Library/Val/Core/ForeignConvertible.val
@@ -10,7 +10,7 @@ public trait ForeignConvertible {
   type ForeignRepresentation: ForeignConvertible
 
   /// Creates a new instance from its foreign representation.
-  init(foreign_value: ForeignRepresentation)
+  init(foreign_value: sink ForeignRepresentation)
 
   /// Returns the foreign representation of this instance.
   fun foreign_value() -> ForeignRepresentation

--- a/Library/Val/Core/Int.val
+++ b/Library/Val/Core/Int.val
@@ -68,7 +68,7 @@ public conformance Int: ForeignConvertible {
 
   public typealias ForeignRepresentation = Builtin.i64
 
-  public init(foreign_value: Builtin.i64) {
+  public init(foreign_value: sink Builtin.i64) {
     &self.value = foreign_value
   }
 

--- a/Library/Val/Core/Int.val
+++ b/Library/Val/Core/Int.val
@@ -63,3 +63,17 @@ public conformance Int: Copyable {
   }
 
 }
+
+public conformance Int: ForeignConvertible {
+
+  public typealias ForeignRepresentation = Builtin.i64
+
+  public init(foreign_value: Builtin.i64) {
+    &self.value = foreign_value
+  }
+
+  public fun foreign_value() -> Builtin.i64 {
+    value
+  }
+
+}

--- a/Library/Val/Core/RawPointer.val
+++ b/Library/Val/Core/RawPointer.val
@@ -3,12 +3,28 @@ public type RawPointer {
 
   var value: Builtin.ptr
 
+  memberwise init
+
 }
 
 public conformance RawPointer: Copyable {
 
   public fun copy() -> Self {
     RawPointer(value: value)
+  }
+
+}
+
+public conformance RawPointer: ForeignConvertible {
+
+  public typealias ForeignRepresentation = Builtin.ptr
+
+  public init(foreign_value: Builtin.ptr) {
+    &self.value = foreign_value
+  }
+
+  public fun foreign_value() -> Builtin.ptr {
+    value
   }
 
 }

--- a/Library/Val/Core/RawPointer.val
+++ b/Library/Val/Core/RawPointer.val
@@ -19,7 +19,7 @@ public conformance RawPointer: ForeignConvertible {
 
   public typealias ForeignRepresentation = Builtin.ptr
 
-  public init(foreign_value: Builtin.ptr) {
+  public init(foreign_value: sink Builtin.ptr) {
     &self.value = foreign_value
   }
 

--- a/Sources/CodeGen/CXX/CXXTranspiler.swift
+++ b/Sources/CodeGen/CXX/CXXTranspiler.swift
@@ -684,7 +684,7 @@ public struct CXXTranspiler {
     // Foward function result if the result type is Int32.
     let resultType = (source.type.base as! LambdaType).output
     let forwardReturn = wholeValProgram.relations.areEquivalent(
-      resultType, ^wholeValProgram.ast.coreType(named: "Int32")!)
+      resultType, ^wholeValProgram.ast.coreType("Int32")!)
 
     // Build the body of the CXX entry-point function.
     var bodyContent: [CXXStmt] = []

--- a/Sources/CodeGen/LLVM/LLVM+Extensions.swift
+++ b/Sources/CodeGen/LLVM/LLVM+Extensions.swift
@@ -35,7 +35,7 @@ extension LLVM.Module {
 
     let transpilation = function(named: ir.abiName(of: f))!
 
-    let val32 = ir.syntax.ast.coreType(named: "Int32")!
+    let val32 = ir.syntax.ast.coreType("Int32")!
     switch m[f].output.ast {
     case val32:
       let t = StructType(ir.syntax.llvm(val32, in: &self))!

--- a/Sources/Core/AST/AST.swift
+++ b/Sources/Core/AST/AST.swift
@@ -115,7 +115,7 @@ public struct AST {
   /// Returns the type named `name` defined in the core library or `nil` it does not exist.
   ///
   /// - Requires: The Core library must have been loaded.
-  public func coreType(named name: String) -> ProductType? {
+  public func coreType(_ name: String) -> ProductType? {
     precondition(isCoreModuleLoaded, "Core library is not loaded")
 
     for id in topLevelDecls(coreLibrary!) where id.kind == ProductTypeDecl.self {
@@ -131,7 +131,7 @@ public struct AST {
   /// Returns the trait named `name` defined in the core library or `nil` if it does not exist.
   ///
   /// - Requires: The Core library must have been loaded.
-  public func coreTrait(named name: String) -> TraitType? {
+  public func coreTrait(_ name: String) -> TraitType? {
     precondition(isCoreModuleLoaded, "Core library is not loaded")
 
     for id in topLevelDecls(coreLibrary!) where id.kind == TraitDecl.self {
@@ -151,9 +151,9 @@ public struct AST {
   public func coreTrait<T: Expr>(forTypesExpressibleBy literal: T.Type) -> TraitType? {
     switch literal.kind {
     case FloatLiteralExpr.self:
-      return coreTrait(named: "ExpressibleByFloatLiteral")
+      return coreTrait("ExpressibleByFloatLiteral")
     case IntegerLiteralExpr.self:
-      return coreTrait(named: "ExpressibleByIntegerLiteral")
+      return coreTrait("ExpressibleByIntegerLiteral")
     default:
       return nil
     }
@@ -162,12 +162,12 @@ public struct AST {
   /// `Val.Sinkable` trait from the Core library.
   ///
   /// - Requires: The Core library must have been loaded.
-  public var sinkableTrait: TraitType { coreTrait(named: "Sinkable")! }
+  public var sinkableTrait: TraitType { coreTrait("Sinkable")! }
 
   /// `Val.Copyable` trait from the Core library.
   ///
   /// - Requires: The Core library must have been loaded.
-  public var copyableTrait: TraitType { coreTrait(named: "Copyable")! }
+  public var copyableTrait: TraitType { coreTrait("Copyable")! }
 
   // MARK: Helpers
 

--- a/Sources/Core/AST/Name.swift
+++ b/Sources/Core/AST/Name.swift
@@ -16,10 +16,7 @@ public struct Name: Hashable, Codable {
   public let introducer: AccessEffect?
 
   /// Creates a new name.
-  public init(
-    stem: Identifier,
-    labels: [String?] = []
-  ) {
+  public init(stem: Identifier, labels: [String?] = []) {
     self.stem = stem
     self.labels = labels
     self.notation = nil
@@ -27,10 +24,7 @@ public struct Name: Hashable, Codable {
   }
 
   /// Creates a new operator name.
-  public init(
-    stem: Identifier,
-    notation: OperatorNotation
-  ) {
+  public init(stem: Identifier, notation: OperatorNotation ) {
     self.stem = stem
     self.labels = []
     self.notation = notation
@@ -60,12 +54,12 @@ public struct Name: Hashable, Codable {
     }
   }
 
-  /// Creates the name introduced by `decl` in `ast`.
+  /// Creates the name introduced by `d` in `ast`.
   public init(of d: InitializerDecl.ID, in ast: AST) {
     self.init(stem: "init", labels: ast[ast[d].parameters].map(\.label?.value))
   }
 
-  /// Creates the name introduced by `decl` in `ast`.
+  /// Creates the name introduced by `d` in `ast`.
   public init(of d: MethodDecl.ID, in ast: AST) {
     let stem = ast[d].identifier.value
     if let notation = ast[d].notation?.value {
@@ -75,11 +69,22 @@ public struct Name: Hashable, Codable {
     }
   }
 
+  /// Creates the name introduced by `d` in `ast`.
+  public init(of d: SubscriptDecl.ID, in ast: AST) {
+    let stem = ast[d].identifier?.value ?? "[]"
+    self.init(stem: stem, labels: ast[ast[d].parameters ?? []].map(\.label?.value))
+  }
+
   /// Returns `self` appending `x` or `nil` if `self` already has an introducer.
   public func appending(_ x: AccessEffect) -> Name? {
     introducer == nil
       ? Name(stem: stem, labels: labels, notation: notation, introducer: x)
       : nil
+  }
+
+  /// Returns `self` sans access effect.
+  public func removingIntroducer() -> Name {
+    Name(stem: stem, labels: labels, notation: notation)
   }
 
   /// Returns a textual description of `labels`.

--- a/Sources/Core/AST/Name.swift
+++ b/Sources/Core/AST/Name.swift
@@ -61,6 +61,11 @@ public struct Name: Hashable, Codable {
   }
 
   /// Creates the name introduced by `decl` in `ast`.
+  public init(of d: InitializerDecl.ID, in ast: AST) {
+    self.init(stem: "init", labels: ast[ast[d].parameters].map(\.label?.value))
+  }
+
+  /// Creates the name introduced by `decl` in `ast`.
   public init(of d: MethodDecl.ID, in ast: AST) {
     let stem = ast[d].identifier.value
     if let notation = ast[d].notation?.value {

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -192,9 +192,9 @@ struct ConstraintSystem {
       return nil
 
     case is BuiltinType:
-      // Built-in types are `Sinkable`.
+      // Built-in types are `Sinkable` and `ForeignConvertible`.
       missingTraits = goal.traits.subtracting(
-        [checker.ast.coreTrait("Sinkable")!])
+        [checker.ast.coreTrait("Sinkable")!, checker.ast.coreTrait("ForeignConvertible")!])
 
     default:
       missingTraits = goal.traits.subtracting(

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -194,7 +194,7 @@ struct ConstraintSystem {
     case is BuiltinType:
       // Built-in types are `Sinkable`.
       missingTraits = goal.traits.subtracting(
-        [checker.ast.coreTrait(named: "Sinkable")!])
+        [checker.ast.coreTrait("Sinkable")!])
 
     default:
       missingTraits = goal.traits.subtracting(

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -192,7 +192,7 @@ extension TypeChecker {
     in scope: AnyScopeID,
     updating state: inout State
   ) -> AnyType {
-    state.facts.constrain(subject, in: ast, toHaveType: ast.coreType(named: "Bool")!)
+    state.facts.constrain(subject, in: ast, toHaveType: ast.coreType("Bool")!)
   }
 
   private mutating func inferredType(
@@ -249,7 +249,7 @@ extension TypeChecker {
     let syntax = ast[subject]
 
     // Visit the condition(s).
-    let boolType = AnyType(ast.coreType(named: "Bool")!)
+    let boolType = AnyType(ast.coreType("Bool")!)
     for item in syntax.condition {
       switch item {
       case .expr(let expr):
@@ -281,7 +281,7 @@ extension TypeChecker {
     in scope: AnyScopeID,
     updating state: inout State
   ) -> AnyType {
-    let defaultType = ^ast.coreType(named: "Double")!
+    let defaultType = ^ast.coreType("Double")!
     return inferredType(
       ofLiteralExpr: subject, shapedBy: shape, defaultingTo: defaultType,
       in: scope, updating: &state)
@@ -406,7 +406,7 @@ extension TypeChecker {
     in scope: AnyScopeID,
     updating state: inout State
   ) -> AnyType {
-    let defaultType = ^ast.coreType(named: "Int")!
+    let defaultType = ^ast.coreType("Int")!
     return inferredType(
       ofLiteralExpr: subject, shapedBy: shape, defaultingTo: defaultType,
       in: scope, updating: &state)
@@ -561,9 +561,9 @@ extension TypeChecker {
   ) -> AnyType {
     switch program.ast[subject].kind {
     case .file:
-      return state.facts.constrain(subject, in: ast, toHaveType: ast.coreType(named: "String")!)
+      return state.facts.constrain(subject, in: ast, toHaveType: ast.coreType("String")!)
     case .line:
-      return state.facts.constrain(subject, in: ast, toHaveType: ast.coreType(named: "Int")!)
+      return state.facts.constrain(subject, in: ast, toHaveType: ast.coreType("Int")!)
     }
   }
 
@@ -634,7 +634,7 @@ extension TypeChecker {
     in scope: AnyScopeID,
     updating state: inout State
   ) -> AnyType {
-    state.facts.constrain(subject, in: ast, toHaveType: ast.coreType(named: "String")!)
+    state.facts.constrain(subject, in: ast, toHaveType: ast.coreType("String")!)
   }
 
   private mutating func inferredType(

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -185,6 +185,12 @@ extension Diagnostic {
     .error("trait '\(x)' requires method '\(m)' with type '\(t)'", at: site)
   }
 
+  static func error(
+    trait x: TraitType, requiresInitializer t: AnyType, at site: SourceRange
+  ) -> Diagnostic {
+    .error("trait '\(x)' requires initializer with type '\(t)'", at: site)
+  }
+
   static func error(staleConstraint c: any Constraint) -> Diagnostic {
     .error("stale constraint '\(c)'", at: c.origin.site)
   }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1078,7 +1078,7 @@ public struct TypeChecker {
     // Target type must be `Sinkable`.
     guard let targetType = checkedType(of: ast[s].left, in: scope) else { return }
     let lhsConstraint = ConformanceConstraint(
-      targetType, conformsTo: [ast.coreTrait(named: "Sinkable")!],
+      targetType, conformsTo: [ast.coreTrait("Sinkable")!],
       origin: ConstraintOrigin(.initializationOrAssignment, at: ast[s].site))
 
     // Source type must be subtype of the target type.
@@ -1094,7 +1094,7 @@ public struct TypeChecker {
   }
 
   private mutating func check(conditional s: ConditionalStmt.ID, in scope: AnyScopeID) {
-    let boolType = AnyType(ast.coreType(named: "Bool")!)
+    let boolType = AnyType(ast.coreType("Bool")!)
     for c in ast[s].condition {
       switch c {
       case .expr(let e):
@@ -1124,7 +1124,7 @@ public struct TypeChecker {
     check(braceStmt: ast[subject].body)
 
     // Visit the condition of the loop in the scope of the body.
-    let boolType = AnyType(ast.coreType(named: "Bool")!)
+    let boolType = AnyType(ast.coreType("Bool")!)
     check(ast[subject].condition, in: ast[subject].body, hasType: boolType, cause: .structural)
   }
 
@@ -1139,7 +1139,7 @@ public struct TypeChecker {
 
   private mutating func check(while s: WhileStmt.ID, in scope: AnyScopeID) {
     // Visit the condition(s).
-    let boolType = AnyType(ast.coreType(named: "Bool")!)
+    let boolType = AnyType(ast.coreType("Bool")!)
     for item in ast[s].condition {
       switch item {
       case .expr(let e):

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1849,24 +1849,18 @@ extension TypedProgram {
   ///
   /// - Requires: `access` is either `.set` or `.inout`.
   fileprivate func moveDecl(_ access: AccessEffect) -> MethodImpl.ID {
-    ast[ast.sinkableTrait.decl].members.first { (m) -> MethodImpl.ID? in
-      guard
-        let d = MethodDecl.ID(m),
-        ast[d].identifier.value == "take_value"
-      else { return nil }
-      return ast[d].impls.first(where: { ast[$0].introducer.value == access })
-    }!
+    let d = ast.requirements(
+      Name(stem: "take_value", labels: ["from"], introducer: access),
+      in: ast.sinkableTrait.decl)
+    return MethodImpl.ID(d[0])!
   }
 
   /// Returns the declaration of `Copyable.copy`'s requirement.
   fileprivate func copyDecl() -> FunctionDecl.ID {
-    ast[ast.copyableTrait.decl].members.first { (m) -> FunctionDecl.ID? in
-      guard
-        let d = FunctionDecl.ID(m),
-        ast[d].identifier?.value == "copy"
-      else { return nil }
-      return d
-    }!
+    let d = ast.requirements(
+      Name(stem: "copy"),
+      in: ast.copyableTrait.decl)
+    return FunctionDecl.ID(d[0])!
   }
 
 }

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -715,7 +715,7 @@ public struct Emitter {
     let value = Operand.constant(
       .integer(IntegerConstant(expr.value ? 1 : 0, bitWidth: 1)))
 
-    let boolType = program.ast.coreType(named: "Bool")!
+    let boolType = program.ast.coreType("Bool")!
     return module.append(
       module.makeRecord(boolType, aggregating: [value], anchoredAt: expr.site),
       to: insertionBlock!)[0]
@@ -1329,7 +1329,7 @@ public struct Emitter {
     at site: SourceRange,
     into module: inout Module
   ) -> Operand {
-    let t = program.ast.coreType(named: "Int")!
+    let t = program.ast.coreType("Int")!
     let s = module.makeRecord(
       t, aggregating: [.constant(.integer(IntegerConstant(i, bitWidth: 64)))], anchoredAt: site)
     return module.append(s, to: insertionBlock!)[0]
@@ -1343,7 +1343,7 @@ public struct Emitter {
     _ expr: AnyExprID.TypedNode,
     into module: inout Module
   ) -> Operand {
-    precondition(program.relations.canonical(expr.type) == program.ast.coreType(named: "Bool")!)
+    precondition(program.relations.canonical(expr.type) == program.ast.coreType("Bool")!)
     let b = emitRValue(expr, into: &module)
     return module.append(
       module.makeDestructure(b, anchoredAt: expr.site),
@@ -1361,13 +1361,13 @@ public struct Emitter {
     into module: inout Module
   ) -> Operand {
     switch literalType {
-    case program.ast.coreType(named: "Double")!:
+    case program.ast.coreType("Double")!:
       let v = Constant.floatingPoint(.double(s))
       return module.append(
         module.makeRecord(literalType, aggregating: [.constant(v)], anchoredAt: anchor),
         to: insertionBlock!)[0]
 
-    case program.ast.coreType(named: "Float")!:
+    case program.ast.coreType("Float")!:
       let v = Constant.floatingPoint(.float(s))
       return module.append(
         module.makeRecord(literalType, aggregating: [.constant(v)], anchoredAt: anchor),
@@ -1390,11 +1390,11 @@ public struct Emitter {
   ) -> Operand {
     let bits: WideUInt?
     switch literalType {
-    case program.ast.coreType(named: "Int")!:
+    case program.ast.coreType("Int")!:
       bits = .init(valLiteral: s, signed: true, bitWidth: 64)
-    case program.ast.coreType(named: "Int32")!:
+    case program.ast.coreType("Int32")!:
       bits = .init(valLiteral: s, signed: true, bitWidth: 32)
-    case program.ast.coreType(named: "Int8")!:
+    case program.ast.coreType("Int8")!:
       bits = .init(valLiteral: s, signed: true, bitWidth: 8)
     default:
       unreachable("unexpected numeric type")
@@ -1422,7 +1422,7 @@ public struct Emitter {
     at site: SourceRange,
     into module: inout Module
   ) -> Operand {
-    let t = program.ast.coreType(named: n)!
+    let t = program.ast.coreType(n)!
     let o = module.makeRecord(t, aggregating: parts, anchoredAt: site)
     return module.append(o, to: insertionBlock!)[0]
   }
@@ -1447,8 +1447,8 @@ public struct Emitter {
   ) -> Operand {
     let t = module.type(of: o).ast
 
-    let i = program.ast.coreType(named: "Int")!
-    let p = program.ast.coreType(named: "RawPointer")!
+    let i = program.ast.coreType("Int")!
+    let p = program.ast.coreType("RawPointer")!
     if (t == i) || (t == p) {
       let s = module.append(
         module.makeElementAddr(o, at: [0], anchoredAt: site), to: insertionBlock!)[0]

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -243,7 +243,6 @@ public struct Module {
   /// Returns the identifier of the Val IR initializer corresponding to `d`.
   mutating func initializerDeclaration(lowering d: InitializerDecl.Typed) -> Function.ID {
     if let id = loweredFunctions[d.id] { return id }
-    precondition(d.module == syntax)
     precondition(!d.isMemberwise)
 
     let declType = LambdaType(d.type)!

--- a/Sources/IR/Operands/Constant/FunctionReference.swift
+++ b/Sources/IR/Operands/Constant/FunctionReference.swift
@@ -1,3 +1,5 @@
+import Core
+
 /// A Val IR reference to a user function.
 public struct FunctionRef: ConstantProtocol, Hashable {
 
@@ -11,6 +13,12 @@ public struct FunctionRef: ConstantProtocol, Hashable {
   public init(to function: Function.ID, type: LoweredType) {
     self.function = function
     self.type = type
+  }
+
+  /// Creates a reference to the lowered form of `d` in `module`.
+  public init(to d: FunctionDecl.Typed, in module: inout Module) {
+    self.function = module.getOrCreateFunction(correspondingTo: d)
+    self.type = .address(LambdaType(d.type)!.lifted)
   }
 
 }

--- a/Sources/IR/Operands/Constant/FunctionReference.swift
+++ b/Sources/IR/Operands/Constant/FunctionReference.swift
@@ -21,6 +21,12 @@ public struct FunctionRef: ConstantProtocol, Hashable {
     self.type = .address(LambdaType(d.type)!.lifted)
   }
 
+  /// Creates a reference to the lowered form of `d` in `module`.
+  public init(to d: InitializerDecl.Typed, in module: inout Module) {
+    self.function = module.initializerDeclaration(lowering: d)
+    self.type = .address(LambdaType(d.type)!.lifted)
+  }
+
 }
 
 extension FunctionRef: CustomStringConvertible {

--- a/Tests/ValTests/TestCases/TypeChecking/Conformance.val
+++ b/Tests/ValTests/TestCases/TypeChecking/Conformance.val
@@ -49,3 +49,17 @@ type B: R, S {
     sink {}
   }
 }
+
+
+trait T {
+  init(x: Int)
+}
+
+type C1: T {
+  init(x: Int) {}
+}
+
+//! @+1 diagnostic type 'C2' does not conform to trait 'T'
+type C2: T {
+  init(y: Int) {}
+}


### PR DESCRIPTION
The trait `ForeignConvertible` is used to describe how to convert a value from and to its foreign representation, for use with a foreign function interface. Built-in types automatically conform to `ForeignConvertible`. For other types, a conformance must be declared and implement the conversion.

Though the trait is designed to support it, this patch doesn't implement conversion from/to a types that aren't built-in. Further, conversion from foreign is not tested. This issues will be addressed with different PRs.