### PR TITLE
Refactor the way extensions are bound

### DIFF
--- a/Sources/Core/DeclReference.swift
+++ b/Sources/Core/DeclReference.swift
@@ -10,11 +10,14 @@ public enum DeclReference: Hashable {
   /// A reference to an initializer used as a constructor.
   case constructor(InitializerDecl.ID, GenericArguments)
 
-  /// A reference to a built-in function.
-  case builtinFunction(BuiltinFunction)
+  /// A reference to the built-in module.
+  case builtinModule
 
   /// A reference to a built-in type.
   case builtinType
+
+  /// A reference to a built-in function.
+  case builtinFunction(BuiltinFunction)
 
   /// Converts a direct initializer reference to a constructor reference.
   public init?(constructor other: DeclReference) {

--- a/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
@@ -59,10 +59,17 @@ enum NameResolutionResult {
 
     /// Creates an instance denoting a built-in type.
     init(_ t: BuiltinType) {
+      precondition(t != .module)
       self.reference = .builtinType
-      self.type = .init(shape: ^t, constraints: [])
+      self.type = .init(shape: ^MetatypeType(of: t), constraints: [])
       self.argumentsDiagnostic = nil
     }
+
+    /// A candidate denoting a reference to the built-in module.
+    static var builtinModule = Candidate(
+      reference: .builtinModule,
+      type: .init(shape: .builtin(.module), constraints: []),
+      argumentsDiagnostic: nil)
 
   }
 

--- a/Sources/FrontEnd/TypeChecking/SubstitutionMap.swift
+++ b/Sources/FrontEnd/TypeChecking/SubstitutionMap.swift
@@ -113,7 +113,7 @@ struct SubstitutionMap {
       return .member(d, a.mapValues({ reify(value: $0, withVariables: substitutionPolicy) }))
     case .constructor(let d, let a):
       return .constructor(d, a.mapValues({ reify(value: $0, withVariables: substitutionPolicy) }))
-    case .builtinType, .builtinFunction:
+    case .builtinModule, .builtinType, .builtinFunction:
       return r
     }
   }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -270,8 +270,7 @@ extension TypeChecker {
 
     let callee: AnyType
     if let e = NameExpr.ID(syntax.callee) {
-      callee = inferredType(
-        of: e, withImplicitDomain: shape, shapedBy: nil, updating: &state)
+      callee = inferredType(of: e, withImplicitDomain: shape, shapedBy: nil, updating: &state)
     } else {
       callee = inferredType(of: syntax.callee, shapedBy: nil, updating: &state)
     }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -135,6 +135,8 @@ extension TypeChecker {
       return inferredType(of: CastExpr.ID(subject)!, shapedBy: shape, updating: &s)
     case ConditionalExpr.self:
       return inferredType(of: ConditionalExpr.ID(subject)!, shapedBy: shape, updating: &s)
+    case ExistentialTypeExpr.self:
+      return inferredType(of: ExistentialTypeExpr.ID(subject)!, shapedBy: shape, updating: &s)
     case FloatLiteralExpr.self:
       return inferredType(of: FloatLiteralExpr.ID(subject)!, shapedBy: shape, updating: &s)
     case FunctionCallExpr.self:
@@ -251,6 +253,56 @@ extension TypeChecker {
         t, [firstBranch, secondBranch],
         origin: .init(.branchMerge, at: ast[subject].introducerSite)))
     return state.facts.constrain(subject, in: ast, toHaveType: t)
+  }
+
+  private mutating func inferredType(
+    of subject: ExistentialTypeExpr.ID, shapedBy shape: AnyType?,
+    updating state: inout State
+  ) -> AnyType {
+    assert(!ast[subject].traits.isEmpty, "existential type with no interface")
+
+    // Realize the interface.
+    var interface: [AnyType] = []
+    for n in ast[subject].traits {
+      // Expression must resolve to a nominal type.
+      guard let t = resolve(nominalType: n) else {
+        report(.error(invalidExistentialInterface: n, in: ast))
+        return .error
+      }
+
+      // Expression must refer to a type.
+      guard let u = MetatypeType(t) else {
+        report(.error(typeExprDenotesValue: n, in: ast))
+        return .error
+      }
+
+      interface.append(u.instance)
+    }
+
+    // TODO: Process where clauses
+    guard ast[subject].whereClause == nil else { fatalError("not implemented") }
+
+    // Interface must be either a single type or a set of traits.
+    if let t = TraitType(interface[0]) {
+      var traits = Set([t])
+      for i in 1 ..< interface.count {
+        if let u = TraitType(interface[i]) {
+          traits.insert(u)
+        } else {
+          report(.error(invalidPointerConversionAt: ast[ast[subject].traits[i]].site))
+          return state.facts.assignErrorType(to: subject)
+        }
+      }
+
+      let result = MetatypeType(of: ExistentialType(traits: traits, constraints: []))
+      return state.facts.constrain(subject, in: ast, toHaveType: result)
+    } else if let t = interface.uniqueElement {
+      let result = MetatypeType(of: ExistentialType(unparameterized: t, constraints: []))
+      return state.facts.constrain(subject, in: ast, toHaveType: result)
+    } else {
+      report(.error(tooManyExistentialBoundsAt: ast[ast[subject].traits[1]].site))
+      return state.facts.assignErrorType(to: subject)
+    }
   }
 
   private mutating func inferredType(

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -139,6 +139,10 @@ extension Diagnostic {
     .error("existential generic type may have only one bound", at: site)
   }
 
+  static func error(invalidExistentialInterface e: NameExpr.ID, in ast: AST) -> Diagnostic {
+    return .error("'\(ast[e].name.value)' is not a valid existential interface", at: ast[e].site)
+  }
+
   static func error(
     invalidConformanceConstraintTo type: AnyType, at site: SourceRange
   ) -> Diagnostic {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+Diagnostics.swift
@@ -55,8 +55,9 @@ extension Diagnostic {
     .error("duplicate parameter name '\(name)'", at: site)
   }
 
-  static func error(nameRefersToValue expr: NameExpr.ID, in ast: AST) -> Diagnostic {
-    .error("expected type but '\(ast[expr].name.value)' refers to a value", at: ast[expr].site)
+  static func error<T: ExprID>(typeExprDenotesValue e: T, in ast: AST) -> Diagnostic {
+    let n = NameExpr.ID(e).map({ "'\(ast[$0].name.value)'" }) ?? "expression"
+    return .error("expected type but \(n) denotes a value", at: ast[e].site)
   }
 
   static func error(genericDeclHasCapturesAt site: SourceRange) -> Diagnostic {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -134,7 +134,9 @@ public struct TypeChecker {
   }
 
   /// If `d` has generic parameters, returns a table from those parameters to corresponding value
-  /// in `substitutions` or a fresh variable if no such value exists. Otherwise, returns `nil`.
+  /// in `substitutions`. Otherwise, returns `nil`.
+  ///
+  /// - Requires: `substitutions` has a value for each generic parameter introduced by `d`.
   private mutating func extractArguments<T: GenericDecl>(
     of d: T.ID,
     from substitutions: GenericArguments
@@ -144,7 +146,7 @@ public struct TypeChecker {
 
     return GenericArguments(
       uniqueKeysWithValues: e.parameters.map({ (p) in
-        (key: p, value: substitutions[p] ?? ^TypeVariable())
+        (key: p, value: substitutions[p]!)
       }))
   }
 

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -1749,7 +1749,7 @@ public struct Emitter {
     case .constructor:
       fatalError()
 
-    case .builtinFunction, .builtinType:
+    case .builtinModule, .builtinFunction, .builtinType:
       // Built-in functions and types are never used as l-value.
       unreachable()
     }

--- a/Tests/ValTests/TestCases/TypeChecking/GenericParameters.val
+++ b/Tests/ValTests/TestCases/TypeChecking/GenericParameters.val
@@ -1,6 +1,6 @@
 //- typeCheck expecting: failure
 
-//! @+1 diagnostic expected type but 'v' refers to a value
+//! @+1 diagnostic expected type but 'v' denotes a value
 fun f0<X, v: Int>(_ x: X, _ y: v) {}
 
 //! @+1 diagnostic only one annotation is allowed on generic value parameter declarations

--- a/Tests/ValTests/TestCases/TypeChecking/IllegalExtension.val
+++ b/Tests/ValTests/TestCases/TypeChecking/IllegalExtension.val
@@ -1,0 +1,4 @@
+//- typeCheck expecting: failure
+
+//! @+1 diagnostic expected type but expression denotes a value
+extension true {}


### PR DESCRIPTION
This PR is the first of a series of changes steps aimed at refactoring the evaluation of type expressions.