### PR TITLE
Refactor initialization

### DIFF
--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -125,7 +125,7 @@ extension Diagnostic {
     .error("type '\(type)' is not a trait", at: site)
   }
 
-  static func error(
+  public static func error(
     _ type: AnyType, doesNotConformTo trait: TraitType, at site: SourceRange,
     because notes: DiagnosticSet = []
   ) -> Diagnostic {

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -718,6 +718,8 @@ public struct Emitter {
   }
 
   private mutating func emit(assignStmt stmt: AssignStmt.Typed, into module: inout Module) {
+    // The left operand of an assignment should always be marked for mutation, even if the
+    // statement actually denotes initialization.
     guard stmt.left.kind == InoutExpr.self else {
       report(.error(assignmentLHSRequiresMutationMarkerAt: .empty(at: stmt.left.site.first())))
       return

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -2037,8 +2037,7 @@ public struct Emitter {
   ) {
     if let tuple = TupleExpr.ID(value) {
       emitInitialization(of: storage, to: tuple, into: &module)
-    } else if
-      let call = FunctionCallExpr.ID(value),
+    } else if let call = FunctionCallExpr.ID(value),
       let n = NameExpr.ID(program.ast[call].callee),
       case .constructor = program.referredDecls[n]!
     {

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -732,7 +732,7 @@ public struct Emitter {
     // Built-in types do not require deinitialization.
     let l = program.relations.canonical(stmt.left.type)
     if l.base is BuiltinType {
-      emitInitialization(of: lhs, to: rhs, anchoredAt: stmt.site, into: &module)
+      emitInitialization(of: lhs, to: rhs, at: stmt.site, into: &module)
       return
     }
 
@@ -1010,7 +1010,7 @@ public struct Emitter {
     frames.push(.init(scope: AnyScopeID(expr.id)))
     let a = emitRValue(program[expr.success], into: &module)
     if let s = resultStorage {
-      emitInitialization(of: s, to: a, anchoredAt: program[expr.success].site, into: &module)
+      emitInitialization(of: s, to: a, at: program[expr.success].site, into: &module)
     }
     emitStackDeallocs(in: &module, site: expr.site)
     frames.pop()
@@ -1021,7 +1021,7 @@ public struct Emitter {
     let i = frames.top.allocs.count
     let b = emitRValue(program[expr.failure], into: &module)
     if let s = resultStorage {
-      emitInitialization(of: s, to: b, anchoredAt: program[expr.failure].site, into: &module)
+      emitInitialization(of: s, to: b, at: program[expr.failure].site, into: &module)
     }
     for a in frames.top.allocs[i...] {
       module.append(module.makeDeallocStack(for: a, anchoredAt: expr.site), to: insertionBlock!)
@@ -1852,7 +1852,7 @@ public struct Emitter {
       module.makeAllocStack(module.type(of: rvalue).ast, anchoredAt: site),
       to: insertionBlock!)[0]
     frames.top.allocs.append(storage)
-    emitInitialization(of: storage, to: rvalue, anchoredAt: site, into: &module)
+    emitInitialization(of: storage, to: rvalue, at: site, into: &module)
     return storage
   }
 
@@ -2053,18 +2053,18 @@ public struct Emitter {
   }
 
   /// Inserts the IR for initializing `storage` with `value` at the end of the current insertion
-  /// block, anchoring new instructions at `anchor` into `module`.
+  /// block, anchoring new instructions at `site` into `module`.
   private mutating func emitInitialization(
     of storage: Operand,
     to value: Operand,
-    anchoredAt anchor: SourceRange,
+    at site: SourceRange,
     into module: inout Module
   ) {
     let s = module.append(
-      module.makeBorrow(.set, from: storage, anchoredAt: anchor),
+      module.makeBorrow(.set, from: storage, anchoredAt: site),
       to: insertionBlock!)[0]
     module.append(
-      module.makeStore(value, at: s, anchoredAt: anchor),
+      module.makeStore(value, at: s, anchoredAt: site),
       to: insertionBlock!)
   }
 

--- a/Tests/EndToEndTests/TestCases/Factorial.val
+++ b/Tests/EndToEndTests/TestCases/Factorial.val
@@ -2,13 +2,7 @@ fun factorial(_ n: Int) -> Int {
   if n < 2 { 1 } else { n * factorial(n - 1) }
 }
 
-fun assert(_ b: Bool) {
-  if !b {
-    let _ = fatal_error()
-  }
-}
-
 public fun main() {
   let r = factorial(6)
-  assert(r == 720)
+  precondition(r == 720)
 }


### PR DESCRIPTION
This patch gets rid of needless moves when a binding is initialized with the result of a constructor call.