### PR TITLE
Fix monomorphization of generic uses nested in generic functions

### DIFF
--- a/Library/Val/Core/Pointer.val
+++ b/Library/Val/Core/Pointer.val
@@ -1,0 +1,33 @@
+/// A pointer for accessing typed data.
+public type Pointer<Pointee> {
+
+  var value: Builtin.ptr
+
+  memberwise init
+
+  /// Creates a copy of `other`.
+  public init(_ other: RawPointer) {
+    &self.value = other.value
+  }
+
+  /// Returns the result of applying `action` to a projection of the value referenced by `self`.
+  public fun with_pointee<T>(_ action: [](Pointee) -> T) -> T {
+    action(value as* (remote let Pointee))
+  }
+
+  /// Projects a pointer to `pointee`.
+  public static subscript to(_ pointee: Pointee): Self {
+    Pointer(value: Builtin.address(of: pointee))
+  }
+
+}
+
+public conformance Pointer: Deinitializable {}
+
+public conformance Pointer: Copyable {
+
+  public fun copy() -> Self {
+    Pointer(value: value)
+  }
+
+}

--- a/Sources/Core/TypeRelations.swift
+++ b/Sources/Core/TypeRelations.swift
@@ -68,11 +68,9 @@ public struct TypeRelations {
     }
   }
 
-  /// Returns a copy of `generic` monomorphized for the given `arguments`.
-  ///
-  /// This method has no effect if `arguments` is empty.
-  public func monomorphize(_ generic: AnyType, for arguments: GenericArguments) -> AnyType {
-    return arguments.isEmpty ? generic : generic.transform(transform(_:))
+  /// Returns `generic` monomorphized for the given `parameterization`.
+  public func monomorphize(_ generic: AnyType, for parameterization: GenericArguments) -> AnyType {
+    return parameterization.isEmpty ? generic : generic.transform(transform(_:))
 
     /// Returns how to specialize `t`.
     func transform(_ t: AnyType) -> TypeTransformAction {
@@ -82,7 +80,7 @@ public struct TypeRelations {
       case let u as BoundGenericType:
         return transform(u)
       case let u as GenericTypeParameterType:
-        return .stepOver((arguments[u.decl] as? AnyType) ?? .error)
+        return .stepOver((parameterization[u.decl] as? AnyType) ?? .error)
       case let u as SkolemType:
         return transform(u)
       default:
@@ -99,19 +97,32 @@ public struct TypeRelations {
 
     /// Returns how to monomorphize `t`.
     func transform(_ t: BoundGenericType) -> TypeTransformAction {
-      let updatedArguments = t.arguments.mapValues { (v) -> any CompileTimeValue in
+      let updatedParameterization = t.arguments.mapValues { (v) -> any CompileTimeValue in
         if let w = v as? AnyType {
-          return monomorphize(w, for: arguments)
+          return monomorphize(w, for: parameterization)
         } else {
           return v
         }
       }
-      return .stepOver(^BoundGenericType(t.base, arguments: updatedArguments))
+      return .stepOver(^BoundGenericType(t.base, arguments: updatedParameterization))
     }
 
     /// Returns how to monomorphize `t`.
     func transform(_ t: SkolemType) -> TypeTransformAction {
-      .stepOver(monomorphize(t.base, for: arguments))
+      .stepOver(monomorphize(t.base, for: parameterization))
+    }
+  }
+
+  /// Returns `arguments` monomorphized for the given `parameterization`.
+  public func monomorphize(
+    _ arguments: GenericArguments, for parameterization: GenericArguments
+  ) -> GenericArguments {
+    arguments.mapValues { (v) in
+      if let t = v as? AnyType {
+        return monomorphize(t, for: parameterization)
+      } else {
+        fatalError("not implemented")
+      }
     }
   }
 

--- a/Sources/Core/TypedProgram.swift
+++ b/Sources/Core/TypedProgram.swift
@@ -120,11 +120,16 @@ public struct TypedProgram: Program {
     return p.reversed().joined()
   }
 
-  /// Returns a copy of `generic` monomorphized for the given `arguments`.
-  ///
-  /// This method has no effect if `arguments` is empty.
-  public func monomorphize(_ generic: AnyType, for arguments: GenericArguments) -> AnyType {
-    relations.monomorphize(generic, for: arguments)
+  /// Returns a copy of `generic` monomorphized for the given `parameterization`.
+  public func monomorphize(_ generic: AnyType, for parameterization: GenericArguments) -> AnyType {
+    relations.monomorphize(generic, for: parameterization)
+  }
+
+  /// Returns `arguments` monomorphized for the given `parameterization`.
+  public func monomorphize(
+    _ arguments: GenericArguments, for parameterization: GenericArguments
+  ) -> GenericArguments {
+    relations.monomorphize(arguments, for: parameterization)
   }
 
   /// If `t` has a record layout, returns the names and types of its stored properties, replacing

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -38,9 +38,7 @@ extension Module {
   /// depolymorphized version of its callee. Otherwise, does nothing.
   ///
   /// - Requires: `i` identifies a `CallInstruction`
-  private mutating func depolymorphize(
-    call i: InstructionID, in ir: LoweredProgram
-  ) {
+  private mutating func depolymorphize(call i: InstructionID, in ir: LoweredProgram) {
     let s = self[i] as! CallInstruction
     guard
       let callee = s.callee.constant as? FunctionReference,
@@ -60,9 +58,7 @@ extension Module {
   /// a depolymorphized version of its callee. Otherwise, does nothing.
   ///
   /// - Requires: `i` identifies a `ProjectInstruction`
-  private mutating func depolymorphize(
-    project i: InstructionID, in ir: LoweredProgram
-  ) {
+  private mutating func depolymorphize(project i: InstructionID, in ir: LoweredProgram) {
     let s = self[i] as! ProjectInstruction
     guard !s.parameterization.isEmpty else { return }
 

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -219,7 +219,8 @@ extension Module {
 
       let newCallee: Operand
       if let callee = s.callee.constant as? FunctionReference, !callee.arguments.isEmpty {
-        let g = monomorphize(callee, in: ir)
+        let p = program.monomorphize(callee.arguments, for: parameterization)
+        let g = monomorphize(callee.function, for: p, usedIn: callee.useScope, in: ir)
         newCallee = .constant(FunctionReference(to: g, usedIn: callee.useScope, in: self))
       } else {
         newCallee = rewritten(s.callee)

--- a/Tests/EndToEndTests/TestCases/AddressOf.val
+++ b/Tests/EndToEndTests/TestCases/AddressOf.val
@@ -1,0 +1,7 @@
+//- compileAndRun expecting: success
+
+public fun main() {
+  let x = 42
+  let y = Pointer.to[x]
+  y.with_pointee(fun(_ i) -> Void { precondition(i == 42) })
+}


### PR DESCRIPTION
Before the patch, monomorphization would not properly apply the parameterization of a generic function called in another generic function. For example:

```swift
fun use_0<T>(_ x: T) {}

fun use_1<T>(_ x: T) { use_0(x) }

public fun main() {
  let i = 42
  use_1(i)
}
```