### PR TITLE
Fix a bug in extension lookup

### DIFF
--- a/Tests/ValTests/TestCases/TypeChecking/ExtensionOfImport.val
+++ b/Tests/ValTests/TestCases/TypeChecking/ExtensionOfImport.val
@@ -1,0 +1,9 @@
+//! expect-success
+
+extension Double {
+  public static fun gravity() -> Double { 9.81 }
+}
+
+public fun main() {
+  let _: Double = .gravity()
+}


### PR DESCRIPTION
`TypeChecker.extendingDecls(of:exposedTo:)` was inconditionally looking into all modules imported of the AST, not exluding those that are not visible to the scope from which lookup originated.

As a result, name lookup could gather extensions declared in non-dependent modules and cause resolution failures.