### PR TITLE
Implement `Pointer<Pointee>`

### DIFF
--- a/Library/Val/Core/Pointer.val
+++ b/Library/Val/Core/Pointer.val
@@ -1,0 +1,33 @@
+/// A pointer for accessing typed data.
+public type Pointer<Pointee> {
+
+  var value: Builtin.ptr
+
+  memberwise init
+
+  /// Creates a copy of `other`.
+  public init(_ other: RawPointer) {
+    &self.value = other.value
+  }
+
+  /// Returns the result of applying `action` to a projection of the value referenced by `self`.
+  public fun with_pointee<T>(_ action: [](Pointee) -> T) -> T {
+    action(value as* (remote let Pointee))
+  }
+
+  /// Projects a pointer to `pointee`.
+  public static subscript to(_ pointee: Pointee): Self {
+    Pointer(value: Builtin.address(of: pointee))
+  }
+
+}
+
+public conformance Pointer: Deinitializable {}
+
+public conformance Pointer: Copyable {
+
+  public fun copy() -> Self {
+    Pointer(value: value)
+  }
+
+}

--- a/Tests/EndToEndTests/TestCases/AddressOf.val
+++ b/Tests/EndToEndTests/TestCases/AddressOf.val
@@ -1,0 +1,7 @@
+//- compileAndRun expecting: success
+
+public fun main() {
+  let x = 42
+  let y = Pointer.to[x]
+  y.with_pointee(fun(_ i) -> Void { precondition(i == 42) })
+}


### PR DESCRIPTION
This PR proposes a simplistic implementation of `Pointer<Pointee>` that can be used to get a pointer to a local value.