### PR TITLE
`private` Access Modifier

### DIFF
--- a/Sources/Core/AST/Decl/BindingDecl.swift
+++ b/Sources/Core/AST/Decl/BindingDecl.swift
@@ -7,7 +7,7 @@ public struct BindingDecl: Decl {
   public let attributes: [SourceRepresentable<Attribute>]
 
   /// The access modifier of the declaration, if any.
-  public let accessModifier: SourceRepresentable<AccessModifier>?
+  public let accessModifier: SourceRepresentable<AccessModifier>
 
   /// The member modifier of the declaration.
   public let memberModifier: SourceRepresentable<MemberModifier>?
@@ -29,14 +29,15 @@ public struct BindingDecl: Decl {
   ) {
     self.site = site
     self.attributes = attributes
-    self.accessModifier = accessModifier
+    // implicitly mark the binding as private
+    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
     self.memberModifier = memberModifier
     self.pattern = pattern
     self.initializer = initializer
   }
 
   /// Returns whether the declaration is public.
-  public var isPublic: Bool { accessModifier?.value == .public }
+  public var isPublic: Bool { accessModifier.value == .public }
 
   /// Returns whether the declaration denotes a static member.
   public var isStatic: Bool { memberModifier?.value == .static }

--- a/Sources/Core/AST/Decl/BindingDecl.swift
+++ b/Sources/Core/AST/Decl/BindingDecl.swift
@@ -21,7 +21,7 @@ public struct BindingDecl: Decl {
   /// Creates an instance with the given properties.
   public init(
     attributes: [SourceRepresentable<Attribute>] = [],
-    accessModifier: SourceRepresentable<AccessModifier>? = nil,
+    accessModifier: SourceRepresentable<AccessModifier>,
     memberModifier: SourceRepresentable<MemberModifier>? = nil,
     pattern: BindingPattern.ID,
     initializer: AnyExprID?,
@@ -29,8 +29,7 @@ public struct BindingDecl: Decl {
   ) {
     self.site = site
     self.attributes = attributes
-    // implicitly mark the binding as private
-    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
+    self.accessModifier = accessModifier
     self.memberModifier = memberModifier
     self.pattern = pattern
     self.initializer = initializer

--- a/Sources/Core/AST/Decl/ConformanceDecl.swift
+++ b/Sources/Core/AST/Decl/ConformanceDecl.swift
@@ -20,7 +20,7 @@ public struct ConformanceDecl: TypeExtendingDecl {
 
   /// Creates an instance with the given properties.
   public init(
-    accessModifier: SourceRepresentable<AccessModifier>?,
+    accessModifier: SourceRepresentable<AccessModifier>,
     subject: AnyTypeExprID,
     conformances: [NameExpr.ID],
     whereClause: SourceRepresentable<WhereClause>?,
@@ -28,8 +28,7 @@ public struct ConformanceDecl: TypeExtendingDecl {
     site: SourceRange
   ) {
     self.site = site
-    // implicitly mark conformance(s) as private
-    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
+    self.accessModifier = accessModifier
     self.subject = subject
     self.conformances = conformances
     self.whereClause = whereClause

--- a/Sources/Core/AST/Decl/ConformanceDecl.swift
+++ b/Sources/Core/AST/Decl/ConformanceDecl.swift
@@ -4,7 +4,7 @@ public struct ConformanceDecl: TypeExtendingDecl {
   public let site: SourceRange
 
   /// The access modifier of the declaration, if any.
-  public let accessModifier: SourceRepresentable<AccessModifier>?
+  public let accessModifier: SourceRepresentable<AccessModifier>
 
   /// The expression of the extended type.
   public let subject: AnyTypeExprID
@@ -28,7 +28,8 @@ public struct ConformanceDecl: TypeExtendingDecl {
     site: SourceRange
   ) {
     self.site = site
-    self.accessModifier = accessModifier
+    // implicitly mark conformance(s) as private
+    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
     self.subject = subject
     self.conformances = conformances
     self.whereClause = whereClause

--- a/Sources/Core/AST/Decl/ExtensionDecl.swift
+++ b/Sources/Core/AST/Decl/ExtensionDecl.swift
@@ -4,7 +4,7 @@ public struct ExtensionDecl: TypeExtendingDecl {
   public let site: SourceRange
 
   /// The access modifier of the declaration, if any.
-  public let accessModifier: SourceRepresentable<AccessModifier>?
+  public let accessModifier: SourceRepresentable<AccessModifier>
 
   /// The expression of the extended type.
   public let subject: AnyTypeExprID
@@ -24,7 +24,8 @@ public struct ExtensionDecl: TypeExtendingDecl {
     site: SourceRange
   ) {
     self.site = site
-    self.accessModifier = accessModifier
+    // implicitly mark the extension as private
+    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
     self.subject = subject
     self.whereClause = whereClause
     self.members = members

--- a/Sources/Core/AST/Decl/ExtensionDecl.swift
+++ b/Sources/Core/AST/Decl/ExtensionDecl.swift
@@ -17,15 +17,14 @@ public struct ExtensionDecl: TypeExtendingDecl {
 
   /// Creates an instance with the given properties.
   public init(
-    accessModifier: SourceRepresentable<AccessModifier>?,
+    accessModifier: SourceRepresentable<AccessModifier>,
     subject: AnyTypeExprID,
     whereClause: SourceRepresentable<WhereClause>?,
     members: [AnyDeclID],
     site: SourceRange
   ) {
     self.site = site
-    // implicitly mark the extension as private
-    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
+    self.accessModifier = accessModifier
     self.subject = subject
     self.whereClause = whereClause
     self.members = members

--- a/Sources/Core/AST/Decl/FunctionDecl.swift
+++ b/Sources/Core/AST/Decl/FunctionDecl.swift
@@ -53,7 +53,7 @@ public struct FunctionDecl: GenericDecl, GenericScope {
   public init(
     introducerSite: SourceRange,
     attributes: [SourceRepresentable<Attribute>] = [],
-    accessModifier: SourceRepresentable<AccessModifier>? = nil,
+    accessModifier: SourceRepresentable<AccessModifier>,
     memberModifier: SourceRepresentable<MemberModifier>? = nil,
     receiverEffect: SourceRepresentable<AccessEffect>? = nil,
     notation: SourceRepresentable<OperatorNotation>? = nil,
@@ -70,8 +70,7 @@ public struct FunctionDecl: GenericDecl, GenericScope {
     self.site = site
     self.introducerSite = introducerSite
     self.attributes = attributes
-    // implicitly mark the function as private
-    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
+    self.accessModifier = accessModifier
     self.memberModifier = memberModifier
     self.receiverEffect = receiverEffect
     self.notation = notation

--- a/Sources/Core/AST/Decl/FunctionDecl.swift
+++ b/Sources/Core/AST/Decl/FunctionDecl.swift
@@ -12,7 +12,7 @@ public struct FunctionDecl: GenericDecl, GenericScope {
   public let attributes: [SourceRepresentable<Attribute>]
 
   /// The access modifier of the declaration, if any.
-  public let accessModifier: SourceRepresentable<AccessModifier>?
+  public let accessModifier: SourceRepresentable<AccessModifier>
 
   /// The member modifier of the declaration.
   public let memberModifier: SourceRepresentable<MemberModifier>?
@@ -70,7 +70,8 @@ public struct FunctionDecl: GenericDecl, GenericScope {
     self.site = site
     self.introducerSite = introducerSite
     self.attributes = attributes
-    self.accessModifier = accessModifier
+    // implicitly mark the function as private
+    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
     self.memberModifier = memberModifier
     self.receiverEffect = receiverEffect
     self.notation = notation
@@ -85,7 +86,7 @@ public struct FunctionDecl: GenericDecl, GenericScope {
   }
 
   /// Returns whether the declaration is public.
-  public var isPublic: Bool { accessModifier?.value == .public }
+  public var isPublic: Bool { accessModifier.value == .public }
 
   /// Returns whether the declaration denotes a static member function.
   public var isStatic: Bool { memberModifier?.value == .static }

--- a/Sources/Core/AST/Decl/InitializerDecl.swift
+++ b/Sources/Core/AST/Decl/InitializerDecl.swift
@@ -41,7 +41,7 @@ public struct InitializerDecl: GenericDecl, GenericScope {
   public init(
     introducer: SourceRepresentable<Introducer>,
     attributes: [SourceRepresentable<Attribute>],
-    accessModifier: SourceRepresentable<AccessModifier>?,
+    accessModifier: SourceRepresentable<AccessModifier>,
     genericClause: SourceRepresentable<GenericClause>?,
     parameters: [ParameterDecl.ID],
     receiver: ParameterDecl.ID,
@@ -53,8 +53,7 @@ public struct InitializerDecl: GenericDecl, GenericScope {
     self.site = site
     self.introducer = introducer
     self.attributes = attributes
-    // implicitly mark the initializer as private
-    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
+    self.accessModifier = accessModifier
     self.genericClause = genericClause
     self.parameters = parameters
     self.receiver = receiver

--- a/Sources/Core/AST/Decl/InitializerDecl.swift
+++ b/Sources/Core/AST/Decl/InitializerDecl.swift
@@ -21,7 +21,7 @@ public struct InitializerDecl: GenericDecl, GenericScope {
   public let attributes: [SourceRepresentable<Attribute>]
 
   /// The access modifier of the declaration, if any.
-  public let accessModifier: SourceRepresentable<AccessModifier>?
+  public let accessModifier: SourceRepresentable<AccessModifier>
 
   /// The generic clause of the declaration, if any.
   public let genericClause: SourceRepresentable<GenericClause>?
@@ -53,7 +53,8 @@ public struct InitializerDecl: GenericDecl, GenericScope {
     self.site = site
     self.introducer = introducer
     self.attributes = attributes
-    self.accessModifier = accessModifier
+    // implicitly mark the initializer as private
+    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
     self.genericClause = genericClause
     self.parameters = parameters
     self.receiver = receiver
@@ -64,7 +65,7 @@ public struct InitializerDecl: GenericDecl, GenericScope {
   public var isMemberwise: Bool { introducer.value == .memberwiseInit }
 
   /// Returns whether the declaration is public.
-  public var isPublic: Bool { accessModifier?.value == .public }
+  public var isPublic: Bool { accessModifier.value == .public }
 
   public func validateForm(in ast: AST, into diagnostics: inout DiagnosticSet) {
 

--- a/Sources/Core/AST/Decl/MethodDecl.swift
+++ b/Sources/Core/AST/Decl/MethodDecl.swift
@@ -10,7 +10,7 @@ public struct MethodDecl: GenericDecl, GenericScope {
   public let attributes: [SourceRepresentable<Attribute>]
 
   /// The access modifier of the declaration, if any.
-  public let accessModifier: SourceRepresentable<AccessModifier>?
+  public let accessModifier: SourceRepresentable<AccessModifier>
 
   /// The operator notation of the method.
   public let notation: SourceRepresentable<OperatorNotation>?
@@ -36,7 +36,7 @@ public struct MethodDecl: GenericDecl, GenericScope {
   public init(
     introducerSite: SourceRange,
     attributes: [SourceRepresentable<Attribute>],
-    accessModifier: SourceRepresentable<AccessModifier>?,
+    accessModifier: SourceRepresentable<AccessModifier>? = nil,
     notation: SourceRepresentable<OperatorNotation>?,
     identifier: SourceRepresentable<Identifier>,
     genericClause: SourceRepresentable<GenericClause>?,
@@ -48,7 +48,8 @@ public struct MethodDecl: GenericDecl, GenericScope {
     self.site = site
     self.introducerSite = introducerSite
     self.attributes = attributes
-    self.accessModifier = accessModifier
+    // implicitly mark the method as private
+    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
     self.notation = notation
     self.identifier = identifier
     self.genericClause = genericClause
@@ -58,7 +59,7 @@ public struct MethodDecl: GenericDecl, GenericScope {
   }
 
   /// Returns whether the declaration is public.
-  public var isPublic: Bool { accessModifier?.value == .public }
+  public var isPublic: Bool { accessModifier.value == .public }
 
   public func validateForm(in ast: AST, into diagnostics: inout DiagnosticSet) {
     // Parameter declarations must have a type annotation.

--- a/Sources/Core/AST/Decl/MethodDecl.swift
+++ b/Sources/Core/AST/Decl/MethodDecl.swift
@@ -36,7 +36,7 @@ public struct MethodDecl: GenericDecl, GenericScope {
   public init(
     introducerSite: SourceRange,
     attributes: [SourceRepresentable<Attribute>],
-    accessModifier: SourceRepresentable<AccessModifier>? = nil,
+    accessModifier: SourceRepresentable<AccessModifier>,
     notation: SourceRepresentable<OperatorNotation>?,
     identifier: SourceRepresentable<Identifier>,
     genericClause: SourceRepresentable<GenericClause>?,
@@ -48,8 +48,7 @@ public struct MethodDecl: GenericDecl, GenericScope {
     self.site = site
     self.introducerSite = introducerSite
     self.attributes = attributes
-    // implicitly mark the method as private
-    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
+    self.accessModifier = accessModifier
     self.notation = notation
     self.identifier = identifier
     self.genericClause = genericClause

--- a/Sources/Core/AST/Decl/NamespaceDecl.swift
+++ b/Sources/Core/AST/Decl/NamespaceDecl.swift
@@ -7,7 +7,7 @@ public struct NamespaceDecl: SingleEntityDecl, LexicalScope {
   public let introducerSite: SourceRange
 
   /// The access modifier of the declaration, if any.
-  public let accessModifier: SourceRepresentable<AccessModifier>?
+  public let accessModifier: SourceRepresentable<AccessModifier>
 
   /// The identifier of the namespace.
   public let identifier: SourceRepresentable<Identifier>
@@ -25,7 +25,8 @@ public struct NamespaceDecl: SingleEntityDecl, LexicalScope {
   ) {
     self.site = site
     self.introducerSite = introducerSite
-    self.accessModifier = accessModifier
+    // implicitly mark the namespace as private
+    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
     self.identifier = identifier
     self.members = members
   }

--- a/Sources/Core/AST/Decl/NamespaceDecl.swift
+++ b/Sources/Core/AST/Decl/NamespaceDecl.swift
@@ -18,15 +18,14 @@ public struct NamespaceDecl: SingleEntityDecl, LexicalScope {
   /// Creates an instance with the given properties.
   public init(
     introducerSite: SourceRange,
-    accessModifier: SourceRepresentable<AccessModifier>?,
+    accessModifier: SourceRepresentable<AccessModifier>,
     identifier: SourceRepresentable<Identifier>,
     members: [AnyDeclID],
     site: SourceRange
   ) {
     self.site = site
     self.introducerSite = introducerSite
-    // implicitly mark the namespace as private
-    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
+    self.accessModifier = accessModifier
     self.identifier = identifier
     self.members = members
   }

--- a/Sources/Core/AST/Decl/OperatorDecl.swift
+++ b/Sources/Core/AST/Decl/OperatorDecl.swift
@@ -7,7 +7,7 @@ public struct OperatorDecl: Decl {
   public let introducerSite: SourceRange
 
   /// The access modifier of the declaration, if any.
-  public let accessModifier: SourceRepresentable<AccessModifier>?
+  public let accessModifier: SourceRepresentable<AccessModifier>
 
   /// The notation of the operator.
   public let notation: SourceRepresentable<OperatorNotation>
@@ -29,7 +29,8 @@ public struct OperatorDecl: Decl {
   ) {
     self.site = site
     self.introducerSite = introducerSite
-    self.accessModifier = accessModifier
+    // implicitly mark the operator as private
+    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
     self.notation = notation
     self.name = name
     self.precedenceGroup = precedenceGroup

--- a/Sources/Core/AST/Decl/OperatorDecl.swift
+++ b/Sources/Core/AST/Decl/OperatorDecl.swift
@@ -21,7 +21,7 @@ public struct OperatorDecl: Decl {
   /// Creates an instance with the given properties.
   public init(
     introducerSite: SourceRange,
-    accessModifier: SourceRepresentable<AccessModifier>?,
+    accessModifier: SourceRepresentable<AccessModifier>,
     notation: SourceRepresentable<OperatorNotation>,
     name: SourceRepresentable<Identifier>,
     precedenceGroup: SourceRepresentable<PrecedenceGroup>?,
@@ -29,8 +29,7 @@ public struct OperatorDecl: Decl {
   ) {
     self.site = site
     self.introducerSite = introducerSite
-    // implicitly mark the operator as private
-    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
+    self.accessModifier = accessModifier
     self.notation = notation
     self.name = name
     self.precedenceGroup = precedenceGroup

--- a/Sources/Core/AST/Decl/ProductTypeDecl.swift
+++ b/Sources/Core/AST/Decl/ProductTypeDecl.swift
@@ -4,7 +4,7 @@ public struct ProductTypeDecl: SingleEntityDecl, GenericDecl, TypeScope, Generic
   public let site: SourceRange
 
   /// The access modifier of the declaration, if any.
-  public let accessModifier: SourceRepresentable<AccessModifier>?
+  public let accessModifier: SourceRepresentable<AccessModifier>
 
   /// The identifier of the type.
   public let identifier: SourceRepresentable<Identifier>
@@ -34,7 +34,8 @@ public struct ProductTypeDecl: SingleEntityDecl, GenericDecl, TypeScope, Generic
     precondition(members.contains(AnyDeclID(memberwiseInit)))
 
     self.site = site
-    self.accessModifier = accessModifier
+    // implicitly mark the product type as private
+    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
     self.identifier = identifier
     self.genericClause = genericClause
     self.conformances = conformances
@@ -45,7 +46,7 @@ public struct ProductTypeDecl: SingleEntityDecl, GenericDecl, TypeScope, Generic
   public var baseName: String { identifier.value }
 
   /// Returns whether the declaration is public.
-  public var isPublic: Bool { accessModifier?.value != nil }
+  public var isPublic: Bool { accessModifier.value == .public }
 
   public func validateForm(in ast: AST, into diagnostics: inout DiagnosticSet) {
     for m in members {

--- a/Sources/Core/AST/Decl/ProductTypeDecl.swift
+++ b/Sources/Core/AST/Decl/ProductTypeDecl.swift
@@ -23,7 +23,7 @@ public struct ProductTypeDecl: SingleEntityDecl, GenericDecl, TypeScope, Generic
 
   /// Creates an instance with the given properties.
   public init(
-    accessModifier: SourceRepresentable<AccessModifier>?,
+    accessModifier: SourceRepresentable<AccessModifier>,
     identifier: SourceRepresentable<Identifier>,
     genericClause: SourceRepresentable<GenericClause>?,
     conformances: [NameExpr.ID],
@@ -34,8 +34,7 @@ public struct ProductTypeDecl: SingleEntityDecl, GenericDecl, TypeScope, Generic
     precondition(members.contains(AnyDeclID(memberwiseInit)))
 
     self.site = site
-    // implicitly mark the product type as private
-    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
+    self.accessModifier = accessModifier
     self.identifier = identifier
     self.genericClause = genericClause
     self.conformances = conformances

--- a/Sources/Core/AST/Decl/SubscriptDecl.swift
+++ b/Sources/Core/AST/Decl/SubscriptDecl.swift
@@ -49,7 +49,7 @@ public struct SubscriptDecl: GenericDecl, GenericScope {
   public init(
     introducer: SourceRepresentable<Introducer>,
     attributes: [SourceRepresentable<Attribute>],
-    accessModifier: SourceRepresentable<AccessModifier>?,
+    accessModifier: SourceRepresentable<AccessModifier>,
     memberModifier: SourceRepresentable<MemberModifier>?,
     identifier: SourceRepresentable<Identifier>?,
     genericClause: SourceRepresentable<GenericClause>?,
@@ -62,7 +62,7 @@ public struct SubscriptDecl: GenericDecl, GenericScope {
     self.site = site
     self.introducer = introducer
     self.attributes = attributes
-    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
+    self.accessModifier = accessModifier
     self.memberModifier = memberModifier
     self.identifier = identifier
     self.genericClause = genericClause

--- a/Sources/Core/AST/Decl/SubscriptDecl.swift
+++ b/Sources/Core/AST/Decl/SubscriptDecl.swift
@@ -20,7 +20,7 @@ public struct SubscriptDecl: GenericDecl, GenericScope {
   public let attributes: [SourceRepresentable<Attribute>]
 
   /// The access modifier of the declaration, if any.
-  public let accessModifier: SourceRepresentable<AccessModifier>?
+  public let accessModifier: SourceRepresentable<AccessModifier>
 
   /// The member modifier of the declaration.
   public let memberModifier: SourceRepresentable<MemberModifier>?
@@ -62,7 +62,7 @@ public struct SubscriptDecl: GenericDecl, GenericScope {
     self.site = site
     self.introducer = introducer
     self.attributes = attributes
-    self.accessModifier = accessModifier
+    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
     self.memberModifier = memberModifier
     self.identifier = identifier
     self.genericClause = genericClause
@@ -76,7 +76,7 @@ public struct SubscriptDecl: GenericDecl, GenericScope {
   public var isProperty: Bool { introducer.value == .property }
 
   /// Returns whether the declaration is public.
-  public var isPublic: Bool { accessModifier?.value == .public }
+  public var isPublic: Bool { accessModifier.value == .public }
 
   /// Returns whether the declaration denotes a static subscript.
   public var isStatic: Bool { memberModifier?.value == .static }

--- a/Sources/Core/AST/Decl/TraitDecl.swift
+++ b/Sources/Core/AST/Decl/TraitDecl.swift
@@ -6,7 +6,7 @@ public struct TraitDecl: SingleEntityDecl, TypeScope, GenericScope {
   public let site: SourceRange
 
   /// The access modifier of the declaration, if any.
-  public let accessModifier: SourceRepresentable<AccessModifier>?
+  public let accessModifier: SourceRepresentable<AccessModifier>
 
   /// The identifier of the trait.
   public let identifier: SourceRepresentable<Identifier>
@@ -32,7 +32,8 @@ public struct TraitDecl: SingleEntityDecl, TypeScope, GenericScope {
     precondition(members.contains(AnyDeclID(selfParameterDecl)))
 
     self.site = site
-    self.accessModifier = accessModifier
+    // implicitly mark the trait as private
+    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
     self.identifier = identifier
     self.refinements = refinements
     self.selfParameterDecl = selfParameterDecl

--- a/Sources/Core/AST/Decl/TraitDecl.swift
+++ b/Sources/Core/AST/Decl/TraitDecl.swift
@@ -22,7 +22,7 @@ public struct TraitDecl: SingleEntityDecl, TypeScope, GenericScope {
 
   /// Creates an instance with the given properties.
   public init(
-    accessModifier: SourceRepresentable<AccessModifier>?,
+    accessModifier: SourceRepresentable<AccessModifier>,
     identifier: SourceRepresentable<Identifier>,
     refinements: [NameExpr.ID],
     members: [AnyDeclID],
@@ -32,8 +32,7 @@ public struct TraitDecl: SingleEntityDecl, TypeScope, GenericScope {
     precondition(members.contains(AnyDeclID(selfParameterDecl)))
 
     self.site = site
-    // implicitly mark the trait as private
-    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
+    self.accessModifier = accessModifier
     self.identifier = identifier
     self.refinements = refinements
     self.selfParameterDecl = selfParameterDecl

--- a/Sources/Core/AST/Decl/TypeAliasDecl.swift
+++ b/Sources/Core/AST/Decl/TypeAliasDecl.swift
@@ -17,15 +17,14 @@ public struct TypeAliasDecl: SingleEntityDecl, GenericDecl, TypeScope, GenericSc
 
   /// Creates an instance with the given properties.
   public init(
-    accessModifier: SourceRepresentable<AccessModifier>?,
+    accessModifier: SourceRepresentable<AccessModifier>,
     identifier: SourceRepresentable<Identifier>,
     genericClause: SourceRepresentable<GenericClause>?,
     aliasedType: AnyTypeExprID,
     site: SourceRange
   ) {
     self.site = site
-    // implicitly mark the type alias as private
-    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
+    self.accessModifier = accessModifier
     self.identifier = identifier
     self.genericClause = genericClause
     self.aliasedType = aliasedType

--- a/Sources/Core/AST/Decl/TypeAliasDecl.swift
+++ b/Sources/Core/AST/Decl/TypeAliasDecl.swift
@@ -4,7 +4,7 @@ public struct TypeAliasDecl: SingleEntityDecl, GenericDecl, TypeScope, GenericSc
   public let site: SourceRange
 
   /// The access modifier of the declaration, if any.
-  public let accessModifier: SourceRepresentable<AccessModifier>?
+  public let accessModifier: SourceRepresentable<AccessModifier>
 
   /// The identifier of the alias.
   public let identifier: SourceRepresentable<Identifier>
@@ -24,7 +24,8 @@ public struct TypeAliasDecl: SingleEntityDecl, GenericDecl, TypeScope, GenericSc
     site: SourceRange
   ) {
     self.site = site
-    self.accessModifier = accessModifier
+    // implicitly mark the type alias as private
+    self.accessModifier = accessModifier ?? SourceRepresentable(value: .private, range: site)
     self.identifier = identifier
     self.genericClause = genericClause
     self.aliasedType = aliasedType

--- a/Sources/Core/AST/DeclModifiers/AccessModifier.swift
+++ b/Sources/Core/AST/DeclModifiers/AccessModifier.swift
@@ -1,6 +1,9 @@
 /// An access modifier.
 public enum AccessModifier: Codable {
 
+  /// Denotes (the default) private declaration.
+  case `private`
+
   /// Denotes a public declaration.
   case `public`
 

--- a/Sources/FrontEnd/Parse/Lexer.swift
+++ b/Sources/FrontEnd/Parse/Lexer.swift
@@ -100,6 +100,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       case "postfix": token.kind = .`postfix`
       case "prefix": token.kind = .`prefix`
       case "property": token.kind = .`property`
+      case "private": token.kind = .`private`
       case "public": token.kind = .`public`
       case "remote": token.kind = .`remote`
       case "return": token.kind = .`return`

--- a/Sources/FrontEnd/Parse/Parser+Diagnostics.swift
+++ b/Sources/FrontEnd/Parse/Parser+Diagnostics.swift
@@ -55,6 +55,17 @@ extension Diagnostic {
   }
 
   static func error(
+    inconsistentAccessModifiers m: SourceRepresentable<AccessModifier>,
+    appearsAfterPreviousAccessModifier prev: SourceRepresentable<AccessModifier>
+  ) -> Diagnostic {
+    .error(
+      "inconsistent access modifier '\(m.value)'", at: m.site,
+      notes: [
+        .note("previously declared as '\(prev.value)'", at: prev.site)
+      ])
+  }
+
+  static func error(
     duplicateImplementationIntroducer i: SourceRepresentable<AccessEffect>
   ) -> Diagnostic {
     .error("duplicate implementation introducer '\(i.value)'", at: i.site)

--- a/Sources/FrontEnd/Parse/Parser+Diagnostics.swift
+++ b/Sources/FrontEnd/Parse/Parser+Diagnostics.swift
@@ -56,12 +56,12 @@ extension Diagnostic {
 
   static func error(
     inconsistentAccessModifiers m: SourceRepresentable<AccessModifier>,
-    appearsAfterPreviousAccessModifier prev: SourceRepresentable<AccessModifier>
+    appearsAfterPreviousAccessModifier p: SourceRepresentable<AccessModifier>
   ) -> Diagnostic {
     .error(
       "inconsistent access modifier '\(m.value)'", at: m.site,
       notes: [
-        .note("previously declared as '\(prev.value)'", at: prev.site)
+        .note("previously declared as '\(p.value)'", at: p.site)
       ])
   }
 

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -1330,11 +1330,10 @@ public enum Parser {
         SourceRepresentable(value: .static, range: token.site)
       }))
 
-  static let accessModifier =
-    (take(.public)
-      .map({ (_, token) -> SourceRepresentable<AccessModifier> in
-        SourceRepresentable(value: .public, range: token.site)
-      }))
+  static let accessModifier = translate([
+    .private: AccessModifier.private,
+    .public: AccessModifier.public,
+  ])
 
   static let captureList = inContext(
     .captureList,

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -134,11 +134,11 @@ public enum Parser {
         }
 
         // Catch incosistent access modifiers.
-        else if let prev = accessModifiers.first, prev != access {
+        else if let p = accessModifiers.first, p != access {
           state.diagnostics.insert(
             .error(
               inconsistentAccessModifiers: access,
-              appearsAfterPreviousAccessModifier: prev))
+              appearsAfterPreviousAccessModifier: p))
         }
 
         // Catch duplicate access modifiers.
@@ -432,12 +432,11 @@ public enum Parser {
     }
 
     // Create a new `BindingDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     assert(prologue.memberModifiers.count <= 1)
     return state.insert(
       BindingDecl(
         attributes: prologue.attributes,
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         memberModifier: prologue.memberModifiers.first,
         pattern: pattern,
         initializer: initializer,
@@ -470,10 +469,9 @@ public enum Parser {
     }
 
     // Create a new `ConformanceDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     return state.insert(
       ConformanceDecl(
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         subject: parts.0.0.0.1,
         conformances: parts.0.0.1,
         whereClause: parts.0.1,
@@ -511,10 +509,9 @@ public enum Parser {
     }
 
     // Create a new `ExtensionDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     return state.insert(
       ExtensionDecl(
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         subject: parts.0.0.1,
         whereClause: parts.0.1,
         members: parts.1,
@@ -584,13 +581,12 @@ public enum Parser {
     }
 
     // Create a new `FunctionDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     assert(prologue.memberModifiers.count <= 1)
     return state.insert(
       FunctionDecl(
         introducerSite: head.introducerSite,
         attributes: prologue.attributes,
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         memberModifier: prologue.memberModifiers.first,
         receiverEffect: signature.receiverEffect,
         notation: head.notation,
@@ -628,12 +624,11 @@ public enum Parser {
     }
 
     // Create a new `MethodDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     return state.insert(
       MethodDecl(
         introducerSite: head.introducerSite,
         attributes: prologue.attributes,
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         notation: head.notation,
         identifier: head.stem,
         genericClause: head.genericClause,
@@ -702,13 +697,12 @@ public enum Parser {
         site: introducer.site))
 
     // Create a new `InitializerDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     assert(prologue.memberModifiers.isEmpty)
     return state.insert(
       InitializerDecl(
         introducer: SourceRepresentable(value: .`init`, range: introducer.site),
         attributes: prologue.attributes,
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         genericClause: genericClause,
         parameters: parameters,
         receiver: receiver,
@@ -738,12 +732,11 @@ public enum Parser {
         site: introducerSite))
 
     // Create a new `InitializerDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     return state.insert(
       InitializerDecl(
         introducer: SourceRepresentable(value: .memberwiseInit, range: introducerSite),
         attributes: prologue.attributes,
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         genericClause: nil,
         parameters: [],
         receiver: receiver,
@@ -774,11 +767,10 @@ public enum Parser {
     }
 
     // Create a new `NamespaceDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     return state.insert(
       NamespaceDecl(
         introducerSite: parts.0.0.site,
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         identifier: state.token(parts.0.1),
         members: parts.1,
         site: state.range(from: prologue.startIndex)))
@@ -808,11 +800,10 @@ public enum Parser {
     }
 
     // Create a new `OperatorDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     return state.insert(
       OperatorDecl(
         introducerSite: parts.0.0.0.site,
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         notation: parts.0.0.1,
         name: parts.0.1,
         precedenceGroup: parts.1,
@@ -833,13 +824,12 @@ public enum Parser {
       using: { (s) in try parseSubscriptDeclBody(in: &s, asNonStaticMember: isNonStatic) })
 
     // Create a new `SubscriptDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     assert(prologue.memberModifiers.count <= 1)
     return state.insert(
       SubscriptDecl(
         introducer: head.introducer,
         attributes: prologue.attributes,
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         memberModifier: prologue.memberModifiers.first,
         identifier: head.stem,
         genericClause: nil,
@@ -867,13 +857,12 @@ public enum Parser {
       using: { (s) in try parseSubscriptDeclBody(in: &s, asNonStaticMember: isNonStatic) })
 
     // Create a new `SubscriptDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     assert(prologue.memberModifiers.count <= 1)
     return state.insert(
       SubscriptDecl(
         introducer: head.introducer,
         attributes: prologue.attributes,
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         memberModifier: prologue.memberModifiers.first,
         identifier: head.stem,
         genericClause: head.genericClause,
@@ -1007,10 +996,9 @@ public enum Parser {
     members.append(AnyDeclID(selfParameterDecl))
 
     // Create a new `TraitDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     return state.insert(
       TraitDecl(
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         identifier: state.token(name),
         refinements: refinements,
         members: members,
@@ -1050,10 +1038,9 @@ public enum Parser {
       updating: &state)
 
     // Create a new `ProductTypeDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     return state.insert(
       ProductTypeDecl(
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         identifier: state.token(parts.0.0.0.1),
         genericClause: parts.0.0.1,
         conformances: parts.0.1 ?? [],
@@ -1083,7 +1070,7 @@ public enum Parser {
       synthesized: InitializerDecl(
         introducer: SourceRepresentable(value: .memberwiseInit, range: startOfTypeDecl),
         attributes: [],
-        accessModifier: nil,
+        accessModifier: SourceRepresentable(value: .private, range: startOfTypeDecl),
         genericClause: nil,
         parameters: [],
         receiver: receiver,
@@ -1118,14 +1105,25 @@ public enum Parser {
     }
 
     // Create a new `TypeAliasDecl`.
-    assert(prologue.accessModifiers.count <= 1)
     return state.insert(
       TypeAliasDecl(
-        accessModifier: prologue.accessModifiers.first,
+        accessModifier: declAccessModifier(ofDeclPrologue: prologue, in: &state),
         identifier: state.token(parts.0.0.0.1),
         genericClause: parts.0.0.1,
         aliasedType: parts.1,
         site: state.range(from: prologue.startIndex)))
+  }
+
+  /// Returns the specified access modifier of the provided `prologue`, or synthesizes an implicit one
+  private static func declAccessModifier(
+    ofDeclPrologue prologue: DeclPrologue,
+    in state: inout ParserState
+  ) -> SourceRepresentable<AccessModifier> {
+    // Declarations are private by default.
+    assert(prologue.accessModifiers.count <= 1)
+    return prologue.accessModifiers.first
+      ?? SourceRepresentable(
+        value: .private, range: state.lexer.sourceCode.emptyRange(at: prologue.startIndex))
   }
 
   static func parseFunctionDeclHead(
@@ -1983,6 +1981,7 @@ public enum Parser {
     let decl = state.insert(
       FunctionDecl(
         introducerSite: introducer.site,
+        accessModifier: SourceRepresentable(value: .private, range: introducer.site),
         receiverEffect: signature.receiverEffect,
         explicitCaptures: explicitCaptures ?? [],
         parameters: signature.parameters,
@@ -2145,6 +2144,7 @@ public enum Parser {
     let decl = state.insert(
       FunctionDecl(
         introducerSite: introducer.site,
+        accessModifier: SourceRepresentable(value: .private, range: introducer.site),
         receiverEffect: effect,
         explicitCaptures: explicitCaptures,
         output: output,
@@ -2376,11 +2376,13 @@ public enum Parser {
   static let conditionalClauseItem = Choose(
     bindingPattern.and(take(.assign)).and(expr)
       .map({ (state, tree) -> ConditionItem in
+        let startOfBindingDecl = state.ast[tree.0.0].site
         let id = state.insert(
           BindingDecl(
+            accessModifier: SourceRepresentable(value: .private, range: startOfBindingDecl),
             pattern: tree.0.0,
             initializer: tree.1,
-            site: state.ast[tree.0.0].site.extended(upTo: state.currentIndex)))
+            site: startOfBindingDecl.extended(upTo: state.currentIndex)))
         return .decl(id)
       }),
     or:
@@ -2799,11 +2801,13 @@ public enum Parser {
   static let forStmt =
     (take(.for).and(bindingPattern).and(forSite).and(maybe(forFilter)).and(loopBody)
       .map({ (state, tree) -> ForStmt.ID in
+        let startOfBindingDecl = state.ast[tree.0.0.0.1].site
         let decl = state.insert(
           BindingDecl(
+            accessModifier: SourceRepresentable(value: .private, range: startOfBindingDecl),
             pattern: tree.0.0.0.1,
             initializer: nil,
-            site: state.ast[tree.0.0.0.1].site))
+            site: startOfBindingDecl))
         return state.insert(
           ForStmt(
             binding: decl, domain: tree.0.0.1, filter: tree.0.1, body: tree.1,

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -133,7 +133,7 @@ public enum Parser {
               appearsBeforeAccessModifier: access))
         }
 
-        // Catch incosistent access modifiers.
+        // Catch inconsistent access modifiers.
         else if let p = accessModifiers.first, p != access {
           state.diagnostics.insert(
             .error(

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -133,6 +133,14 @@ public enum Parser {
               appearsBeforeAccessModifier: access))
         }
 
+        // Catch incosistent access modifiers.
+        else if let prev = accessModifiers.first, prev != access {
+          state.diagnostics.insert(
+            .error(
+              inconsistentAccessModifiers: access,
+              appearsAfterPreviousAccessModifier: prev))
+        }
+
         // Catch duplicate access modifiers.
         else if !accessModifiers.insert(access).inserted {
           state.diagnostics.insert(.error(duplicateAccessModifier: access))

--- a/Sources/FrontEnd/Parse/Token.swift
+++ b/Sources/FrontEnd/Parse/Token.swift
@@ -47,6 +47,7 @@ public struct Token {
     case `postfix`
     case `prefix`
     case `property`
+    case `private`
     case `public`
     case `remote`
     case `return`

--- a/Tests/ValTests/LexerTests.swift
+++ b/Tests/ValTests/LexerTests.swift
@@ -119,7 +119,7 @@ final class LexerTests: XCTestCase {
   func testKeywords() {
     let input: SourceFile = """
       any break catch conformance continue deinit do else extension for fun if import in infix init
-      inout let match namespace nil operator postfix prefix property public remote return set sink
+      inout let match namespace nil operator postfix prefix property private public remote return set sink
       some spawn static subscript trait try type typealias var where while yield yielded
       """
 
@@ -151,6 +151,7 @@ final class LexerTests: XCTestCase {
         TokenSpecification(.`postfix`, "postfix"),
         TokenSpecification(.`prefix`, "prefix"),
         TokenSpecification(.`property`, "property"),
+        TokenSpecification(.`private`, "private"),
         TokenSpecification(.`public`, "public"),
         TokenSpecification(.`remote`, "remote"),
         TokenSpecification(.`return`, "return"),

--- a/Tests/ValTests/ParserTests.swift
+++ b/Tests/ValTests/ParserTests.swift
@@ -99,7 +99,7 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "public fun foo() {}"
     let (declID, ast) = try input.parse(inContext: .namespaceBody, with: Parser.parseDecl)
     let decl = try XCTUnwrap(ast[declID] as? FunctionDecl)
-    XCTAssertEqual(decl.accessModifier?.value, .public)
+    XCTAssertEqual(decl.accessModifier.value, .public)
   }
 
   func testTypeAliasDecl() throws {
@@ -175,7 +175,7 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "public var x: Int"
     let (declID, ast) = try input.parse(inContext: .productBody, with: Parser.parseDecl)
     let decl = try XCTUnwrap(ast[declID] as? BindingDecl)
-    XCTAssertEqual(decl.accessModifier?.value, .public)
+    XCTAssertEqual(decl.accessModifier.value, .public)
   }
 
   func testProductTypeMemberStatic() throws {
@@ -189,7 +189,7 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "public static var x: Int"
     let (declID, ast) = try input.parse(inContext: .productBody, with: Parser.parseDecl)
     let decl = try XCTUnwrap(ast[declID] as? BindingDecl)
-    XCTAssertEqual(decl.accessModifier?.value, .public)
+    XCTAssertEqual(decl.accessModifier.value, .public)
     XCTAssertEqual(decl.memberModifier?.value, .static)
   }
 
@@ -362,7 +362,7 @@ final class ParserTests: XCTestCase {
     let input: SourceFile = "public static fun forty_two() -> Int { 42 }"
     let (declID, ast) = try input.parse(inContext: .extensionBody, with: Parser.parseDecl)
     let decl = try XCTUnwrap(ast[declID] as? FunctionDecl)
-    XCTAssertEqual(decl.accessModifier?.value, .public)
+    XCTAssertEqual(decl.accessModifier.value, .public)
     XCTAssertEqual(decl.memberModifier?.value, .static)
   }
 


### PR DESCRIPTION
This PR adds support for the `private` access modifier (#84), as discussed with @kyouko-taiga.
It is possible to mark functions, method, binding, etc. declaration explicitly as `private`, e.g.,:
```
private fun my_private_function(_ a: let Int, _ b: let Int) -> Int { ... }
```
Furthermore, any declaration without access modifiers is treated implicitly as private.
We may consider a changing the `SourceRange` of the implicitly "generated" private access modifiers. 