### PR TITLE
Function.parameters => Function.genericParameters

### DIFF
--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -453,7 +453,7 @@ extension Module {
       name: "<\(list: parameterization.values), \(useScope)>(\(source.name))",
       site: source.site,
       linkage: .module,
-      parameters: [],
+      genericParameters: [],
       inputs: inputs,
       output: output,
       blocks: [])

--- a/Sources/IR/Function.swift
+++ b/Sources/IR/Function.swift
@@ -20,7 +20,7 @@ public struct Function {
   public let linkage: Linkage
 
   /// The generic (a.k.a., compile-time) parameters of the function.
-  public let parameters: [GenericParameterDecl.ID]
+  public let genericParameters: [GenericParameterDecl.ID]
 
   /// The run-time parameters of the function.
   public let inputs: [Parameter]
@@ -44,7 +44,7 @@ public struct Function {
 
   /// `true` iff the function takes generic parameters.
   public var isGeneric: Bool {
-    !parameters.isEmpty
+    !genericParameters.isEmpty
   }
 
   /// Appends to `self` a basic block in `scope` that accepts `parameters`, returning its address.

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -192,7 +192,7 @@ public struct Module {
       name: program.debugName(decl: d),
       site: program.ast[d].site,
       linkage: .external,
-      parameters: Array(parameters),
+      genericParameters: Array(parameters),
       inputs: inputs,
       output: output,
       blocks: [])
@@ -253,7 +253,7 @@ public struct Module {
       name: program.debugName(decl: d),
       site: program.ast[d].site,
       linkage: .external,
-      parameters: Array(parameters),
+      genericParameters: Array(parameters),
       inputs: inputs,
       output: output,
       blocks: [])
@@ -277,7 +277,7 @@ public struct Module {
       name: program.debugName(decl: d),
       site: program.ast[d].introducer.site,
       linkage: .external,
-      parameters: Array(parameters),
+      genericParameters: Array(parameters),
       inputs: inputs,
       output: .void,
       blocks: [])
@@ -345,7 +345,7 @@ public struct Module {
       name: "",
       site: .empty(at: program.ast[id].site.first()),
       linkage: .external,
-      parameters: [],  // TODO
+      genericParameters: [],  // TODO
       inputs: inputs,
       output: output,
       blocks: [])
@@ -386,7 +386,7 @@ public struct Module {
   /// - Requires: `f` is declared in `self`.
   public func parameterization(in f: Function.ID) -> GenericArguments {
     var result = GenericArguments()
-    for p in functions[f]!.parameters {
+    for p in functions[f]!.genericParameters {
       guard
         let t = MetatypeType(program[p].type),
         let u = GenericTypeParameterType(t.instance)


### PR DESCRIPTION
“Function parameters” already means something else.