### PR TITLE
Remember generic arguments

### DIFF
--- a/Sources/Core/CompileTimeValues/GenericArguments.swift
+++ b/Sources/Core/CompileTimeValues/GenericArguments.swift
@@ -1,4 +1,3 @@
-import Core
 import Utils
 
 /// A map from generic parameter to its argument.

--- a/Sources/Core/Constraints/ConstraintSet.swift
+++ b/Sources/Core/Constraints/ConstraintSet.swift
@@ -15,4 +15,4 @@ public struct ConstraintHashableWitness: HashableWitness {
 
 }
 
-public typealias ConstraintSet = CustomWitnessedSet<Constraint, ConstraintHashableWitness>
+public typealias ConstraintSet = CustomWitnessedSet<ConstraintHashableWitness>

--- a/Sources/Core/Constraints/OverloadConstraint.swift
+++ b/Sources/Core/Constraints/OverloadConstraint.swift
@@ -60,7 +60,9 @@ public struct OverloadConstraint: DisjunctiveConstraintProtocol, Hashable {
   public struct Predicate: DisjunctiveConstraintTerm, Hashable {
 
     /// Creates an instance having the given properties.
-    public init(reference: DeclRef, type: AnyType, constraints: ConstraintSet, penalties: Int) {
+    public init(
+      reference: DeclReference, type: AnyType, constraints: ConstraintSet, penalties: Int
+    ) {
       self.reference = reference
       self.type = type
       self.constraints = constraints
@@ -68,7 +70,7 @@ public struct OverloadConstraint: DisjunctiveConstraintProtocol, Hashable {
     }
 
     /// The candidate reference.
-    public let reference: DeclRef
+    public let reference: DeclReference
 
     /// The instantiated type the referred declaration.
     public let type: AnyType

--- a/Sources/Core/DeclReference.swift
+++ b/Sources/Core/DeclReference.swift
@@ -2,13 +2,13 @@
 public enum DeclReference: Hashable {
 
   /// A direct reference.
-  case direct(AnyDeclID)
+  case direct(AnyDeclID, GenericArguments)
 
   /// A reference to a member declaration bound to a receiver.
-  case member(AnyDeclID)
+  case member(AnyDeclID, GenericArguments)
 
   /// A reference to an initializer used as a constructor.
-  case constructor(InitializerDecl.ID)
+  case constructor(InitializerDecl.ID, GenericArguments)
 
   /// A reference to a built-in function.
   case builtinFunction(BuiltinFunction)
@@ -18,8 +18,8 @@ public enum DeclReference: Hashable {
 
   /// Converts a direct initializer reference to a constructor reference.
   public init?(constructor other: DeclReference) {
-    if case .direct(let d) = other, let i = InitializerDecl.ID(d) {
-      self = .constructor(i)
+    if case .direct(let d, let a) = other, let i = InitializerDecl.ID(d) {
+      self = .constructor(i, a)
     } else {
       return nil
     }
@@ -28,14 +28,28 @@ public enum DeclReference: Hashable {
   /// Accesses the referred declaration if `self` is `.direct`, `.member`, or `.constructor`.
   public var decl: AnyDeclID? {
     switch self {
-    case .direct(let d):
+    case .direct(let d, _):
       return d
-    case .member(let d):
+    case .member(let d, _):
       return d
-    case .constructor(let d):
+    case .constructor(let d, _):
       return AnyDeclID(d)
     default:
       return nil
+    }
+  }
+
+  // The generic arguments applied to the referred declaration.
+  public var arguments: GenericArguments {
+    switch self {
+    case .direct(_, let a):
+      return a
+    case .member(_, let a):
+      return a
+    case .constructor(_, let a):
+      return a
+    default:
+      return [:]
     }
   }
 

--- a/Sources/Core/DeclReference.swift
+++ b/Sources/Core/DeclReference.swift
@@ -16,6 +16,15 @@ public enum DeclReference: Hashable {
   /// A reference to a built-in type.
   case builtinType
 
+  /// Converts a direct initializer reference to a constructor reference.
+  public init?(constructor other: DeclReference) {
+    if case .direct(let d) = other, let i = InitializerDecl.ID(d) {
+      self = .constructor(i)
+    } else {
+      return nil
+    }
+  }
+
   /// Accesses the referred declaration if `self` is `.direct`, `.member`, or `.constructor`.
   public var decl: AnyDeclID? {
     switch self {

--- a/Sources/Core/DeclReference.swift
+++ b/Sources/Core/DeclReference.swift
@@ -1,5 +1,5 @@
 /// A reference to a declaration.
-public enum DeclRef: Hashable {
+public enum DeclReference: Hashable {
 
   /// A direct reference.
   case direct(AnyDeclID)

--- a/Sources/Core/TypedNode.swift
+++ b/Sources/Core/TypedNode.swift
@@ -41,6 +41,14 @@ public struct TypedNode<ID: NodeIDProtocol>: Hashable {
 
 }
 
+extension TypedNode: CustomStringConvertible {
+
+  public var description: String {
+    String(site.text)
+  }
+
+}
+
 extension AST.Node {
 
   /// Type describing the current node with type information.

--- a/Sources/Core/TypedNode.swift
+++ b/Sources/Core/TypedNode.swift
@@ -226,7 +226,7 @@ extension TypedNode where ID == NameExpr.ID {
   }
 
   /// The declaration to which `self` refers.
-  public var declaration: DeclRef {
+  public var declaration: DeclReference {
     program.referredDecls[id]!
   }
 

--- a/Sources/Core/TypedProgram.swift
+++ b/Sources/Core/TypedProgram.swift
@@ -29,7 +29,7 @@ public struct TypedProgram: Program {
   public let implicitCaptures: DeclProperty<[ImplicitCapture]>
 
   /// A map from name expression to its referred declaration.
-  public let referredDecls: [NameExpr.ID: DeclRef]
+  public let referredDecls: [NameExpr.ID: DeclReference]
 
   /// A map from sequence expressions to their evaluation order.
   public let foldedSequenceExprs: [SequenceExpr.ID: FoldedSequenceExpr]
@@ -52,7 +52,7 @@ public struct TypedProgram: Program {
     exprTypes: ExprProperty<AnyType>,
     implicitCaptures: DeclProperty<[ImplicitCapture]>,
     synthesizedDecls: [ModuleDecl.ID: [SynthesizedDecl]],
-    referredDecls: [NameExpr.ID: DeclRef],
+    referredDecls: [NameExpr.ID: DeclReference],
     foldedSequenceExprs: [SequenceExpr.ID: FoldedSequenceExpr],
     relations: TypeRelations
   ) {

--- a/Sources/Core/Types/BoundGenericType.swift
+++ b/Sources/Core/Types/BoundGenericType.swift
@@ -1,24 +1,20 @@
-import OrderedCollections
 import Utils
 
 /// A generic type bound to arguments.
 public struct BoundGenericType: TypeProtocol {
 
-  /// The arguments of a bound generic type.
-  public typealias Arguments = OrderedDictionary<GenericParameterDecl.ID, any CompileTimeValue>
-
   /// The underlying generic type.
   public let base: AnyType
 
   /// The type and value arguments of the base type.
-  public let arguments: Arguments
+  public let arguments: GenericArguments
 
   public let flags: TypeFlags
 
   /// Creates a bound generic type binding `base` to the given `arguments`.
   ///
   /// - Requires: `arguments` is not empty.
-  public init<T: TypeProtocol>(_ base: T, arguments: Arguments) {
+  public init<T: TypeProtocol>(_ base: T, arguments: GenericArguments) {
     precondition(!arguments.isEmpty)
     self.base = ^base
     self.arguments = arguments
@@ -80,18 +76,6 @@ extension BoundGenericType: CustomStringConvertible {
     default:
       return "<\(list: arguments.values)>(\(base))"
     }
-  }
-
-}
-
-extension BoundGenericType.Arguments {
-
-  /// Returns this argument list appended with `suffix`.
-  ///
-  /// - Requires: `self` does not define a value for any of the values defined in `suffix`.
-  public func appending(_ suffix: Self) -> Self {
-    // Note: `merging` perserves order.
-    self.merging(suffix, uniquingKeysWith: { (_, _) in unreachable() })
   }
 
 }

--- a/Sources/Core/Types/BoundGenericType.swift
+++ b/Sources/Core/Types/BoundGenericType.swift
@@ -83,3 +83,15 @@ extension BoundGenericType: CustomStringConvertible {
   }
 
 }
+
+extension BoundGenericType.Arguments {
+
+  /// Returns this argument list appended with `suffix`.
+  ///
+  /// - Requires: `self` does not define a value for any of the values defined in `suffix`.
+  public func appending(_ suffix: Self) -> Self {
+    // Note: `merging` perserves order.
+    self.merging(suffix, uniquingKeysWith: { (_, _) in unreachable() })
+  }
+
+}

--- a/Sources/Core/Types/BoundGenericType.swift
+++ b/Sources/Core/Types/BoundGenericType.swift
@@ -73,6 +73,13 @@ extension BoundGenericType: Hashable {
 
 extension BoundGenericType: CustomStringConvertible {
 
-  public var description: String { "\(base)<\(list: arguments.values)>" }
+  public var description: String {
+    switch base.base {
+    case is ProductType, is TypeAliasType:
+      return "\(base)<\(list: arguments.values)>"
+    default:
+      return "<\(list: arguments.values)>(\(base))"
+    }
+  }
 
 }

--- a/Sources/FrontEnd/TypeChecking/BindingMap.swift
+++ b/Sources/FrontEnd/TypeChecking/BindingMap.swift
@@ -1,4 +1,4 @@
 import Core
 
 /// A map from name expression to its referred declaration.
-public typealias BindingMap = [NameExpr.ID: DeclRef]
+public typealias BindingMap = [NameExpr.ID: DeclReference]

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -34,7 +34,7 @@ struct ConstraintSystem {
   /// This map is monotonically extended during constraint solving to assign a declaration to each
   /// unresolved name expression in the constraint system. A system is complete if it can be used
   /// to derive a complete name binding map w.r.t. its unresolved name expressions.
-  private var bindingAssumptions: [NameExpr.ID: DeclRef] = [:]
+  private var bindingAssumptions: [NameExpr.ID: DeclReference] = [:]
 
   /// The penalties associated with the constraint system.
   ///

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -435,7 +435,7 @@ struct ConstraintSystem {
       // TODO: Handle bound generic typess
 
       return OverloadConstraint.Predicate(
-        reference: .member(match),
+        reference: .member(match, [:]),
         type: matchType,
         constraints: [],
         penalties: checker.program.isRequirement(match) ? 1 : 0)

--- a/Sources/FrontEnd/TypeChecking/GenericArguments.swift
+++ b/Sources/FrontEnd/TypeChecking/GenericArguments.swift
@@ -1,4 +1,129 @@
 import Core
+import Utils
 
 /// A map from generic parameter to its argument.
-typealias GenericArguments = [GenericParameterDecl.ID: any CompileTimeValue]
+public struct GenericArguments {
+
+  /// A key in this map.
+  public typealias Key = GenericParameterDecl.ID
+
+  /// A value in this map.
+  public typealias Value = any CompileTimeValue
+
+  /// A value wrapped into an equatable box.
+  fileprivate typealias _Value = HashableBox<CompileTimeValueHashableWitness>
+
+  /// The type of this map's contents.
+  fileprivate typealias Contents = [GenericParameterDecl.ID: _Value]
+
+  /// The contents of `self`
+  fileprivate var contents: Contents
+
+  /// Creates an empty dictionary.
+  public init() {
+    self.contents = [:]
+  }
+
+  /// Creates a new map from the key-value pairs in the given sequence.
+  public init<S: Sequence>(uniqueKeysWithValues keysAndValues: S) where S.Element == (Key, Value) {
+    self.contents = .init(uniqueKeysWithValues: Self.adapt(keysAndValues))
+  }
+
+  /// Accesses the value associated with the given key.
+  public subscript(key: Key) -> Value? {
+    get { contents[key]?.base }
+    set { contents[key] = newValue.map(_Value.init(_:)) }
+  }
+
+  /// Merges the key-value pairs in `other` into `self` using `combine` to determine the value for
+  /// any duplicate keys.
+  public mutating func merge<S: Sequence>(
+    _ other: S, uniquingKeysWith combine: (Value, Value) throws -> Value
+  ) rethrows where S.Element == (Key, Value) {
+    try contents.merge(Self.adapt(other)) { (a, b) in
+      try .init(combine(a.base, b.base))
+    }
+  }
+
+  /// Merges `other` into `self` using `combine` to determine the value for any duplicate keys.
+  public mutating func merge(
+    _ other: Self, uniquingKeysWith combine: (Value, Value) throws -> Value
+  ) rethrows {
+    try contents.merge(other.contents) { (a, b) in
+      try .init(combine(a.base, b.base))
+    }
+  }
+
+  /// Returns a sequence containing the given `keysAndValues` with the values wrapped in `_Value`.
+  private static func adapt<S: Sequence>(
+    _ keysAndValues: S
+  ) -> LazyMapSequence<S, (Key, _Value)> where S.Element == (Key, Value) {
+    keysAndValues.lazy.map({ ($0, _Value($1)) })
+  }
+
+}
+
+extension GenericArguments: Hashable {}
+
+extension GenericArguments: ExpressibleByDictionaryLiteral {
+
+  public init(dictionaryLiteral elements: (Key, Value)...) {
+    self.init(uniqueKeysWithValues: elements)
+  }
+
+}
+
+extension GenericArguments: Collection {
+
+  public typealias Element = (key: Key, value: Value)
+
+  public struct Index: Comparable {
+
+    fileprivate let value: Contents.Index
+
+    public static func < (l: Self, r: Self) -> Bool {
+      l.value < r.value
+    }
+
+  }
+
+  public var startIndex: Index {
+    .init(value: contents.startIndex)
+  }
+
+  public var endIndex: Index {
+    .init(value: contents.endIndex)
+  }
+
+  public func index(after position: Index) -> Index {
+    .init(value: contents.index(after: position.value))
+  }
+
+  public subscript(position: Index) -> Element {
+    read(contents[position.value], { (key: $0.key, value: $0.value.base) })
+  }
+
+}
+
+extension GenericArguments: CustomStringConvertible {
+
+  public var description: String {
+    String(describing: contents)
+  }
+
+}
+
+/// A type serving as a witness for `Constraint`s conformance to `Hashable`.
+private struct CompileTimeValueHashableWitness: HashableWitness {
+
+  typealias Element = any CompileTimeValue
+
+  static func hash(_ constraint: Element, into hasher: inout Hasher) {
+    constraint.hash(into: &hasher)
+  }
+
+  static func isEqual(_ left: Element, to right: Element) -> Bool {
+    left.equals(right)
+  }
+
+}

--- a/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
@@ -12,28 +12,22 @@ enum NameResolutionResult {
     /// The quantifier-free type of the declaration at its use site.
     let type: InstantiatedType
 
-    // The generic arguments applied to the resolved declaration.
-    let arguments: GenericArguments
-
     /// Creates an instance with the given properties.
-    init(reference: DeclReference, type: InstantiatedType, arguments: GenericArguments) {
+    init(reference: DeclReference, type: InstantiatedType) {
       self.reference = reference
       self.type = type
-      self.arguments = arguments
     }
 
     /// Creates an instance denoting a built-in function.
     init(_ f: BuiltinFunction) {
       self.reference = .builtinFunction(f)
       self.type = .init(shape: ^f.type(), constraints: [])
-      self.arguments = [:]
     }
 
     /// Creates an instance denoting a built-in type.
     init(_ t: BuiltinType) {
       self.reference = .builtinType
       self.type = .init(shape: ^t, constraints: [])
-      self.arguments = [:]
     }
 
   }

--- a/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
@@ -7,13 +7,13 @@ enum NameResolutionResult {
   struct Candidate {
 
     /// Declaration being referenced.
-    let reference: DeclRef
+    let reference: DeclReference
 
     /// The quantifier-free type of the declaration at its use site.
     let type: InstantiatedType
 
     /// Creates an instance with the given properties.
-    init(reference: DeclRef, type: InstantiatedType) {
+    init(reference: DeclReference, type: InstantiatedType) {
       self.reference = reference
       self.type = type
     }

--- a/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
@@ -13,10 +13,10 @@ enum NameResolutionResult {
     let type: InstantiatedType
 
     // The generic arguments applied to the resolved declaration.
-    let arguments: BoundGenericType.Arguments
+    let arguments: GenericArguments
 
     /// Creates an instance with the given properties.
-    init(reference: DeclReference, type: InstantiatedType, arguments: BoundGenericType.Arguments) {
+    init(reference: DeclReference, type: InstantiatedType, arguments: GenericArguments) {
       self.reference = reference
       self.type = type
       self.arguments = arguments

--- a/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
@@ -12,20 +12,28 @@ enum NameResolutionResult {
     /// The quantifier-free type of the declaration at its use site.
     let type: InstantiatedType
 
+    // The generic arguments applied to the resolved declaration.
+    let arguments: BoundGenericType.Arguments
+
     /// Creates an instance with the given properties.
-    init(reference: DeclReference, type: InstantiatedType) {
+    init(reference: DeclReference, type: InstantiatedType, arguments: BoundGenericType.Arguments) {
       self.reference = reference
       self.type = type
+      self.arguments = arguments
     }
 
     /// Creates an instance denoting a built-in function.
     init(_ f: BuiltinFunction) {
-      self.init(reference: .builtinFunction(f), type: .init(shape: ^f.type(), constraints: []))
+      self.reference = .builtinFunction(f)
+      self.type = .init(shape: ^f.type(), constraints: [])
+      self.arguments = [:]
     }
 
     /// Creates an instance denoting a built-in type.
     init(_ t: BuiltinType) {
-      self.init(reference: .builtinType, type: .init(shape: ^t, constraints: []))
+      self.reference = .builtinType
+      self.type = .init(shape: ^t, constraints: [])
+      self.arguments = [:]
     }
 
   }

--- a/Sources/FrontEnd/TypeChecking/Solution.swift
+++ b/Sources/FrontEnd/TypeChecking/Solution.swift
@@ -43,7 +43,7 @@ struct Solution {
   /// Creates an instance with the given properties.
   init(
     substitutions typeAssumptions: SubstitutionMap,
-    bindings bindingAssumptions: [NameExpr.ID: DeclRef],
+    bindings bindingAssumptions: [NameExpr.ID: DeclReference],
     penalties: Int,
     diagnostics: DiagnosticSet
   ) {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -358,8 +358,7 @@ extension TypeChecker {
     let initName = SourceRepresentable(
       value: Name(stem: "init", labels: ["self"] + ast[subject].arguments.map(\.label?.value)),
       range: ast[callee].name.site)
-    let initCandidates = resolve(
-      initName, parameterizedBy: [], memberOf: instance, exposedTo: scope)
+    let initCandidates = resolve(initName, memberOf: instance, exposedTo: scope)
 
     // We're done if we couldn't find any initializer.
     if initCandidates.isEmpty {
@@ -369,23 +368,39 @@ extension TypeChecker {
 
     if let pick = initCandidates.uniqueElement {
       // Rebind the callee and constrain its type.
-      let ctor = LambdaType(constructorFormOf: .init(pick.type.shape)!)
-      guard case .direct(let d) = pick.reference else { unreachable() }
-      referredDecls[callee] = .constructor(.init(d)!)
-      state.facts.assign(^ctor, to: callee)
+      let constructor = LambdaType(constructorFormOf: .init(pick.type.shape)!)
+      referredDecls[callee] = DeclReference(constructor: pick.reference)!
+      state.facts.assign(^constructor, to: callee)
       state.facts.append(pick.type.constraints)
 
-      // Visit the arguments.
-      if parametersMatching(
-        arguments: ast[subject].arguments, of: ast[subject].callee, in: scope,
-        shapedBy: ctor.inputs, updating: &state)
-      {
-        return state.facts.constrain(subject, in: ast, toHaveType: ctor.output)
-      } else {
-        return state.facts.assignErrorType(to: subject)
+      var arguments: [FunctionCallConstraint.Argument] = []
+      for a in ast[subject].arguments {
+        let p = inferredType(
+          of: a.value, shapedBy: ^TypeVariable(), in: scope, updating: &state)
+        arguments.append(.init(label: a.label, type: p, site: ast[a.value].site))
       }
+
+      state.facts.append(
+        FunctionCallConstraint(
+          ^constructor, accepts: arguments, returns: constructor.output,
+          origin: ConstraintOrigin(.callee, at: ast[ast[subject].callee].site)))
+
+      return state.facts.constrain(subject, in: ast, toHaveType: constructor.output)
     } else {
       fatalError("not implemented")
+    }
+  }
+
+  /// Returns the constructor type corresponding to given `initializer`.
+  private func convertToConstructor(_ initializer: AnyType) -> AnyType {
+    switch initializer.base {
+    case let t as LambdaType:
+      return ^LambdaType(constructorFormOf: t)
+    case let t as BoundGenericType:
+      let c = LambdaType(constructorFormOf: .init(t.base)!)
+      return ^BoundGenericType(c, arguments: t.arguments)
+    default:
+      unreachable()
     }
   }
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -766,8 +766,9 @@ extension TypeChecker {
         state.facts.append(instantiatedType.constraints)
 
         // Update the referred declaration map if necessary.
+        // FIXME: Handle generic arguments
         if let c = NameExpr.ID(syntax.callee) {
-          referredDecls[c] = .member(decl)
+          referredDecls[c] = .member(decl, [:])
         }
 
         return state.facts.constrain(subject, in: ast, toHaveType: calleeType.output)

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1686,9 +1686,9 @@ public struct TypeChecker {
       // If the candidate is a direct reference to a type declaration, the next component should be
       // looked up in the referred type's declaration space rather than that of its metatype.
       if let d = c.reference.decl, isNominalTypeDecl(d) {
-        parent = (MetatypeType(c.type.shape)!.instance, c.arguments)
+        parent = (MetatypeType(c.type.shape)!.instance, c.reference.arguments)
       } else {
-        parent = (c.type.shape, c.arguments)
+        parent = (c.type.shape, c.reference.arguments)
       }
     }
 
@@ -1765,9 +1765,9 @@ public struct TypeChecker {
         cause: .init(.binding, at: name.site))
 
       if program.isNonStaticMember(m) && !(parent?.type.base is MetatypeType) {
-        candidates.append(.init(reference: .member(m), type: t, arguments: allArguments))
+        candidates.append(.init(reference: .member(m, allArguments), type: t))
       } else {
-        candidates.append(.init(reference: .direct(m), type: t, arguments: allArguments))
+        candidates.append(.init(reference: .direct(m, allArguments), type: t))
       }
     }
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1726,7 +1726,7 @@ public struct TypeChecker {
       else { continue }
 
       // Determine how the declaration is being referenced.
-      let reference: DeclRef
+      let reference: DeclReference
       if !program.isNonStaticMember(match) {
         reference = .direct(match)
       } else if parentType?.base is MetatypeType {
@@ -1741,10 +1741,10 @@ public struct TypeChecker {
       switch reference {
       case .direct(let d), .member(let d):
         t = instantiate(targetType, in: program.scopeIntroducing(d), cause: c)
-      case .constructor(let d):
-        t = instantiate(targetType, in: program.scopeIntroducing(initializer: d), cause: c)
       case .builtinFunction, .builtinType:
         t = .init(shape: targetType, constraints: [])
+      case .constructor:
+        unreachable()
       }
       candidates.append(.init(reference: reference, type: t))
     }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1748,8 +1748,9 @@ public struct TypeChecker {
     let parentArguments = parent?.arguments ?? [:]
     for m in matches {
       guard var matchType = resolvedType(of: m) else { continue }
-      guard var matchArguments = associateGenericParameters(
-        of: name, declaredBy: m, to: arguments, reportingErrorsTo: &candidateDiagnostics)
+      guard
+        var matchArguments = associateGenericParameters(
+          of: name, declaredBy: m, to: arguments, reportingErrorsTo: &candidateDiagnostics)
       else { continue }
 
       if let g = BoundGenericType(matchType) {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -811,7 +811,7 @@ public struct TypeChecker {
     at declSite: SourceRange
   ) -> Conformance? {
     let useScope = AnyScopeID(source)
-    let specializations = [ast[trait.decl].selfParameterDecl: model]
+    let specializations: GenericArguments = [ast[trait.decl].selfParameterDecl: model]
     var implementations = Conformance.ImplementationMap()
     var notes: DiagnosticSet = []
 
@@ -939,7 +939,7 @@ public struct TypeChecker {
     of requirementName: Name,
     in model: AnyType,
     withCallableType requiredType: LambdaType,
-    specializedWith specializations: [GenericParameterDecl.ID: AnyType],
+    specializedWith specializations: GenericArguments,
     exposedTo scope: AnyScopeID
   ) -> AnyDeclID? {
     /// Returns `true` if candidate `d` has `requirementType`.

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -951,7 +951,7 @@ public struct Emitter {
       switch n.declaration {
       case .builtinFunction(let f):
         return emit(apply: f, to: expr.arguments, at: expr.site, into: &module)
-      case .constructor(let d):
+      case .constructor(let d, _):
         return emitRValue(constructorCall: expr, applying: d, into: &module)
       default:
         break
@@ -1159,7 +1159,7 @@ public struct Emitter {
     into module: inout Module
   ) -> Operand {
     switch e.declaration {
-    case .direct(let d):
+    case .direct(let d, _):
       guard let s = frames[program[d]] else { fatalError("not implemented") }
       if module.type(of: s).isObject {
         return s
@@ -1167,7 +1167,7 @@ public struct Emitter {
         return module.append(module.makeLoad(s, anchoredAt: e.site), to: insertionBlock!)[0]
       }
 
-    case .member(let d):
+    case .member(let d, _):
       return emitRValue(memberExpr: e, declaredBy: program[d], into: &module)
 
     case .constructor:
@@ -1268,7 +1268,7 @@ public struct Emitter {
         ParameterType(calleeType.inputs[0].type)!.access, foldedSequenceExpr: lhs, into: &module)
 
       // Emit the callee.
-      guard case .member(let calleeDecl) = program.referredDecls[callee.expr] else {
+      guard case .member(let calleeDecl, _) = program.referredDecls[callee.expr] else {
         unreachable()
       }
       let f = Operand.constant(
@@ -1357,7 +1357,7 @@ public struct Emitter {
     let calleeType = LambdaType(program.relations.canonical(callee.type))!
 
     switch callee.declaration {
-    case .direct(let d) where d.kind == FunctionDecl.self:
+    case .direct(let d, _) where d.kind == FunctionDecl.self:
       // Callee is a direct reference to a function declaration.
       guard calleeType.environment == .void else {
         fatalError("not implemented")
@@ -1366,7 +1366,7 @@ public struct Emitter {
       let ref = FunctionReference(to: program[FunctionDecl.ID(d)!], in: &module)
       return (.constant(ref), [])
 
-    case .member(let d) where d.kind == FunctionDecl.self:
+    case .member(let d, _) where d.kind == FunctionDecl.self:
       // Callee is a member reference to a function or method.
       let ref = FunctionReference(to: program[FunctionDecl.ID(d)!], in: &module)
       let fun = Operand.constant(ref)
@@ -1734,10 +1734,10 @@ public struct Emitter {
     into module: inout Module
   ) -> Operand {
     switch syntax.declaration {
-    case .direct(let d):
+    case .direct(let d, _):
       return emitLValue(directReferenceTo: program[d], into: &module)
 
-    case .member(let d):
+    case .member(let d, _):
       let r = emitLValue(receiverOf: syntax, into: &module)
       return emitProperty(boundTo: r, declaredBy: program[d], into: &module, at: syntax.site)
 

--- a/Sources/Utils/CustomWitnessedSet.swift
+++ b/Sources/Utils/CustomWitnessedSet.swift
@@ -1,8 +1,11 @@
 /// An unordered collection of unique elements using a custom hash witness.
-public struct CustomWitnessedSet<Element, Witness: HashableWitness<Element>> {
+public struct CustomWitnessedSet<Witness: HashableWitness> {
+
+  /// The type of the elements in the set.
+  public typealias Element = Witness.Element
 
   /// An element wrapped into a hashable box.
-  fileprivate typealias _Element = HashableBox<Element, Witness>
+  fileprivate typealias _Element = HashableBox<Witness>
 
   /// The contents of `self`
   fileprivate var contents: Set<_Element>

--- a/Sources/Utils/EquatableWitness.swift
+++ b/Sources/Utils/EquatableWitness.swift
@@ -1,0 +1,10 @@
+/// A type serving as a witness to another type's conformance to `Equatable`.
+public protocol EquatableWitness<Element> {
+
+  /// The element for which `Self` serves as a witness.
+  associatedtype Element
+
+  /// Returns whether `left` is equal to `right`.
+  static func isEqual(_ left: Element, to right: Element) -> Bool
+
+}

--- a/Sources/Utils/HashableBox.swift
+++ b/Sources/Utils/HashableBox.swift
@@ -1,11 +1,11 @@
 /// A wrapper implementing a value's conformance to `Hashable` with a custom witness.
-public struct HashableBox<Base, Witness: HashableWitness<Base>>: Hashable {
+public struct HashableBox<Witness: HashableWitness>: Hashable {
 
   /// The value wrapped by this instance.
-  public let base: Base
+  public let base: Witness.Element
 
   /// Creates a new instance wrapping `base`.
-  public init(_ base: Base) {
+  public init(_ base: Witness.Element) {
     self.base = base
   }
 

--- a/Sources/Utils/HashableWitness.swift
+++ b/Sources/Utils/HashableWitness.swift
@@ -1,13 +1,10 @@
 /// A type serving as a witness to another type's conformance to `Hashable`.
-public protocol HashableWitness<Element> {
+public protocol HashableWitness<Element>: EquatableWitness {
 
   /// The element for which `Self` serves as a witness.
   associatedtype Element
 
   /// Hashes the salient features of `element` by feeding them into `hasher`.
   static func hash(_ element: Element, into hasher: inout Hasher)
-
-  /// Returns whether `left` is equal to `right`.
-  static func isEqual(_ left: Element, to right: Element) -> Bool
 
 }


### PR DESCRIPTION
To support monomorphization, the emitter should have access to the generic arguments that were used to infer the types of all expressions.