### PR TITLE
FunctionReference.arguments => genericArguments

### DIFF
--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -43,7 +43,7 @@ extension Module {
     let s = self[i] as! CallInstruction
     guard
       let callee = s.callee.constant as? FunctionReference,
-      !callee.arguments.isEmpty
+      !callee.genericArguments.isEmpty
     else { return }
 
     // TODO: Use existentialization unless the function is inlinable
@@ -97,7 +97,7 @@ extension Module {
   private mutating func monomorphize(
     _ r: FunctionReference, in ir: LoweredProgram
   ) -> Function.ID {
-    monomorphize(r.function, in: ir, for: r.arguments, usedIn: r.useScope)
+    monomorphize(r.function, in: ir, for: r.genericArguments, usedIn: r.useScope)
   }
 
   /// Returns a reference to the monomorphized form of `f` for given `parameterization` in
@@ -238,8 +238,8 @@ extension Module {
       let s = sourceModule[i] as! CallInstruction
 
       let newCallee: Operand
-      if let callee = s.callee.constant as? FunctionReference, !callee.arguments.isEmpty {
-        let p = program.monomorphize(callee.arguments, for: parameterization)
+      if let callee = s.callee.constant as? FunctionReference, !callee.genericArguments.isEmpty {
+        let p = program.monomorphize(callee.genericArguments, for: parameterization)
         let g = monomorphize(callee.function, in: ir, for: p, usedIn: callee.useScope)
         newCallee = .constant(FunctionReference(to: g, usedIn: callee.useScope, in: self))
       } else {
@@ -335,11 +335,11 @@ extension Module {
       let s = sourceModule[i] as! PartialApplyInstruction
 
       let newCallee: FunctionReference
-      if s.callee.arguments.isEmpty {
+      if s.callee.genericArguments.isEmpty {
         assert(!sourceModule[s.callee.function].isGeneric)
         newCallee = s.callee
       } else {
-        let p = program.monomorphize(s.callee.arguments, for: parameterization)
+        let p = program.monomorphize(s.callee.genericArguments, for: parameterization)
         let g = monomorphize(s.callee.function, in: ir, for: p, usedIn: s.callee.useScope)
         newCallee = FunctionReference(to: g, usedIn: s.callee.useScope, in: self)
       }

--- a/Sources/IR/Operands/Constant/FunctionReference.swift
+++ b/Sources/IR/Operands/Constant/FunctionReference.swift
@@ -12,8 +12,8 @@ public struct FunctionReference: Constant, Hashable {
   /// The scope in Val sources from which the function is being referred to.
   public let useScope: AnyScopeID
 
-  /// If `function` is generic, the arguments to its generic parameter.
-  public let arguments: GenericArguments
+  /// If `function` is generic, actual arguments corresponding to its generic parameters.
+  public let genericArguments: GenericArguments
 
   /// Creates a reference to `f`, which is in `module`, used in `s`.
   public init(
@@ -31,7 +31,7 @@ public struct FunctionReference: Constant, Hashable {
     self.function = f
     self.type = .address(t)
     self.useScope = s
-    self.arguments = arguments
+    self.genericArguments = arguments
   }
 
   /// Creates in `module` a reference to the lowered form of `d`, which is used in `s` and
@@ -49,7 +49,7 @@ public struct FunctionReference: Constant, Hashable {
     self.function = module.demandFunctionDeclaration(lowering: d)
     self.type = .address(LambdaType(t)!.lifted)
     self.useScope = s
-    self.arguments = arguments
+    self.genericArguments = arguments
   }
 
   /// Creates in `module` a reference to the lowered form of `d`, which is used in `s`.
@@ -66,7 +66,7 @@ public struct FunctionReference: Constant, Hashable {
     self.function = module.demandInitializerDeclaration(lowering: d)
     self.type = .address(LambdaType(t)!.lifted)
     self.useScope = s
-    self.arguments = arguments
+    self.genericArguments = arguments
   }
 
 }
@@ -74,10 +74,10 @@ public struct FunctionReference: Constant, Hashable {
 extension FunctionReference: CustomStringConvertible {
 
   public var description: String {
-    if arguments.isEmpty {
+    if genericArguments.isEmpty {
       return "@\(function)"
     } else {
-      return "@\(function)<\(list: arguments.values)>"
+      return "@\(function)<\(list: genericArguments.values)>"
     }
   }
 

--- a/Sources/IR/Operands/Instruction/CallInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CallInstruction.swift
@@ -39,7 +39,7 @@ public struct CallInstruction: Instruction {
   /// `true` iff the instruction denotes a call to a generic function.
   public var isGeneric: Bool {
     if let f = callee.constant as? FunctionReference {
-      return !f.arguments.isEmpty
+      return !f.genericArguments.isEmpty
     } else {
       return false
     }


### PR DESCRIPTION
"function argument" already has a different meaning