### PR TITLE
Make parallel testing work locally.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,9 +26,9 @@ jobs:
       matrix:
         host: [
           { type: linux, os: ubuntu-latest,
-	    build-options: "-v --build-tests -Xswiftc -enable-testing",
-	    test-options: "-v --enable-code-coverage"
-	  }
+            build-options: "-v --build-tests -Xswiftc -enable-testing",
+            test-options: "-v --enable-code-coverage"
+          }
         ]
         configuration: [ "debug", "release" ]
 
@@ -59,11 +59,11 @@ jobs:
       matrix:
         host: [
           {
-  	    type: macos, os: macos-latest,
+              type: macos, os: macos-latest,
             build-options: "-v --build-tests -Xswiftc -enable-testing",
-	    # No coverage support on MacOS
-	    test-options: "-v"
-	  }
+            # No coverage support on MacOS
+            test-options: "-v"
+          }
         ]
         swift: [
           { version: "5.8" }

--- a/Sources/Utils/FileManager+Extensions.swift
+++ b/Sources/Utils/FileManager+Extensions.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension FileManager {
+
+  /// Creates a new temporary directory and returns its URL
+  public func makeTemporaryDirectory() throws -> URL {
+    let r = temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try createDirectory(at: r, withIntermediateDirectories: true)
+    return r
+  }
+
+  /// Returns a unique URL into which a temporary file can be written.
+  public func makeTemporaryFileURL() -> URL {
+    temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: false)
+  }
+
+}

--- a/Sources/ValCommand/ValCommand.swift
+++ b/Sources/ValCommand/ValCommand.swift
@@ -170,8 +170,8 @@ public struct ValCommand: ParsableCommand {
 
     assert(outputType == .binary)
 
-    let objectFiles = try llvmProgram.write(
-      .objectFile, to: FileManager.default.temporaryDirectory)
+    let objectDir = try FileManager.default.makeTemporaryDirectory()
+    let objectFiles = try llvmProgram.write(.objectFile, to: objectDir)
     let binaryPath = executableOutputPath(default: productName)
 
     #if os(macOS)

--- a/Tests/EndToEndTests/ExecutionTests.swift
+++ b/Tests/EndToEndTests/ExecutionTests.swift
@@ -22,7 +22,7 @@ final class ExecutionTests: XCTestCase {
   }
 
   func testHelloWorld() throws {
-    let f = FileManager.default.temporaryFile()
+    let f = FileManager.default.makeTemporaryFileURL()
     let s = #"public fun main() { print("Hello, World!") }"#
     try s.write(to: f, atomically: true, encoding: .utf8)
 
@@ -36,7 +36,7 @@ final class ExecutionTests: XCTestCase {
   ///
   /// Ensures that the compilation succeeds.
   func compile(_ input: URL, with arguments: [String]) throws -> URL {
-    let output = FileManager.default.temporaryFile()
+    let output = FileManager.default.makeTemporaryFileURL()
     let cli = try ValCommand.parse(arguments + ["-o", output.relativePath, input.relativePath])
     var stderr = ""
     let status = try cli.execute(loggingTo: &stderr)
@@ -70,15 +70,6 @@ final class ExecutionTests: XCTestCase {
     let standardOutput = String(
       data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)
     return (task.terminationStatus, standardOutput ?? "")
-  }
-
-}
-
-extension FileManager {
-
-  /// Returns the URL of a temporary file.
-  func temporaryFile() -> URL {
-    temporaryDirectory.appendingPathComponent("\(UUID())")
   }
 
 }

--- a/Tests/ValCommandTests/SourceLineExtensionsTests.swift
+++ b/Tests/ValCommandTests/SourceLineExtensionsTests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class SourceLineExtensionsTests: XCTestCase {
 
   func testInitFromArgument() throws {
-    let f = FileManager.default.temporaryFile()
+    let f = FileManager.default.makeTemporaryFileURL()
     try "Hello,\nWorld!".write(to: f, atomically: true, encoding: .utf8)
 
     let l1 = try XCTUnwrap(SourceLine(argument: "\(f.relativePath):1"))

--- a/Tests/ValCommandTests/ValCommandTests.swift
+++ b/Tests/ValCommandTests/ValCommandTests.swift
@@ -101,7 +101,7 @@ final class ValCommandTests: XCTestCase {
 
   /// Writes `s` to a temporary file and returns its URL.
   private func newFile(containing s: String) throws -> URL {
-    let f = FileManager.default.temporaryFile()
+    let f = FileManager.default.makeTemporaryFileURL()
     try s.write(to: f, atomically: true, encoding: .utf8)
     return f
   }
@@ -113,7 +113,7 @@ final class ValCommandTests: XCTestCase {
     _ input: URL
   ) throws -> CompilationResult {
     // Create a temporary output.
-    let output = FileManager.default.temporaryFile()
+    let output = FileManager.default.makeTemporaryFileURL()
 
     // Parse the command line's arguments.
     let cli = try ValCommand.parse(arguments + ["-o", output.relativePath, input.relativePath])
@@ -122,15 +122,6 @@ final class ValCommandTests: XCTestCase {
     var stderr = ""
     let status = try cli.execute(loggingTo: &stderr)
     return CompilationResult(status: status, output: output, stderr: stderr)
-  }
-
-}
-
-extension FileManager {
-
-  /// Returns the URL of a temporary file.
-  func temporaryFile() -> URL {
-    temporaryDirectory.appendingPathComponent("\(UUID())")
   }
 
 }


### PR DESCRIPTION
I noticed during local parallel testing that Val.o was sometimes reported by the linker as having length 0.  I think that's because it was being written directly into FileManager.default.temporaryDirectory, and testing processes were stomping on one another.