### PR TITLE
LoweredXXX => IR.XXX

### DIFF
--- a/Sources/CodeGen/LLVM/LLVMProgram.swift
+++ b/Sources/CodeGen/LLVM/LLVMProgram.swift
@@ -18,7 +18,7 @@ public struct LLVMProgram {
   /// - Parameters:
   ///   - target: The machine for which `ir` is transpiled. Defaults to the current host.
   public init(
-    _ ir: LoweredProgram,
+    _ ir: IR.Program,
     mainModule: ModuleDecl.ID,
     for target: LLVM.TargetMachine? = nil
   ) throws {

--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -595,7 +595,7 @@ extension LLVM.Module {
       let s = m[i] as! CallFFIInstruction
       let parameters = s.operands.map({ ir.llvm(m.type(of: $0).ast, in: &self) })
 
-      let returnType: IRType
+      let returnType: LLVM.IRType
       if s.returnType.ast.isVoidOrNever {
         returnType = void
       } else {

--- a/Sources/CodeGen/LLVM/Transpilation.swift
+++ b/Sources/CodeGen/LLVM/Transpilation.swift
@@ -274,7 +274,7 @@ extension LLVM.Module {
 
   /// Returns the LLVM IR value of the requirement implementation `i`, which is in `ir`.
   private mutating func transpiledRequirementImplementation(
-    _ i: IR.LoweredConformance.Implementation, from ir: IR.Program
+    _ i: IR.Conformance.Implementation, from ir: IR.Program
   ) -> LLVM.Function {
     switch i {
     case .function(let f):

--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -115,7 +115,7 @@ extension IR.Program {
   func llvm(sumType val: SumType, in module: inout LLVM.Module) -> LLVM.IRType {
     precondition(val[.isCanonical])
 
-    var payload: IRType = LLVM.StructType([], in: &module)
+    var payload: LLVM.IRType = LLVM.StructType([], in: &module)
     if val == .never {
       return payload
     }

--- a/Sources/CodeGen/LLVM/TypeLowering.swift
+++ b/Sources/CodeGen/LLVM/TypeLowering.swift
@@ -3,7 +3,7 @@ import IR
 import LLVM
 import Utils
 
-extension LoweredProgram {
+extension IR.Program {
 
   /// Returns the LLVM form of `val` in `module`.
   ///

--- a/Sources/Core/Program.swift
+++ b/Sources/Core/Program.swift
@@ -1,6 +1,6 @@
 import Utils
 
-/// A type representing a Val program and its properties at a some stage of compilation.
+/// Types representing Val programs at some stage after syntactic and scope analysis.
 public protocol Program {
 
   /// The AST of the program.

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -470,8 +470,8 @@ extension TypedProgram {
   ///
   /// This method has no effect if `arguments` is empty.
   fileprivate func monomorphize(
-    _ generic: IR.LoweredType, applying arguments: GenericArguments
-  ) -> IR.LoweredType {
+    _ generic: IRType, applying arguments: GenericArguments
+  ) -> IRType {
     let t = monomorphize(generic.ast, for: arguments)
     return .init(ast: t, isAddress: generic.isAddress)
   }

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -470,8 +470,8 @@ extension TypedProgram {
   ///
   /// This method has no effect if `arguments` is empty.
   fileprivate func monomorphize(
-    _ generic: IR.Type_, applying arguments: GenericArguments
-  ) -> IR.Type_ {
+    _ generic: IR.`Type`, applying arguments: GenericArguments
+  ) -> IR.`Type` {
     let t = monomorphize(generic.ast, for: arguments)
     return .init(ast: t, isAddress: generic.isAddress)
   }

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -470,8 +470,8 @@ extension TypedProgram {
   ///
   /// This method has no effect if `arguments` is empty.
   fileprivate func monomorphize(
-    _ generic: IRType, applying arguments: GenericArguments
-  ) -> IRType {
+    _ generic: IR.Type_, applying arguments: GenericArguments
+  ) -> IR.Type_ {
     let t = monomorphize(generic.ast, for: arguments)
     return .init(ast: t, isAddress: generic.isAddress)
   }

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -470,8 +470,8 @@ extension TypedProgram {
   ///
   /// This method has no effect if `arguments` is empty.
   fileprivate func monomorphize(
-    _ generic: LoweredType, applying arguments: GenericArguments
-  ) -> LoweredType {
+    _ generic: IR.LoweredType, applying arguments: GenericArguments
+  ) -> IR.LoweredType {
     let t = monomorphize(generic.ast, for: arguments)
     return .init(ast: t, isAddress: generic.isAddress)
   }

--- a/Sources/IR/Analysis/Module+Depolymorphize.swift
+++ b/Sources/IR/Analysis/Module+Depolymorphize.swift
@@ -4,7 +4,7 @@ import Utils
 extension Module {
 
   /// Generates the non-parametric resilient API of `self`, reading definitions from `ir`.
-  public mutating func depolymorphize(in ir: LoweredProgram) {
+  public mutating func depolymorphize(in ir: IR.Program) {
     let work = functions.keys
     for k in work {
       // Ignore internal functions and functions without definitions.
@@ -22,7 +22,7 @@ extension Module {
 
   /// Replaces uses of parametric types and functions in `f` with their monomorphic or existential
   /// counterparts, reading definitions from `ir`.
-  private mutating func depolymorphize(_ f: Function.ID, in ir: LoweredProgram) {
+  private mutating func depolymorphize(_ f: Function.ID, in ir: IR.Program) {
     for i in blocks(in: f).map(instructions(in:)).joined() {
       switch self[i] {
       case is CallInstruction:
@@ -39,7 +39,7 @@ extension Module {
   /// depolymorphized version of its callee. Otherwise, does nothing.
   ///
   /// - Requires: `i` identifies a `CallInstruction`
-  private mutating func depolymorphize(call i: InstructionID, in ir: LoweredProgram) {
+  private mutating func depolymorphize(call i: InstructionID, in ir: IR.Program) {
     let s = self[i] as! CallInstruction
     guard
       let callee = s.callee.constant as? FunctionReference,
@@ -59,7 +59,7 @@ extension Module {
   /// a depolymorphized version of its callee. Otherwise, does nothing.
   ///
   /// - Requires: `i` identifies a `ProjectInstruction`
-  private mutating func depolymorphize(project i: InstructionID, in ir: LoweredProgram) {
+  private mutating func depolymorphize(project i: InstructionID, in ir: IR.Program) {
     let s = self[i] as! ProjectInstruction
     guard !s.parameterization.isEmpty else { return }
 
@@ -95,7 +95,7 @@ extension Module {
   /// Returns a reference to the monomorphized form of `r`, reading definitions from `ir`.
   @discardableResult
   private mutating func monomorphize(
-    _ r: FunctionReference, in ir: LoweredProgram
+    _ r: FunctionReference, in ir: IR.Program
   ) -> Function.ID {
     monomorphize(r.function, in: ir, for: r.genericArguments, usedIn: r.useScope)
   }
@@ -104,7 +104,7 @@ extension Module {
   /// `useScope`, reading definitions from `ir`.
   @discardableResult
   private mutating func monomorphize(
-    _ f: Function.ID, in ir: LoweredProgram,
+    _ f: Function.ID, in ir: IR.Program,
     for parameterization: GenericArguments, usedIn useScope: AnyScopeID
   ) -> Function.ID {
     let result = demandMonomorphizedDeclaration(
@@ -432,7 +432,7 @@ extension Module {
   /// Returns the identity of the Val IR function monomorphizing `f` for given `parameterization`
   /// in `useScope`.
   private mutating func demandMonomorphizedDeclaration(
-    of f: Function.ID, in ir: LoweredProgram,
+    of f: Function.ID, in ir: IR.Program,
     for parameterization: GenericArguments, usedIn useScope: AnyScopeID
   ) -> Function.ID {
     let result = Function.ID(monomorphized: f, for: parameterization)

--- a/Sources/IR/Block.swift
+++ b/Sources/IR/Block.swift
@@ -14,7 +14,7 @@ public struct Block {
   public let scope: AnyScopeID
 
   /// The type input parameters of the block.
-  public let inputs: [LoweredType]
+  public let inputs: [IR.LoweredType]
 
   /// The instructions in the block.
   public internal(set) var instructions: Instructions = []

--- a/Sources/IR/Block.swift
+++ b/Sources/IR/Block.swift
@@ -14,7 +14,7 @@ public struct Block {
   public let scope: AnyScopeID
 
   /// The type input parameters of the block.
-  public let inputs: [IR.LoweredType]
+  public let inputs: [IRType]
 
   /// The instructions in the block.
   public internal(set) var instructions: Instructions = []

--- a/Sources/IR/Block.swift
+++ b/Sources/IR/Block.swift
@@ -14,7 +14,7 @@ public struct Block {
   public let scope: AnyScopeID
 
   /// The type input parameters of the block.
-  public let inputs: [IRType]
+  public let inputs: [IR.Type_]
 
   /// The instructions in the block.
   public internal(set) var instructions: Instructions = []

--- a/Sources/IR/Block.swift
+++ b/Sources/IR/Block.swift
@@ -14,7 +14,7 @@ public struct Block {
   public let scope: AnyScopeID
 
   /// The type input parameters of the block.
-  public let inputs: [IR.Type_]
+  public let inputs: [IR.`Type`]
 
   /// The instructions in the block.
   public internal(set) var instructions: Instructions = []

--- a/Sources/IR/Conformance.swift
+++ b/Sources/IR/Conformance.swift
@@ -39,7 +39,7 @@ public struct Conformance {
 
 }
 
-extension Conformance: Equatable {
+extension IR.Conformance: Equatable {
 
   public static func == (l: Self, r: Self) -> Bool {
     (l.concept == r.concept) && (l.source == r.source)
@@ -47,7 +47,7 @@ extension Conformance: Equatable {
 
 }
 
-extension Conformance: Hashable {
+extension IR.Conformance: Hashable {
 
   public func hash(into hasher: inout Hasher) {
     concept.hash(into: &hasher)

--- a/Sources/IR/Conformance.swift
+++ b/Sources/IR/Conformance.swift
@@ -1,7 +1,7 @@
 import Core
 
 /// Where, how, and under what conditions a type satisfies the requirements of a trait.
-public struct LoweredConformance {
+public struct Conformance {
 
   /// A map from requirement to their implementation.
   public typealias ImplementationMap = DeclProperty<Implementation>
@@ -39,7 +39,7 @@ public struct LoweredConformance {
 
 }
 
-extension LoweredConformance: Equatable {
+extension Conformance: Equatable {
 
   public static func == (l: Self, r: Self) -> Bool {
     (l.concept == r.concept) && (l.source == r.source)
@@ -47,7 +47,7 @@ extension LoweredConformance: Equatable {
 
 }
 
-extension LoweredConformance: Hashable {
+extension Conformance: Hashable {
 
   public func hash(into hasher: inout Hasher) {
     concept.hash(into: &hasher)

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -544,7 +544,7 @@ public struct Emitter {
 
   /// Returns the lowered form of `c`, generating function references in `useScope`.
   private mutating func loweredConformance(
-    _ c: Conformance, in useScope: AnyScopeID
+    _ c: Core.Conformance, in useScope: AnyScopeID
   ) -> LoweredConformance {
     var implementations = LoweredConformance.ImplementationMap()
     for (r, i) in c.implementations.storage {
@@ -1974,7 +1974,7 @@ public struct Emitter {
   /// Inserts the IR for deinitializing the contents of `storage` at `point` in `module`, using `c`
   /// to identify the deinitializer to apply, anchoring new instructions to `site`.
   private static func insertDeinit(
-    _ storage: Operand, withConformanceToDeinitializable c: Conformance, at site: SourceRange,
+    _ storage: Operand, withConformanceToDeinitializable c: Core.Conformance, at site: SourceRange,
     _ point: InsertionPoint, in module: inout Module
   ) {
     let d = module.demandDeinitDeclaration(from: c)
@@ -2075,7 +2075,7 @@ public struct Emitter {
     _ access: AccessEffect,
     of value: Operand,
     to storage: Operand,
-    withConformanceToMovable c: Conformance,
+    withConformanceToMovable c: Core.Conformance,
     at site: SourceRange
   ) {
     let oper = module.demandMoveOperatorDeclaration(access, from: c)

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -531,10 +531,10 @@ public struct Emitter {
   /// Returns the lowered conformances of `model` that are exposed to `useScope`.
   private mutating func loweredConformances(
     of model: AnyType, exposedTo useScope: AnyScopeID
-  ) -> Set<LoweredConformance> {
+  ) -> Set<Conformance> {
     guard let conformances = program.relations.conformances[model] else { return [] }
 
-    var result: Set<LoweredConformance> = []
+    var result: Set<Conformance> = []
     for concept in conformances.keys {
       let c = program.conformance(of: model, to: concept, exposedTo: useScope)!
       result.insert(loweredConformance(c, in: useScope))
@@ -545,8 +545,8 @@ public struct Emitter {
   /// Returns the lowered form of `c`, generating function references in `useScope`.
   private mutating func loweredConformance(
     _ c: Core.Conformance, in useScope: AnyScopeID
-  ) -> LoweredConformance {
-    var implementations = LoweredConformance.ImplementationMap()
+  ) -> Conformance {
+    var implementations = Conformance.ImplementationMap()
     for (r, i) in c.implementations.storage {
       switch i {
       case .concrete(let d):
@@ -564,7 +564,7 @@ public struct Emitter {
   /// Returns the lowered form of the requirement implementation `d` in `useScope`.
   private mutating func loweredRequirementImplementation(
     _ d: AnyDeclID, in useScope: AnyScopeID
-  ) -> LoweredConformance.Implementation {
+  ) -> Conformance.Implementation {
     switch d.kind {
     case FunctionDecl.self:
       let r = FunctionReference(to: FunctionDecl.ID(d)!, usedIn: useScope, in: &module)

--- a/Sources/IR/Emitter.swift
+++ b/Sources/IR/Emitter.swift
@@ -531,10 +531,10 @@ public struct Emitter {
   /// Returns the lowered conformances of `model` that are exposed to `useScope`.
   private mutating func loweredConformances(
     of model: AnyType, exposedTo useScope: AnyScopeID
-  ) -> Set<Conformance> {
+  ) -> Set<IR.Conformance> {
     guard let conformances = program.relations.conformances[model] else { return [] }
 
-    var result: Set<Conformance> = []
+    var result: Set<IR.Conformance> = []
     for concept in conformances.keys {
       let c = program.conformance(of: model, to: concept, exposedTo: useScope)!
       result.insert(loweredConformance(c, in: useScope))
@@ -545,8 +545,8 @@ public struct Emitter {
   /// Returns the lowered form of `c`, generating function references in `useScope`.
   private mutating func loweredConformance(
     _ c: Core.Conformance, in useScope: AnyScopeID
-  ) -> Conformance {
-    var implementations = Conformance.ImplementationMap()
+  ) -> IR.Conformance {
+    var implementations = IR.Conformance.ImplementationMap()
     for (r, i) in c.implementations.storage {
       switch i {
       case .concrete(let d):
@@ -564,7 +564,7 @@ public struct Emitter {
   /// Returns the lowered form of the requirement implementation `d` in `useScope`.
   private mutating func loweredRequirementImplementation(
     _ d: AnyDeclID, in useScope: AnyScopeID
-  ) -> Conformance.Implementation {
+  ) -> IR.Conformance.Implementation {
     switch d.kind {
     case FunctionDecl.self:
       let r = FunctionReference(to: FunctionDecl.ID(d)!, usedIn: useScope, in: &module)

--- a/Sources/IR/Function.swift
+++ b/Sources/IR/Function.swift
@@ -52,7 +52,7 @@ public struct Function {
   /// The new block will become the function's entry if `self` contains no block before
   /// `appendBlock` is called.
   mutating func appendBlock<T: ScopeID>(
-    in scope: T, taking parameters: [LoweredType]
+    in scope: T, taking parameters: [IR.LoweredType]
   ) -> Blocks.Address {
     blocks.append(Block(scope: AnyScopeID(scope), inputs: parameters))
   }

--- a/Sources/IR/Function.swift
+++ b/Sources/IR/Function.swift
@@ -52,7 +52,7 @@ public struct Function {
   /// The new block will become the function's entry if `self` contains no block before
   /// `appendBlock` is called.
   mutating func appendBlock<T: ScopeID>(
-    in scope: T, taking parameters: [IR.LoweredType]
+    in scope: T, taking parameters: [IRType]
   ) -> Blocks.Address {
     blocks.append(Block(scope: AnyScopeID(scope), inputs: parameters))
   }

--- a/Sources/IR/Function.swift
+++ b/Sources/IR/Function.swift
@@ -52,7 +52,7 @@ public struct Function {
   /// The new block will become the function's entry if `self` contains no block before
   /// `appendBlock` is called.
   mutating func appendBlock<T: ScopeID>(
-    in scope: T, taking parameters: [IR.Type_]
+    in scope: T, taking parameters: [IR.`Type`]
   ) -> Blocks.Address {
     blocks.append(Block(scope: AnyScopeID(scope), inputs: parameters))
   }

--- a/Sources/IR/Function.swift
+++ b/Sources/IR/Function.swift
@@ -52,7 +52,7 @@ public struct Function {
   /// The new block will become the function's entry if `self` contains no block before
   /// `appendBlock` is called.
   mutating func appendBlock<T: ScopeID>(
-    in scope: T, taking parameters: [IRType]
+    in scope: T, taking parameters: [IR.Type_]
   ) -> Blocks.Address {
     blocks.append(Block(scope: AnyScopeID(scope), inputs: parameters))
   }

--- a/Sources/IR/LoweredType.swift
+++ b/Sources/IR/LoweredType.swift
@@ -23,17 +23,17 @@ public struct LoweredType: Hashable {
 
   /// Creates an object type.
   public static func object<T: TypeProtocol>(_ type: T) -> Self {
-    LoweredType(ast: type, isAddress: false)
+    IR.LoweredType(ast: type, isAddress: false)
   }
 
   /// Creates and address type.
   public static func address<T: TypeProtocol>(_ type: T) -> Self {
-    LoweredType(ast: type, isAddress: true)
+    IR.LoweredType(ast: type, isAddress: true)
   }
 
 }
 
-extension LoweredType: CustomStringConvertible {
+extension IR.LoweredType: CustomStringConvertible {
 
   public var description: String {
     if isAddress {

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -69,7 +69,7 @@ public struct Module {
   }
 
   /// Returns the type of `operand`.
-  public func type(of operand: Operand) -> IR.Type_ {
+  public func type(of operand: Operand) -> IR.`Type` {
     switch operand {
     case .register(let instruction, let index):
       return functions[instruction.function]![instruction.block][instruction.address].types[index]
@@ -416,7 +416,7 @@ public struct Module {
     assert(ir.blocks.isEmpty)
 
     // In functions, the last parameter of the entry denotes the function's return value.
-    var parameters = ir.inputs.map({ IR.Type_.address($0.type.bareType) })
+    var parameters = ir.inputs.map({ IR.`Type`.address($0.type.bareType) })
     if !ir.isSubscript {
       parameters.append(.address(ir.output))
     }
@@ -431,7 +431,7 @@ public struct Module {
   @discardableResult
   mutating func appendBlock<T: ScopeID>(
     in scope: T,
-    taking parameters: [IR.Type_] = [],
+    taking parameters: [IR.`Type`] = [],
     to f: Function.ID
   ) -> Block.ID {
     let a = functions[f]!.appendBlock(in: scope, taking: parameters)

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -137,7 +137,7 @@ public struct Module {
   }
 
   /// Applies `p` to in this module, which is in `ir`.
-  public mutating func applyPass(_ p: ModulePass, in ir: LoweredProgram) {
+  public mutating func applyPass(_ p: ModulePass, in ir: IR.Program) {
     switch p {
     case .depolymorphize:
       depolymorphize(in: ir)

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -69,7 +69,7 @@ public struct Module {
   }
 
   /// Returns the type of `operand`.
-  public func type(of operand: Operand) -> IR.LoweredType {
+  public func type(of operand: Operand) -> IRType {
     switch operand {
     case .register(let instruction, let index):
       return functions[instruction.function]![instruction.block][instruction.address].types[index]
@@ -416,7 +416,7 @@ public struct Module {
     assert(ir.blocks.isEmpty)
 
     // In functions, the last parameter of the entry denotes the function's return value.
-    var parameters = ir.inputs.map({ IR.LoweredType.address($0.type.bareType) })
+    var parameters = ir.inputs.map({ IRType.address($0.type.bareType) })
     if !ir.isSubscript {
       parameters.append(.address(ir.output))
     }
@@ -431,7 +431,7 @@ public struct Module {
   @discardableResult
   mutating func appendBlock<T: ScopeID>(
     in scope: T,
-    taking parameters: [IR.LoweredType] = [],
+    taking parameters: [IRType] = [],
     to f: Function.ID
   ) -> Block.ID {
     let a = functions[f]!.appendBlock(in: scope, taking: parameters)

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -69,7 +69,7 @@ public struct Module {
   }
 
   /// Returns the type of `operand`.
-  public func type(of operand: Operand) -> IRType {
+  public func type(of operand: Operand) -> IR.Type_ {
     switch operand {
     case .register(let instruction, let index):
       return functions[instruction.function]![instruction.block][instruction.address].types[index]
@@ -416,7 +416,7 @@ public struct Module {
     assert(ir.blocks.isEmpty)
 
     // In functions, the last parameter of the entry denotes the function's return value.
-    var parameters = ir.inputs.map({ IRType.address($0.type.bareType) })
+    var parameters = ir.inputs.map({ IR.Type_.address($0.type.bareType) })
     if !ir.isSubscript {
       parameters.append(.address(ir.output))
     }
@@ -431,7 +431,7 @@ public struct Module {
   @discardableResult
   mutating func appendBlock<T: ScopeID>(
     in scope: T,
-    taking parameters: [IRType] = [],
+    taking parameters: [IR.Type_] = [],
     to f: Function.ID
   ) -> Block.ID {
     let a = functions[f]!.appendBlock(in: scope, taking: parameters)

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -209,7 +209,7 @@ public struct Module {
 
   /// Returns the identity of the Val IR function implementing the deinitializer defined in
   /// conformance `c`.
-  mutating func demandDeinitDeclaration(from c: Conformance) -> Function.ID {
+  mutating func demandDeinitDeclaration(from c: Core.Conformance) -> Function.ID {
     let d = program.ast.deinitRequirement()
     switch c.implementations[d]! {
     case .concrete:
@@ -226,7 +226,7 @@ public struct Module {
   ///
   /// - Requires: `k` is either `.set` or `.inout`
   mutating func demandMoveOperatorDeclaration(
-    _ k: AccessEffect, from c: Conformance
+    _ k: AccessEffect, from c: Core.Conformance
   ) -> Function.ID {
     let d = program.ast.moveRequirement(k)
     switch c.implementations[d]! {

--- a/Sources/IR/Module.swift
+++ b/Sources/IR/Module.swift
@@ -69,7 +69,7 @@ public struct Module {
   }
 
   /// Returns the type of `operand`.
-  public func type(of operand: Operand) -> LoweredType {
+  public func type(of operand: Operand) -> IR.LoweredType {
     switch operand {
     case .register(let instruction, let index):
       return functions[instruction.function]![instruction.block][instruction.address].types[index]
@@ -416,7 +416,7 @@ public struct Module {
     assert(ir.blocks.isEmpty)
 
     // In functions, the last parameter of the entry denotes the function's return value.
-    var parameters = ir.inputs.map({ LoweredType.address($0.type.bareType) })
+    var parameters = ir.inputs.map({ IR.LoweredType.address($0.type.bareType) })
     if !ir.isSubscript {
       parameters.append(.address(ir.output))
     }
@@ -431,7 +431,7 @@ public struct Module {
   @discardableResult
   mutating func appendBlock<T: ScopeID>(
     in scope: T,
-    taking parameters: [LoweredType] = [],
+    taking parameters: [IR.LoweredType] = [],
     to f: Function.ID
   ) -> Block.ID {
     let a = functions[f]!.appendBlock(in: scope, taking: parameters)

--- a/Sources/IR/Operands/Constant/BufferConstant.swift
+++ b/Sources/IR/Operands/Constant/BufferConstant.swift
@@ -13,7 +13,7 @@ public struct BufferConstant: Constant, Hashable {
   }
 
   /// The Val IR type of this instance.
-  public var type: IR.LoweredType { .object(BuiltinType.ptr) }
+  public var type: IRType { .object(BuiltinType.ptr) }
 
 }
 

--- a/Sources/IR/Operands/Constant/BufferConstant.swift
+++ b/Sources/IR/Operands/Constant/BufferConstant.swift
@@ -13,7 +13,7 @@ public struct BufferConstant: Constant, Hashable {
   }
 
   /// The Val IR type of this instance.
-  public var type: IRType { .object(BuiltinType.ptr) }
+  public var type: IR.Type_ { .object(BuiltinType.ptr) }
 
 }
 

--- a/Sources/IR/Operands/Constant/BufferConstant.swift
+++ b/Sources/IR/Operands/Constant/BufferConstant.swift
@@ -13,7 +13,7 @@ public struct BufferConstant: Constant, Hashable {
   }
 
   /// The Val IR type of this instance.
-  public var type: IR.Type_ { .object(BuiltinType.ptr) }
+  public var type: IR.`Type` { .object(BuiltinType.ptr) }
 
 }
 

--- a/Sources/IR/Operands/Constant/BufferConstant.swift
+++ b/Sources/IR/Operands/Constant/BufferConstant.swift
@@ -13,7 +13,7 @@ public struct BufferConstant: Constant, Hashable {
   }
 
   /// The Val IR type of this instance.
-  public var type: LoweredType { .object(BuiltinType.ptr) }
+  public var type: IR.LoweredType { .object(BuiltinType.ptr) }
 
 }
 

--- a/Sources/IR/Operands/Constant/Constant.swift
+++ b/Sources/IR/Operands/Constant/Constant.swift
@@ -2,7 +2,7 @@
 public protocol Constant: Hashable {
 
   /// The type of the value.
-  var type: IR.Type_ { get }
+  var type: IR.`Type` { get }
 
   /// Returns `true` if `self` is equal to `other`.
   func equals(_ other: any Constant) -> Bool

--- a/Sources/IR/Operands/Constant/Constant.swift
+++ b/Sources/IR/Operands/Constant/Constant.swift
@@ -2,7 +2,7 @@
 public protocol Constant: Hashable {
 
   /// The type of the value.
-  var type: LoweredType { get }
+  var type: IR.LoweredType { get }
 
   /// Returns `true` if `self` is equal to `other`.
   func equals(_ other: any Constant) -> Bool

--- a/Sources/IR/Operands/Constant/Constant.swift
+++ b/Sources/IR/Operands/Constant/Constant.swift
@@ -2,7 +2,7 @@
 public protocol Constant: Hashable {
 
   /// The type of the value.
-  var type: IRType { get }
+  var type: IR.Type_ { get }
 
   /// Returns `true` if `self` is equal to `other`.
   func equals(_ other: any Constant) -> Bool

--- a/Sources/IR/Operands/Constant/Constant.swift
+++ b/Sources/IR/Operands/Constant/Constant.swift
@@ -2,7 +2,7 @@
 public protocol Constant: Hashable {
 
   /// The type of the value.
-  var type: IR.LoweredType { get }
+  var type: IRType { get }
 
   /// Returns `true` if `self` is equal to `other`.
   func equals(_ other: any Constant) -> Bool

--- a/Sources/IR/Operands/Constant/FloatingPointConstant.swift
+++ b/Sources/IR/Operands/Constant/FloatingPointConstant.swift
@@ -7,7 +7,7 @@ public struct FloatingPointConstant: Constant, Hashable {
   public let value: String
 
   /// The Val IR type of this instance.
-  public let type: LoweredType
+  public let type: IR.LoweredType
 
   /// Creates a new floating-point Val IR constant with value `v` and the given `type`.
   private init(_ v: String, type: BuiltinType) {

--- a/Sources/IR/Operands/Constant/FloatingPointConstant.swift
+++ b/Sources/IR/Operands/Constant/FloatingPointConstant.swift
@@ -7,7 +7,7 @@ public struct FloatingPointConstant: Constant, Hashable {
   public let value: String
 
   /// The Val IR type of this instance.
-  public let type: IRType
+  public let type: IR.Type_
 
   /// Creates a new floating-point Val IR constant with value `v` and the given `type`.
   private init(_ v: String, type: BuiltinType) {

--- a/Sources/IR/Operands/Constant/FloatingPointConstant.swift
+++ b/Sources/IR/Operands/Constant/FloatingPointConstant.swift
@@ -7,7 +7,7 @@ public struct FloatingPointConstant: Constant, Hashable {
   public let value: String
 
   /// The Val IR type of this instance.
-  public let type: IR.Type_
+  public let type: IR.`Type`
 
   /// Creates a new floating-point Val IR constant with value `v` and the given `type`.
   private init(_ v: String, type: BuiltinType) {

--- a/Sources/IR/Operands/Constant/FloatingPointConstant.swift
+++ b/Sources/IR/Operands/Constant/FloatingPointConstant.swift
@@ -7,7 +7,7 @@ public struct FloatingPointConstant: Constant, Hashable {
   public let value: String
 
   /// The Val IR type of this instance.
-  public let type: IR.LoweredType
+  public let type: IRType
 
   /// Creates a new floating-point Val IR constant with value `v` and the given `type`.
   private init(_ v: String, type: BuiltinType) {

--- a/Sources/IR/Operands/Constant/FunctionReference.swift
+++ b/Sources/IR/Operands/Constant/FunctionReference.swift
@@ -7,7 +7,7 @@ public struct FunctionReference: Constant, Hashable {
   public let function: Function.ID
 
   /// The type of the referred IR function.
-  public let type: IR.LoweredType
+  public let type: IRType
 
   /// The scope in Val sources from which the function is being referred to.
   public let useScope: AnyScopeID

--- a/Sources/IR/Operands/Constant/FunctionReference.swift
+++ b/Sources/IR/Operands/Constant/FunctionReference.swift
@@ -7,7 +7,7 @@ public struct FunctionReference: Constant, Hashable {
   public let function: Function.ID
 
   /// The type of the referred IR function.
-  public let type: IR.Type_
+  public let type: IR.`Type`
 
   /// The scope in Val sources from which the function is being referred to.
   public let useScope: AnyScopeID

--- a/Sources/IR/Operands/Constant/FunctionReference.swift
+++ b/Sources/IR/Operands/Constant/FunctionReference.swift
@@ -7,7 +7,7 @@ public struct FunctionReference: Constant, Hashable {
   public let function: Function.ID
 
   /// The type of the referred IR function.
-  public let type: IRType
+  public let type: IR.Type_
 
   /// The scope in Val sources from which the function is being referred to.
   public let useScope: AnyScopeID

--- a/Sources/IR/Operands/Constant/FunctionReference.swift
+++ b/Sources/IR/Operands/Constant/FunctionReference.swift
@@ -7,7 +7,7 @@ public struct FunctionReference: Constant, Hashable {
   public let function: Function.ID
 
   /// The type of the referred IR function.
-  public let type: LoweredType
+  public let type: IR.LoweredType
 
   /// The scope in Val sources from which the function is being referred to.
   public let useScope: AnyScopeID

--- a/Sources/IR/Operands/Constant/IntegerConstant.swift
+++ b/Sources/IR/Operands/Constant/IntegerConstant.swift
@@ -22,7 +22,7 @@ public struct IntegerConstant: Constant, Hashable {
     self.value = value
   }
 
-  public var type: IR.LoweredType { .object(BuiltinType.i(value.bitWidth)) }
+  public var type: IRType { .object(BuiltinType.i(value.bitWidth)) }
 
 }
 

--- a/Sources/IR/Operands/Constant/IntegerConstant.swift
+++ b/Sources/IR/Operands/Constant/IntegerConstant.swift
@@ -22,7 +22,7 @@ public struct IntegerConstant: Constant, Hashable {
     self.value = value
   }
 
-  public var type: IRType { .object(BuiltinType.i(value.bitWidth)) }
+  public var type: IR.Type_ { .object(BuiltinType.i(value.bitWidth)) }
 
 }
 

--- a/Sources/IR/Operands/Constant/IntegerConstant.swift
+++ b/Sources/IR/Operands/Constant/IntegerConstant.swift
@@ -22,7 +22,7 @@ public struct IntegerConstant: Constant, Hashable {
     self.value = value
   }
 
-  public var type: IR.Type_ { .object(BuiltinType.i(value.bitWidth)) }
+  public var type: IR.`Type` { .object(BuiltinType.i(value.bitWidth)) }
 
 }
 

--- a/Sources/IR/Operands/Constant/IntegerConstant.swift
+++ b/Sources/IR/Operands/Constant/IntegerConstant.swift
@@ -22,7 +22,7 @@ public struct IntegerConstant: Constant, Hashable {
     self.value = value
   }
 
-  public var type: LoweredType { .object(BuiltinType.i(value.bitWidth)) }
+  public var type: IR.LoweredType { .object(BuiltinType.i(value.bitWidth)) }
 
 }
 

--- a/Sources/IR/Operands/Constant/MetatypeType+Constant.swift
+++ b/Sources/IR/Operands/Constant/MetatypeType+Constant.swift
@@ -3,6 +3,6 @@ import Core
 extension MetatypeType: Constant {
 
   /// The Val IR type of this instance.
-  public var type: IR.Type_ { .object(self) }
+  public var type: IR.`Type` { .object(self) }
 
 }

--- a/Sources/IR/Operands/Constant/MetatypeType+Constant.swift
+++ b/Sources/IR/Operands/Constant/MetatypeType+Constant.swift
@@ -3,6 +3,6 @@ import Core
 extension MetatypeType: Constant {
 
   /// The Val IR type of this instance.
-  public var type: IR.LoweredType { .object(self) }
+  public var type: IRType { .object(self) }
 
 }

--- a/Sources/IR/Operands/Constant/MetatypeType+Constant.swift
+++ b/Sources/IR/Operands/Constant/MetatypeType+Constant.swift
@@ -3,6 +3,6 @@ import Core
 extension MetatypeType: Constant {
 
   /// The Val IR type of this instance.
-  public var type: IRType { .object(self) }
+  public var type: IR.Type_ { .object(self) }
 
 }

--- a/Sources/IR/Operands/Constant/MetatypeType+Constant.swift
+++ b/Sources/IR/Operands/Constant/MetatypeType+Constant.swift
@@ -3,6 +3,6 @@ import Core
 extension MetatypeType: Constant {
 
   /// The Val IR type of this instance.
-  public var type: LoweredType { .object(self) }
+  public var type: IR.LoweredType { .object(self) }
 
 }

--- a/Sources/IR/Operands/Constant/PointerConstant.swift
+++ b/Sources/IR/Operands/Constant/PointerConstant.swift
@@ -16,7 +16,7 @@ public struct PointerConstant: Constant, Hashable {
   }
 
   /// The Val IR type of this instance.
-  public var type: IR.Type_ { .object(BuiltinType.ptr) }
+  public var type: IR.`Type` { .object(BuiltinType.ptr) }
 
 }
 

--- a/Sources/IR/Operands/Constant/PointerConstant.swift
+++ b/Sources/IR/Operands/Constant/PointerConstant.swift
@@ -16,7 +16,7 @@ public struct PointerConstant: Constant, Hashable {
   }
 
   /// The Val IR type of this instance.
-  public var type: IR.LoweredType { .object(BuiltinType.ptr) }
+  public var type: IRType { .object(BuiltinType.ptr) }
 
 }
 

--- a/Sources/IR/Operands/Constant/PointerConstant.swift
+++ b/Sources/IR/Operands/Constant/PointerConstant.swift
@@ -16,7 +16,7 @@ public struct PointerConstant: Constant, Hashable {
   }
 
   /// The Val IR type of this instance.
-  public var type: LoweredType { .object(BuiltinType.ptr) }
+  public var type: IR.LoweredType { .object(BuiltinType.ptr) }
 
 }
 

--- a/Sources/IR/Operands/Constant/PointerConstant.swift
+++ b/Sources/IR/Operands/Constant/PointerConstant.swift
@@ -16,7 +16,7 @@ public struct PointerConstant: Constant, Hashable {
   }
 
   /// The Val IR type of this instance.
-  public var type: IRType { .object(BuiltinType.ptr) }
+  public var type: IR.Type_ { .object(BuiltinType.ptr) }
 
 }
 

--- a/Sources/IR/Operands/Constant/Poison.swift
+++ b/Sources/IR/Operands/Constant/Poison.swift
@@ -2,7 +2,7 @@
 public struct Poison: Constant, Hashable {
 
   /// The type of the poison.
-  public let type: LoweredType
+  public let type: IR.LoweredType
 
 }
 

--- a/Sources/IR/Operands/Constant/Poison.swift
+++ b/Sources/IR/Operands/Constant/Poison.swift
@@ -2,7 +2,7 @@
 public struct Poison: Constant, Hashable {
 
   /// The type of the poison.
-  public let type: IR.LoweredType
+  public let type: IRType
 
 }
 

--- a/Sources/IR/Operands/Constant/Poison.swift
+++ b/Sources/IR/Operands/Constant/Poison.swift
@@ -2,7 +2,7 @@
 public struct Poison: Constant, Hashable {
 
   /// The type of the poison.
-  public let type: IRType
+  public let type: IR.Type_
 
 }
 

--- a/Sources/IR/Operands/Constant/Poison.swift
+++ b/Sources/IR/Operands/Constant/Poison.swift
@@ -2,7 +2,7 @@
 public struct Poison: Constant, Hashable {
 
   /// The type of the poison.
-  public let type: IR.Type_
+  public let type: IR.`Type`
 
 }
 

--- a/Sources/IR/Operands/Constant/TraitType+Constant.swift
+++ b/Sources/IR/Operands/Constant/TraitType+Constant.swift
@@ -3,6 +3,6 @@ import Core
 extension TraitType: Constant {
 
   /// The Val IR type of this instance.
-  public var type: IRType { .object(self) }
+  public var type: IR.Type_ { .object(self) }
 
 }

--- a/Sources/IR/Operands/Constant/TraitType+Constant.swift
+++ b/Sources/IR/Operands/Constant/TraitType+Constant.swift
@@ -3,6 +3,6 @@ import Core
 extension TraitType: Constant {
 
   /// The Val IR type of this instance.
-  public var type: IR.Type_ { .object(self) }
+  public var type: IR.`Type` { .object(self) }
 
 }

--- a/Sources/IR/Operands/Constant/TraitType+Constant.swift
+++ b/Sources/IR/Operands/Constant/TraitType+Constant.swift
@@ -3,6 +3,6 @@ import Core
 extension TraitType: Constant {
 
   /// The Val IR type of this instance.
-  public var type: LoweredType { .object(self) }
+  public var type: IR.LoweredType { .object(self) }
 
 }

--- a/Sources/IR/Operands/Constant/TraitType+Constant.swift
+++ b/Sources/IR/Operands/Constant/TraitType+Constant.swift
@@ -3,6 +3,6 @@ import Core
 extension TraitType: Constant {
 
   /// The Val IR type of this instance.
-  public var type: IR.LoweredType { .object(self) }
+  public var type: IRType { .object(self) }
 
 }

--- a/Sources/IR/Operands/Constant/VoidConstant.swift
+++ b/Sources/IR/Operands/Constant/VoidConstant.swift
@@ -5,7 +5,7 @@ public struct VoidConstant: Constant, Hashable {
 
   public init() {}
 
-  public var type: IRType { .object(AnyType.void) }
+  public var type: IR.Type_ { .object(AnyType.void) }
 
 }
 

--- a/Sources/IR/Operands/Constant/VoidConstant.swift
+++ b/Sources/IR/Operands/Constant/VoidConstant.swift
@@ -5,7 +5,7 @@ public struct VoidConstant: Constant, Hashable {
 
   public init() {}
 
-  public var type: IR.Type_ { .object(AnyType.void) }
+  public var type: IR.`Type` { .object(AnyType.void) }
 
 }
 

--- a/Sources/IR/Operands/Constant/VoidConstant.swift
+++ b/Sources/IR/Operands/Constant/VoidConstant.swift
@@ -5,7 +5,7 @@ public struct VoidConstant: Constant, Hashable {
 
   public init() {}
 
-  public var type: IR.LoweredType { .object(AnyType.void) }
+  public var type: IRType { .object(AnyType.void) }
 
 }
 

--- a/Sources/IR/Operands/Constant/VoidConstant.swift
+++ b/Sources/IR/Operands/Constant/VoidConstant.swift
@@ -5,7 +5,7 @@ public struct VoidConstant: Constant, Hashable {
 
   public init() {}
 
-  public var type: LoweredType { .object(AnyType.void) }
+  public var type: IR.LoweredType { .object(AnyType.void) }
 
 }
 

--- a/Sources/IR/Operands/Constant/WitnessTable.swift
+++ b/Sources/IR/Operands/Constant/WitnessTable.swift
@@ -7,12 +7,12 @@ public struct WitnessTable: Constant, Hashable {
   public let witness: AnyType
 
   /// The conformances described by this table.
-  public let conformances: Set<Conformance>
+  public let conformances: Set<IR.Conformance>
 
   /// Creates an instance describing `witness` and its `conformances`.
   ///
   /// - Requires: `witness` is canonical.
-  public init(for witness: AnyType, conformingTo conformances: Set<Conformance>) {
+  public init(for witness: AnyType, conformingTo conformances: Set<IR.Conformance>) {
     self.witness = witness
     self.conformances = conformances
   }

--- a/Sources/IR/Operands/Constant/WitnessTable.swift
+++ b/Sources/IR/Operands/Constant/WitnessTable.swift
@@ -18,7 +18,7 @@ public struct WitnessTable: Constant, Hashable {
   }
 
   /// The Val IR type of this instance.
-  public var type: IR.LoweredType { .object(WitnessTableType()) }
+  public var type: IRType { .object(WitnessTableType()) }
 
 }
 

--- a/Sources/IR/Operands/Constant/WitnessTable.swift
+++ b/Sources/IR/Operands/Constant/WitnessTable.swift
@@ -18,7 +18,7 @@ public struct WitnessTable: Constant, Hashable {
   }
 
   /// The Val IR type of this instance.
-  public var type: IRType { .object(WitnessTableType()) }
+  public var type: IR.Type_ { .object(WitnessTableType()) }
 
 }
 

--- a/Sources/IR/Operands/Constant/WitnessTable.swift
+++ b/Sources/IR/Operands/Constant/WitnessTable.swift
@@ -18,7 +18,7 @@ public struct WitnessTable: Constant, Hashable {
   }
 
   /// The Val IR type of this instance.
-  public var type: IR.Type_ { .object(WitnessTableType()) }
+  public var type: IR.`Type` { .object(WitnessTableType()) }
 
 }
 

--- a/Sources/IR/Operands/Constant/WitnessTable.swift
+++ b/Sources/IR/Operands/Constant/WitnessTable.swift
@@ -7,12 +7,12 @@ public struct WitnessTable: Constant, Hashable {
   public let witness: AnyType
 
   /// The conformances described by this table.
-  public let conformances: Set<LoweredConformance>
+  public let conformances: Set<Conformance>
 
   /// Creates an instance describing `witness` and its `conformances`.
   ///
   /// - Requires: `witness` is canonical.
-  public init(for witness: AnyType, conformingTo conformances: Set<LoweredConformance>) {
+  public init(for witness: AnyType, conformingTo conformances: Set<Conformance>) {
     self.witness = witness
     self.conformances = conformances
   }

--- a/Sources/IR/Operands/Constant/WitnessTable.swift
+++ b/Sources/IR/Operands/Constant/WitnessTable.swift
@@ -18,7 +18,7 @@ public struct WitnessTable: Constant, Hashable {
   }
 
   /// The Val IR type of this instance.
-  public var type: LoweredType { .object(WitnessTableType()) }
+  public var type: IR.LoweredType { .object(WitnessTableType()) }
 
 }
 

--- a/Sources/IR/Operands/Instruction/AccessInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AccessInstruction.swift
@@ -41,7 +41,7 @@ public struct AccessInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [.address(accessedType)] }
+  public var types: [IR.LoweredType] { [.address(accessedType)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/AccessInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AccessInstruction.swift
@@ -41,7 +41,7 @@ public struct AccessInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [.address(accessedType)] }
+  public var types: [IR.`Type`] { [.address(accessedType)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/AccessInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AccessInstruction.swift
@@ -41,7 +41,7 @@ public struct AccessInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [.address(accessedType)] }
+  public var types: [IR.Type_] { [.address(accessedType)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/AccessInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AccessInstruction.swift
@@ -41,7 +41,7 @@ public struct AccessInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [.address(accessedType)] }
+  public var types: [IRType] { [.address(accessedType)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/AddressToPointerInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AddressToPointerInstruction.swift
@@ -18,7 +18,7 @@ public struct AddressToPointerInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [.object(BuiltinType.ptr)] }
+  public var types: [IR.`Type`] { [.object(BuiltinType.ptr)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/AddressToPointerInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AddressToPointerInstruction.swift
@@ -18,7 +18,7 @@ public struct AddressToPointerInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [.object(BuiltinType.ptr)] }
+  public var types: [IR.Type_] { [.object(BuiltinType.ptr)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/AddressToPointerInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AddressToPointerInstruction.swift
@@ -18,7 +18,7 @@ public struct AddressToPointerInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [.object(BuiltinType.ptr)] }
+  public var types: [IRType] { [.object(BuiltinType.ptr)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/AddressToPointerInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AddressToPointerInstruction.swift
@@ -18,7 +18,7 @@ public struct AddressToPointerInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [.object(BuiltinType.ptr)] }
+  public var types: [IR.LoweredType] { [.object(BuiltinType.ptr)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/AdvancedByBytesInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByBytesInstruction.swift
@@ -23,7 +23,7 @@ public struct AdvancedByBytesInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [.object(BuiltinType.ptr)] }
+  public var types: [IR.`Type`] { [.object(BuiltinType.ptr)] }
 
   public var operands: [Operand] { [base, byteOffset] }
 

--- a/Sources/IR/Operands/Instruction/AdvancedByBytesInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByBytesInstruction.swift
@@ -23,7 +23,7 @@ public struct AdvancedByBytesInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [.object(BuiltinType.ptr)] }
+  public var types: [IR.LoweredType] { [.object(BuiltinType.ptr)] }
 
   public var operands: [Operand] { [base, byteOffset] }
 

--- a/Sources/IR/Operands/Instruction/AdvancedByBytesInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByBytesInstruction.swift
@@ -23,7 +23,7 @@ public struct AdvancedByBytesInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [.object(BuiltinType.ptr)] }
+  public var types: [IRType] { [.object(BuiltinType.ptr)] }
 
   public var operands: [Operand] { [base, byteOffset] }
 

--- a/Sources/IR/Operands/Instruction/AdvancedByBytesInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AdvancedByBytesInstruction.swift
@@ -23,7 +23,7 @@ public struct AdvancedByBytesInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [.object(BuiltinType.ptr)] }
+  public var types: [IR.Type_] { [.object(BuiltinType.ptr)] }
 
   public var operands: [Operand] { [base, byteOffset] }
 

--- a/Sources/IR/Operands/Instruction/AllocStackInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AllocStackInstruction.swift
@@ -15,7 +15,7 @@ public struct AllocStackInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [.address(allocatedType)] }
+  public var types: [IR.LoweredType] { [.address(allocatedType)] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/AllocStackInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AllocStackInstruction.swift
@@ -15,7 +15,7 @@ public struct AllocStackInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [.address(allocatedType)] }
+  public var types: [IR.`Type`] { [.address(allocatedType)] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/AllocStackInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AllocStackInstruction.swift
@@ -15,7 +15,7 @@ public struct AllocStackInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [.address(allocatedType)] }
+  public var types: [IR.Type_] { [.address(allocatedType)] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/AllocStackInstruction.swift
+++ b/Sources/IR/Operands/Instruction/AllocStackInstruction.swift
@@ -15,7 +15,7 @@ public struct AllocStackInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [.address(allocatedType)] }
+  public var types: [IRType] { [.address(allocatedType)] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/BorrowInstruction.swift
+++ b/Sources/IR/Operands/Instruction/BorrowInstruction.swift
@@ -7,7 +7,7 @@ public struct BorrowInstruction: Instruction {
   public let capability: AccessEffect
 
   /// The type of the borrowed access.
-  public let borrowedType: IR.LoweredType
+  public let borrowedType: IRType
 
   /// The location of the root object on which an access is borrowed.
   public private(set) var location: Operand
@@ -20,7 +20,7 @@ public struct BorrowInstruction: Instruction {
 
   /// Creates an instance with the given properties.
   fileprivate init(
-    borrowedType: IR.LoweredType,
+    borrowedType: IRType,
     capability: AccessEffect,
     location: Operand,
     binding: VarDecl.ID?,
@@ -33,7 +33,7 @@ public struct BorrowInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [borrowedType] }
+  public var types: [IRType] { [borrowedType] }
 
   public var operands: [Operand] { [location] }
 

--- a/Sources/IR/Operands/Instruction/BorrowInstruction.swift
+++ b/Sources/IR/Operands/Instruction/BorrowInstruction.swift
@@ -7,7 +7,7 @@ public struct BorrowInstruction: Instruction {
   public let capability: AccessEffect
 
   /// The type of the borrowed access.
-  public let borrowedType: IRType
+  public let borrowedType: IR.Type_
 
   /// The location of the root object on which an access is borrowed.
   public private(set) var location: Operand
@@ -20,7 +20,7 @@ public struct BorrowInstruction: Instruction {
 
   /// Creates an instance with the given properties.
   fileprivate init(
-    borrowedType: IRType,
+    borrowedType: IR.Type_,
     capability: AccessEffect,
     location: Operand,
     binding: VarDecl.ID?,
@@ -33,7 +33,7 @@ public struct BorrowInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [borrowedType] }
+  public var types: [IR.Type_] { [borrowedType] }
 
   public var operands: [Operand] { [location] }
 

--- a/Sources/IR/Operands/Instruction/BorrowInstruction.swift
+++ b/Sources/IR/Operands/Instruction/BorrowInstruction.swift
@@ -7,7 +7,7 @@ public struct BorrowInstruction: Instruction {
   public let capability: AccessEffect
 
   /// The type of the borrowed access.
-  public let borrowedType: LoweredType
+  public let borrowedType: IR.LoweredType
 
   /// The location of the root object on which an access is borrowed.
   public private(set) var location: Operand
@@ -20,7 +20,7 @@ public struct BorrowInstruction: Instruction {
 
   /// Creates an instance with the given properties.
   fileprivate init(
-    borrowedType: LoweredType,
+    borrowedType: IR.LoweredType,
     capability: AccessEffect,
     location: Operand,
     binding: VarDecl.ID?,
@@ -33,7 +33,7 @@ public struct BorrowInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [borrowedType] }
+  public var types: [IR.LoweredType] { [borrowedType] }
 
   public var operands: [Operand] { [location] }
 

--- a/Sources/IR/Operands/Instruction/BorrowInstruction.swift
+++ b/Sources/IR/Operands/Instruction/BorrowInstruction.swift
@@ -7,7 +7,7 @@ public struct BorrowInstruction: Instruction {
   public let capability: AccessEffect
 
   /// The type of the borrowed access.
-  public let borrowedType: IR.Type_
+  public let borrowedType: IR.`Type`
 
   /// The location of the root object on which an access is borrowed.
   public private(set) var location: Operand
@@ -20,7 +20,7 @@ public struct BorrowInstruction: Instruction {
 
   /// Creates an instance with the given properties.
   fileprivate init(
-    borrowedType: IR.Type_,
+    borrowedType: IR.`Type`,
     capability: AccessEffect,
     location: Operand,
     binding: VarDecl.ID?,
@@ -33,7 +33,7 @@ public struct BorrowInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [borrowedType] }
+  public var types: [IR.`Type`] { [borrowedType] }
 
   public var operands: [Operand] { [location] }
 

--- a/Sources/IR/Operands/Instruction/BranchInstruction.swift
+++ b/Sources/IR/Operands/Instruction/BranchInstruction.swift
@@ -15,7 +15,7 @@ public struct BranchInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/BranchInstruction.swift
+++ b/Sources/IR/Operands/Instruction/BranchInstruction.swift
@@ -15,7 +15,7 @@ public struct BranchInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/BranchInstruction.swift
+++ b/Sources/IR/Operands/Instruction/BranchInstruction.swift
@@ -15,7 +15,7 @@ public struct BranchInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/BranchInstruction.swift
+++ b/Sources/IR/Operands/Instruction/BranchInstruction.swift
@@ -15,7 +15,7 @@ public struct BranchInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/CallFFIInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CallFFIInstruction.swift
@@ -5,7 +5,7 @@ import Utils
 public struct CallFFIInstruction: Instruction {
 
   /// The type of the return value.
-  public let returnType: IRType
+  public let returnType: IR.Type_
 
   /// The name of the foreign function.
   public let callee: String
@@ -18,7 +18,7 @@ public struct CallFFIInstruction: Instruction {
 
   /// Creates an instance with the given properties.
   fileprivate init(
-    returnType: IRType,
+    returnType: IR.Type_,
     callee: String,
     arguments: [Operand],
     site: SourceRange
@@ -29,7 +29,7 @@ public struct CallFFIInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [returnType] }
+  public var types: [IR.Type_] { [returnType] }
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[i] = new
@@ -56,7 +56,7 @@ extension Module {
   ///   - callee: The name of the foreign function to call
   ///   - arguments: The arguments of the call.
   func makeCallFFI(
-    returning returnType: IRType, applying callee: String, to arguments: [Operand],
+    returning returnType: IR.Type_, applying callee: String, to arguments: [Operand],
     at site: SourceRange
   ) -> CallFFIInstruction {
     precondition(returnType.isObject)

--- a/Sources/IR/Operands/Instruction/CallFFIInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CallFFIInstruction.swift
@@ -5,7 +5,7 @@ import Utils
 public struct CallFFIInstruction: Instruction {
 
   /// The type of the return value.
-  public let returnType: IR.Type_
+  public let returnType: IR.`Type`
 
   /// The name of the foreign function.
   public let callee: String
@@ -18,7 +18,7 @@ public struct CallFFIInstruction: Instruction {
 
   /// Creates an instance with the given properties.
   fileprivate init(
-    returnType: IR.Type_,
+    returnType: IR.`Type`,
     callee: String,
     arguments: [Operand],
     site: SourceRange
@@ -29,7 +29,7 @@ public struct CallFFIInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [returnType] }
+  public var types: [IR.`Type`] { [returnType] }
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[i] = new
@@ -56,7 +56,7 @@ extension Module {
   ///   - callee: The name of the foreign function to call
   ///   - arguments: The arguments of the call.
   func makeCallFFI(
-    returning returnType: IR.Type_, applying callee: String, to arguments: [Operand],
+    returning returnType: IR.`Type`, applying callee: String, to arguments: [Operand],
     at site: SourceRange
   ) -> CallFFIInstruction {
     precondition(returnType.isObject)

--- a/Sources/IR/Operands/Instruction/CallFFIInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CallFFIInstruction.swift
@@ -5,7 +5,7 @@ import Utils
 public struct CallFFIInstruction: Instruction {
 
   /// The type of the return value.
-  public let returnType: LoweredType
+  public let returnType: IR.LoweredType
 
   /// The name of the foreign function.
   public let callee: String
@@ -18,7 +18,7 @@ public struct CallFFIInstruction: Instruction {
 
   /// Creates an instance with the given properties.
   fileprivate init(
-    returnType: LoweredType,
+    returnType: IR.LoweredType,
     callee: String,
     arguments: [Operand],
     site: SourceRange
@@ -29,7 +29,7 @@ public struct CallFFIInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [returnType] }
+  public var types: [IR.LoweredType] { [returnType] }
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[i] = new
@@ -56,7 +56,7 @@ extension Module {
   ///   - callee: The name of the foreign function to call
   ///   - arguments: The arguments of the call.
   func makeCallFFI(
-    returning returnType: LoweredType, applying callee: String, to arguments: [Operand],
+    returning returnType: IR.LoweredType, applying callee: String, to arguments: [Operand],
     at site: SourceRange
   ) -> CallFFIInstruction {
     precondition(returnType.isObject)

--- a/Sources/IR/Operands/Instruction/CallFFIInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CallFFIInstruction.swift
@@ -5,7 +5,7 @@ import Utils
 public struct CallFFIInstruction: Instruction {
 
   /// The type of the return value.
-  public let returnType: IR.LoweredType
+  public let returnType: IRType
 
   /// The name of the foreign function.
   public let callee: String
@@ -18,7 +18,7 @@ public struct CallFFIInstruction: Instruction {
 
   /// Creates an instance with the given properties.
   fileprivate init(
-    returnType: IR.LoweredType,
+    returnType: IRType,
     callee: String,
     arguments: [Operand],
     site: SourceRange
@@ -29,7 +29,7 @@ public struct CallFFIInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [returnType] }
+  public var types: [IRType] { [returnType] }
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[i] = new
@@ -56,7 +56,7 @@ extension Module {
   ///   - callee: The name of the foreign function to call
   ///   - arguments: The arguments of the call.
   func makeCallFFI(
-    returning returnType: IR.LoweredType, applying callee: String, to arguments: [Operand],
+    returning returnType: IRType, applying callee: String, to arguments: [Operand],
     at site: SourceRange
   ) -> CallFFIInstruction {
     precondition(returnType.isObject)

--- a/Sources/IR/Operands/Instruction/CallInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CallInstruction.swift
@@ -34,7 +34,7 @@ public struct CallInstruction: Instruction {
   public var arguments: ArraySlice<Operand> { operands[2...] }
 
   /// The types of the instruction's results.
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   /// `true` iff the instruction denotes a call to a generic function.
   public var isGeneric: Bool {

--- a/Sources/IR/Operands/Instruction/CallInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CallInstruction.swift
@@ -34,7 +34,7 @@ public struct CallInstruction: Instruction {
   public var arguments: ArraySlice<Operand> { operands[2...] }
 
   /// The types of the instruction's results.
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   /// `true` iff the instruction denotes a call to a generic function.
   public var isGeneric: Bool {

--- a/Sources/IR/Operands/Instruction/CallInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CallInstruction.swift
@@ -34,7 +34,7 @@ public struct CallInstruction: Instruction {
   public var arguments: ArraySlice<Operand> { operands[2...] }
 
   /// The types of the instruction's results.
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   /// `true` iff the instruction denotes a call to a generic function.
   public var isGeneric: Bool {

--- a/Sources/IR/Operands/Instruction/CallInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CallInstruction.swift
@@ -34,7 +34,7 @@ public struct CallInstruction: Instruction {
   public var arguments: ArraySlice<Operand> { operands[2...] }
 
   /// The types of the instruction's results.
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   /// `true` iff the instruction denotes a call to a generic function.
   public var isGeneric: Bool {

--- a/Sources/IR/Operands/Instruction/CloseSumInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CloseSumInstruction.swift
@@ -15,7 +15,7 @@ public struct CloseSumInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   public var operands: [Operand] { [start] }
 

--- a/Sources/IR/Operands/Instruction/CloseSumInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CloseSumInstruction.swift
@@ -15,7 +15,7 @@ public struct CloseSumInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   public var operands: [Operand] { [start] }
 

--- a/Sources/IR/Operands/Instruction/CloseSumInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CloseSumInstruction.swift
@@ -15,7 +15,7 @@ public struct CloseSumInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   public var operands: [Operand] { [start] }
 

--- a/Sources/IR/Operands/Instruction/CloseSumInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CloseSumInstruction.swift
@@ -15,7 +15,7 @@ public struct CloseSumInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   public var operands: [Operand] { [start] }
 

--- a/Sources/IR/Operands/Instruction/CondBranchInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CondBranchInstruction.swift
@@ -28,7 +28,7 @@ public struct CondBranchInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   public var operands: [Operand] { [condition] }
 

--- a/Sources/IR/Operands/Instruction/CondBranchInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CondBranchInstruction.swift
@@ -28,7 +28,7 @@ public struct CondBranchInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   public var operands: [Operand] { [condition] }
 

--- a/Sources/IR/Operands/Instruction/CondBranchInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CondBranchInstruction.swift
@@ -28,7 +28,7 @@ public struct CondBranchInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   public var operands: [Operand] { [condition] }
 

--- a/Sources/IR/Operands/Instruction/CondBranchInstruction.swift
+++ b/Sources/IR/Operands/Instruction/CondBranchInstruction.swift
@@ -28,7 +28,7 @@ public struct CondBranchInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   public var operands: [Operand] { [condition] }
 

--- a/Sources/IR/Operands/Instruction/DeallocStackInstruction.swift
+++ b/Sources/IR/Operands/Instruction/DeallocStackInstruction.swift
@@ -15,7 +15,7 @@ public struct DeallocStackInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   public var operands: [Operand] { [location] }
 

--- a/Sources/IR/Operands/Instruction/DeallocStackInstruction.swift
+++ b/Sources/IR/Operands/Instruction/DeallocStackInstruction.swift
@@ -15,7 +15,7 @@ public struct DeallocStackInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   public var operands: [Operand] { [location] }
 

--- a/Sources/IR/Operands/Instruction/DeallocStackInstruction.swift
+++ b/Sources/IR/Operands/Instruction/DeallocStackInstruction.swift
@@ -15,7 +15,7 @@ public struct DeallocStackInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   public var operands: [Operand] { [location] }
 

--- a/Sources/IR/Operands/Instruction/DeallocStackInstruction.swift
+++ b/Sources/IR/Operands/Instruction/DeallocStackInstruction.swift
@@ -15,7 +15,7 @@ public struct DeallocStackInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   public var operands: [Operand] { [location] }
 

--- a/Sources/IR/Operands/Instruction/EndBorrowInstruction.swift
+++ b/Sources/IR/Operands/Instruction/EndBorrowInstruction.swift
@@ -15,7 +15,7 @@ public struct EndBorrowInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   public var operands: [Operand] { [borrow] }
 

--- a/Sources/IR/Operands/Instruction/EndBorrowInstruction.swift
+++ b/Sources/IR/Operands/Instruction/EndBorrowInstruction.swift
@@ -15,7 +15,7 @@ public struct EndBorrowInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   public var operands: [Operand] { [borrow] }
 

--- a/Sources/IR/Operands/Instruction/EndBorrowInstruction.swift
+++ b/Sources/IR/Operands/Instruction/EndBorrowInstruction.swift
@@ -15,7 +15,7 @@ public struct EndBorrowInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   public var operands: [Operand] { [borrow] }
 

--- a/Sources/IR/Operands/Instruction/EndBorrowInstruction.swift
+++ b/Sources/IR/Operands/Instruction/EndBorrowInstruction.swift
@@ -15,7 +15,7 @@ public struct EndBorrowInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   public var operands: [Operand] { [borrow] }
 

--- a/Sources/IR/Operands/Instruction/EndProjectInstruction.swift
+++ b/Sources/IR/Operands/Instruction/EndProjectInstruction.swift
@@ -15,7 +15,7 @@ public struct EndProjectInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   public var operands: [Operand] { [projection] }
 

--- a/Sources/IR/Operands/Instruction/EndProjectInstruction.swift
+++ b/Sources/IR/Operands/Instruction/EndProjectInstruction.swift
@@ -15,7 +15,7 @@ public struct EndProjectInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   public var operands: [Operand] { [projection] }
 

--- a/Sources/IR/Operands/Instruction/EndProjectInstruction.swift
+++ b/Sources/IR/Operands/Instruction/EndProjectInstruction.swift
@@ -15,7 +15,7 @@ public struct EndProjectInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   public var operands: [Operand] { [projection] }
 

--- a/Sources/IR/Operands/Instruction/EndProjectInstruction.swift
+++ b/Sources/IR/Operands/Instruction/EndProjectInstruction.swift
@@ -15,7 +15,7 @@ public struct EndProjectInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   public var operands: [Operand] { [projection] }
 

--- a/Sources/IR/Operands/Instruction/GlobalAddrInstruction.swift
+++ b/Sources/IR/Operands/Instruction/GlobalAddrInstruction.swift
@@ -28,7 +28,7 @@ public struct GlobalAddrInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [.address(valueType)] }
+  public var types: [IR.LoweredType] { [.address(valueType)] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/GlobalAddrInstruction.swift
+++ b/Sources/IR/Operands/Instruction/GlobalAddrInstruction.swift
@@ -28,7 +28,7 @@ public struct GlobalAddrInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [.address(valueType)] }
+  public var types: [IR.`Type`] { [.address(valueType)] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/GlobalAddrInstruction.swift
+++ b/Sources/IR/Operands/Instruction/GlobalAddrInstruction.swift
@@ -28,7 +28,7 @@ public struct GlobalAddrInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [.address(valueType)] }
+  public var types: [IR.Type_] { [.address(valueType)] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/GlobalAddrInstruction.swift
+++ b/Sources/IR/Operands/Instruction/GlobalAddrInstruction.swift
@@ -28,7 +28,7 @@ public struct GlobalAddrInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [.address(valueType)] }
+  public var types: [IRType] { [.address(valueType)] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/Instruction.swift
+++ b/Sources/IR/Operands/Instruction/Instruction.swift
@@ -5,7 +5,7 @@ import Utils
 public protocol Instruction: CustomStringConvertible {
 
   /// The types of the instruction's results (empty for instructions with no result).
-  var types: [IR.LoweredType] { get }
+  var types: [IRType] { get }
 
   /// The operands of the instruction.
   var operands: [Operand] { get }

--- a/Sources/IR/Operands/Instruction/Instruction.swift
+++ b/Sources/IR/Operands/Instruction/Instruction.swift
@@ -5,7 +5,7 @@ import Utils
 public protocol Instruction: CustomStringConvertible {
 
   /// The types of the instruction's results (empty for instructions with no result).
-  var types: [IRType] { get }
+  var types: [IR.Type_] { get }
 
   /// The operands of the instruction.
   var operands: [Operand] { get }

--- a/Sources/IR/Operands/Instruction/Instruction.swift
+++ b/Sources/IR/Operands/Instruction/Instruction.swift
@@ -5,7 +5,7 @@ import Utils
 public protocol Instruction: CustomStringConvertible {
 
   /// The types of the instruction's results (empty for instructions with no result).
-  var types: [IR.Type_] { get }
+  var types: [IR.`Type`] { get }
 
   /// The operands of the instruction.
   var operands: [Operand] { get }

--- a/Sources/IR/Operands/Instruction/Instruction.swift
+++ b/Sources/IR/Operands/Instruction/Instruction.swift
@@ -5,7 +5,7 @@ import Utils
 public protocol Instruction: CustomStringConvertible {
 
   /// The types of the instruction's results (empty for instructions with no result).
-  var types: [LoweredType] { get }
+  var types: [IR.LoweredType] { get }
 
   /// The operands of the instruction.
   var operands: [Operand] { get }

--- a/Sources/IR/Operands/Instruction/LLVMInstruction.swift
+++ b/Sources/IR/Operands/Instruction/LLVMInstruction.swift
@@ -19,7 +19,7 @@ public struct LLVMInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [.object(instruction.type.output)] }
+  public var types: [IRType] { [.object(instruction.type.output)] }
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[i] = new

--- a/Sources/IR/Operands/Instruction/LLVMInstruction.swift
+++ b/Sources/IR/Operands/Instruction/LLVMInstruction.swift
@@ -19,7 +19,7 @@ public struct LLVMInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [.object(instruction.type.output)] }
+  public var types: [IR.LoweredType] { [.object(instruction.type.output)] }
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[i] = new

--- a/Sources/IR/Operands/Instruction/LLVMInstruction.swift
+++ b/Sources/IR/Operands/Instruction/LLVMInstruction.swift
@@ -19,7 +19,7 @@ public struct LLVMInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [.object(instruction.type.output)] }
+  public var types: [IR.`Type`] { [.object(instruction.type.output)] }
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[i] = new

--- a/Sources/IR/Operands/Instruction/LLVMInstruction.swift
+++ b/Sources/IR/Operands/Instruction/LLVMInstruction.swift
@@ -19,7 +19,7 @@ public struct LLVMInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [.object(instruction.type.output)] }
+  public var types: [IR.Type_] { [.object(instruction.type.output)] }
 
   public mutating func replaceOperand(at i: Int, with new: Operand) {
     operands[i] = new

--- a/Sources/IR/Operands/Instruction/LoadInstruction.swift
+++ b/Sources/IR/Operands/Instruction/LoadInstruction.swift
@@ -4,7 +4,7 @@ import Core
 public struct LoadInstruction: Instruction {
 
   /// The type of the object being loaded.
-  public let objectType: IR.LoweredType
+  public let objectType: IRType
 
   /// The location of the object is being loaded.
   public private(set) var source: Operand
@@ -13,13 +13,13 @@ public struct LoadInstruction: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(objectType: IR.LoweredType, from source: Operand, site: SourceRange) {
+  fileprivate init(objectType: IRType, from source: Operand, site: SourceRange) {
     self.objectType = objectType
     self.source = source
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [objectType] }
+  public var types: [IRType] { [objectType] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/LoadInstruction.swift
+++ b/Sources/IR/Operands/Instruction/LoadInstruction.swift
@@ -4,7 +4,7 @@ import Core
 public struct LoadInstruction: Instruction {
 
   /// The type of the object being loaded.
-  public let objectType: IRType
+  public let objectType: IR.Type_
 
   /// The location of the object is being loaded.
   public private(set) var source: Operand
@@ -13,13 +13,13 @@ public struct LoadInstruction: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(objectType: IRType, from source: Operand, site: SourceRange) {
+  fileprivate init(objectType: IR.Type_, from source: Operand, site: SourceRange) {
     self.objectType = objectType
     self.source = source
     self.site = site
   }
 
-  public var types: [IRType] { [objectType] }
+  public var types: [IR.Type_] { [objectType] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/LoadInstruction.swift
+++ b/Sources/IR/Operands/Instruction/LoadInstruction.swift
@@ -4,7 +4,7 @@ import Core
 public struct LoadInstruction: Instruction {
 
   /// The type of the object being loaded.
-  public let objectType: LoweredType
+  public let objectType: IR.LoweredType
 
   /// The location of the object is being loaded.
   public private(set) var source: Operand
@@ -13,13 +13,13 @@ public struct LoadInstruction: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(objectType: LoweredType, from source: Operand, site: SourceRange) {
+  fileprivate init(objectType: IR.LoweredType, from source: Operand, site: SourceRange) {
     self.objectType = objectType
     self.source = source
     self.site = site
   }
 
-  public var types: [LoweredType] { [objectType] }
+  public var types: [IR.LoweredType] { [objectType] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/LoadInstruction.swift
+++ b/Sources/IR/Operands/Instruction/LoadInstruction.swift
@@ -4,7 +4,7 @@ import Core
 public struct LoadInstruction: Instruction {
 
   /// The type of the object being loaded.
-  public let objectType: IR.Type_
+  public let objectType: IR.`Type`
 
   /// The location of the object is being loaded.
   public private(set) var source: Operand
@@ -13,13 +13,13 @@ public struct LoadInstruction: Instruction {
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(objectType: IR.Type_, from source: Operand, site: SourceRange) {
+  fileprivate init(objectType: IR.`Type`, from source: Operand, site: SourceRange) {
     self.objectType = objectType
     self.source = source
     self.site = site
   }
 
-  public var types: [IR.Type_] { [objectType] }
+  public var types: [IR.`Type`] { [objectType] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/MarkStateInstruction.swift
+++ b/Sources/IR/Operands/Instruction/MarkStateInstruction.swift
@@ -19,7 +19,7 @@ public struct MarkStateInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   public var operands: [Operand] { [storage] }
 

--- a/Sources/IR/Operands/Instruction/MarkStateInstruction.swift
+++ b/Sources/IR/Operands/Instruction/MarkStateInstruction.swift
@@ -19,7 +19,7 @@ public struct MarkStateInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   public var operands: [Operand] { [storage] }
 

--- a/Sources/IR/Operands/Instruction/MarkStateInstruction.swift
+++ b/Sources/IR/Operands/Instruction/MarkStateInstruction.swift
@@ -19,7 +19,7 @@ public struct MarkStateInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   public var operands: [Operand] { [storage] }
 

--- a/Sources/IR/Operands/Instruction/MarkStateInstruction.swift
+++ b/Sources/IR/Operands/Instruction/MarkStateInstruction.swift
@@ -19,7 +19,7 @@ public struct MarkStateInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   public var operands: [Operand] { [storage] }
 

--- a/Sources/IR/Operands/Instruction/MoveInstruction.swift
+++ b/Sources/IR/Operands/Instruction/MoveInstruction.swift
@@ -23,7 +23,7 @@ public struct MoveInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   public var operands: [Operand] { [object, target] }
 

--- a/Sources/IR/Operands/Instruction/MoveInstruction.swift
+++ b/Sources/IR/Operands/Instruction/MoveInstruction.swift
@@ -23,7 +23,7 @@ public struct MoveInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   public var operands: [Operand] { [object, target] }
 

--- a/Sources/IR/Operands/Instruction/MoveInstruction.swift
+++ b/Sources/IR/Operands/Instruction/MoveInstruction.swift
@@ -23,7 +23,7 @@ public struct MoveInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   public var operands: [Operand] { [object, target] }
 

--- a/Sources/IR/Operands/Instruction/MoveInstruction.swift
+++ b/Sources/IR/Operands/Instruction/MoveInstruction.swift
@@ -10,13 +10,13 @@ public struct MoveInstruction: Instruction {
   public private(set) var target: Operand
 
   /// The conformance of `target`'s type to `Movable` implementing its move operators.
-  public let movable: Conformance
+  public let movable: Core.Conformance
 
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(object: Operand, target: Operand, movable: Conformance, site: SourceRange) {
+  fileprivate init(object: Operand, target: Operand, movable: Core.Conformance, site: SourceRange) {
     self.object = object
     self.target = target
     self.movable = movable
@@ -50,7 +50,7 @@ extension Module {
   ///   - object: The object to move. Must have an object type.
   ///   - target: The location to initialize or assign. Must have an address type.
   func makeMove(
-    _ object: Operand, to target: Operand, usingConformance movable: Conformance,
+    _ object: Operand, to target: Operand, usingConformance movable: Core.Conformance,
     at site: SourceRange
   ) -> MoveInstruction {
     precondition(type(of: object).isObject)

--- a/Sources/IR/Operands/Instruction/MoveInstruction.swift
+++ b/Sources/IR/Operands/Instruction/MoveInstruction.swift
@@ -23,7 +23,7 @@ public struct MoveInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   public var operands: [Operand] { [object, target] }
 

--- a/Sources/IR/Operands/Instruction/OpenInstruction.swift
+++ b/Sources/IR/Operands/Instruction/OpenInstruction.swift
@@ -20,7 +20,7 @@ public struct OpenInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [.address(type), .object(BuiltinType.i(1))] }
+  public var types: [IR.`Type`] { [.address(type), .object(BuiltinType.i(1))] }
 
   public var operands: [Operand] { [container] }
 

--- a/Sources/IR/Operands/Instruction/OpenInstruction.swift
+++ b/Sources/IR/Operands/Instruction/OpenInstruction.swift
@@ -20,7 +20,7 @@ public struct OpenInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [.address(type), .object(BuiltinType.i(1))] }
+  public var types: [IR.Type_] { [.address(type), .object(BuiltinType.i(1))] }
 
   public var operands: [Operand] { [container] }
 

--- a/Sources/IR/Operands/Instruction/OpenInstruction.swift
+++ b/Sources/IR/Operands/Instruction/OpenInstruction.swift
@@ -20,7 +20,7 @@ public struct OpenInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [.address(type), .object(BuiltinType.i(1))] }
+  public var types: [IRType] { [.address(type), .object(BuiltinType.i(1))] }
 
   public var operands: [Operand] { [container] }
 

--- a/Sources/IR/Operands/Instruction/OpenInstruction.swift
+++ b/Sources/IR/Operands/Instruction/OpenInstruction.swift
@@ -20,7 +20,7 @@ public struct OpenInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [.address(type), .object(BuiltinType.i(1))] }
+  public var types: [IR.LoweredType] { [.address(type), .object(BuiltinType.i(1))] }
 
   public var operands: [Operand] { [container] }
 

--- a/Sources/IR/Operands/Instruction/OpenSumInstruction.swift
+++ b/Sources/IR/Operands/Instruction/OpenSumInstruction.swift
@@ -33,7 +33,7 @@ public struct OpenSumInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [.address(payloadType)] }
+  public var types: [IR.Type_] { [.address(payloadType)] }
 
   public var operands: [Operand] { [container] }
 

--- a/Sources/IR/Operands/Instruction/OpenSumInstruction.swift
+++ b/Sources/IR/Operands/Instruction/OpenSumInstruction.swift
@@ -33,7 +33,7 @@ public struct OpenSumInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [.address(payloadType)] }
+  public var types: [IRType] { [.address(payloadType)] }
 
   public var operands: [Operand] { [container] }
 

--- a/Sources/IR/Operands/Instruction/OpenSumInstruction.swift
+++ b/Sources/IR/Operands/Instruction/OpenSumInstruction.swift
@@ -33,7 +33,7 @@ public struct OpenSumInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [.address(payloadType)] }
+  public var types: [IR.`Type`] { [.address(payloadType)] }
 
   public var operands: [Operand] { [container] }
 

--- a/Sources/IR/Operands/Instruction/OpenSumInstruction.swift
+++ b/Sources/IR/Operands/Instruction/OpenSumInstruction.swift
@@ -33,7 +33,7 @@ public struct OpenSumInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [.address(payloadType)] }
+  public var types: [IR.LoweredType] { [.address(payloadType)] }
 
   public var operands: [Operand] { [container] }
 

--- a/Sources/IR/Operands/Instruction/PartialApplyInstruction.swift
+++ b/Sources/IR/Operands/Instruction/PartialApplyInstruction.swift
@@ -19,7 +19,7 @@ public struct PartialApplyInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [.object(callee.type.ast)] }
+  public var types: [IR.`Type`] { [.object(callee.type.ast)] }
 
   public var operands: [Operand] { [.constant(callee), environment] }
 

--- a/Sources/IR/Operands/Instruction/PartialApplyInstruction.swift
+++ b/Sources/IR/Operands/Instruction/PartialApplyInstruction.swift
@@ -19,7 +19,7 @@ public struct PartialApplyInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [.object(callee.type.ast)] }
+  public var types: [IRType] { [.object(callee.type.ast)] }
 
   public var operands: [Operand] { [.constant(callee), environment] }
 

--- a/Sources/IR/Operands/Instruction/PartialApplyInstruction.swift
+++ b/Sources/IR/Operands/Instruction/PartialApplyInstruction.swift
@@ -19,7 +19,7 @@ public struct PartialApplyInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [.object(callee.type.ast)] }
+  public var types: [IR.Type_] { [.object(callee.type.ast)] }
 
   public var operands: [Operand] { [.constant(callee), environment] }
 

--- a/Sources/IR/Operands/Instruction/PartialApplyInstruction.swift
+++ b/Sources/IR/Operands/Instruction/PartialApplyInstruction.swift
@@ -19,7 +19,7 @@ public struct PartialApplyInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [.object(callee.type.ast)] }
+  public var types: [IR.LoweredType] { [.object(callee.type.ast)] }
 
   public var operands: [Operand] { [.constant(callee), environment] }
 

--- a/Sources/IR/Operands/Instruction/PointerToAddressIntruction.swift
+++ b/Sources/IR/Operands/Instruction/PointerToAddressIntruction.swift
@@ -22,7 +22,7 @@ public struct PointerToAddressInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [.address(target.bareType)] }
+  public var types: [IRType] { [.address(target.bareType)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/PointerToAddressIntruction.swift
+++ b/Sources/IR/Operands/Instruction/PointerToAddressIntruction.swift
@@ -22,7 +22,7 @@ public struct PointerToAddressInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [.address(target.bareType)] }
+  public var types: [IR.Type_] { [.address(target.bareType)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/PointerToAddressIntruction.swift
+++ b/Sources/IR/Operands/Instruction/PointerToAddressIntruction.swift
@@ -22,7 +22,7 @@ public struct PointerToAddressInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [.address(target.bareType)] }
+  public var types: [IR.`Type`] { [.address(target.bareType)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/PointerToAddressIntruction.swift
+++ b/Sources/IR/Operands/Instruction/PointerToAddressIntruction.swift
@@ -22,7 +22,7 @@ public struct PointerToAddressInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [.address(target.bareType)] }
+  public var types: [IR.LoweredType] { [.address(target.bareType)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/ProjectBundleInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ProjectBundleInstruction.swift
@@ -52,7 +52,7 @@ public struct ProjectBundleInstruction: Instruction {
   }
 
   /// The types of the instruction's results.
-  public var types: [LoweredType] {
+  public var types: [IR.LoweredType] {
     [.address(projection.bareType)]
   }
 

--- a/Sources/IR/Operands/Instruction/ProjectBundleInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ProjectBundleInstruction.swift
@@ -52,7 +52,7 @@ public struct ProjectBundleInstruction: Instruction {
   }
 
   /// The types of the instruction's results.
-  public var types: [IR.LoweredType] {
+  public var types: [IRType] {
     [.address(projection.bareType)]
   }
 

--- a/Sources/IR/Operands/Instruction/ProjectBundleInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ProjectBundleInstruction.swift
@@ -52,7 +52,7 @@ public struct ProjectBundleInstruction: Instruction {
   }
 
   /// The types of the instruction's results.
-  public var types: [IRType] {
+  public var types: [IR.Type_] {
     [.address(projection.bareType)]
   }
 

--- a/Sources/IR/Operands/Instruction/ProjectBundleInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ProjectBundleInstruction.swift
@@ -52,7 +52,7 @@ public struct ProjectBundleInstruction: Instruction {
   }
 
   /// The types of the instruction's results.
-  public var types: [IR.Type_] {
+  public var types: [IR.`Type`] {
     [.address(projection.bareType)]
   }
 

--- a/Sources/IR/Operands/Instruction/ProjectInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ProjectInstruction.swift
@@ -37,7 +37,7 @@ public struct ProjectInstruction: Instruction {
   }
 
   /// The types of the instruction's results.
-  public var types: [LoweredType] {
+  public var types: [IR.LoweredType] {
     [.address(projection.bareType)]
   }
 

--- a/Sources/IR/Operands/Instruction/ProjectInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ProjectInstruction.swift
@@ -37,7 +37,7 @@ public struct ProjectInstruction: Instruction {
   }
 
   /// The types of the instruction's results.
-  public var types: [IR.LoweredType] {
+  public var types: [IRType] {
     [.address(projection.bareType)]
   }
 

--- a/Sources/IR/Operands/Instruction/ProjectInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ProjectInstruction.swift
@@ -37,7 +37,7 @@ public struct ProjectInstruction: Instruction {
   }
 
   /// The types of the instruction's results.
-  public var types: [IR.Type_] {
+  public var types: [IR.`Type`] {
     [.address(projection.bareType)]
   }
 

--- a/Sources/IR/Operands/Instruction/ProjectInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ProjectInstruction.swift
@@ -37,7 +37,7 @@ public struct ProjectInstruction: Instruction {
   }
 
   /// The types of the instruction's results.
-  public var types: [IRType] {
+  public var types: [IR.Type_] {
     [.address(projection.bareType)]
   }
 

--- a/Sources/IR/Operands/Instruction/ReturnInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ReturnInstruction.swift
@@ -11,7 +11,7 @@ public struct ReturnInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/ReturnInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ReturnInstruction.swift
@@ -11,7 +11,7 @@ public struct ReturnInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/ReturnInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ReturnInstruction.swift
@@ -11,7 +11,7 @@ public struct ReturnInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/ReturnInstruction.swift
+++ b/Sources/IR/Operands/Instruction/ReturnInstruction.swift
@@ -11,7 +11,7 @@ public struct ReturnInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/StoreInstruction.swift
+++ b/Sources/IR/Operands/Instruction/StoreInstruction.swift
@@ -19,7 +19,7 @@ public struct StoreInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   public var operands: [Operand] { [object, target] }
 

--- a/Sources/IR/Operands/Instruction/StoreInstruction.swift
+++ b/Sources/IR/Operands/Instruction/StoreInstruction.swift
@@ -19,7 +19,7 @@ public struct StoreInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   public var operands: [Operand] { [object, target] }
 

--- a/Sources/IR/Operands/Instruction/StoreInstruction.swift
+++ b/Sources/IR/Operands/Instruction/StoreInstruction.swift
@@ -19,7 +19,7 @@ public struct StoreInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   public var operands: [Operand] { [object, target] }
 

--- a/Sources/IR/Operands/Instruction/StoreInstruction.swift
+++ b/Sources/IR/Operands/Instruction/StoreInstruction.swift
@@ -19,7 +19,7 @@ public struct StoreInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   public var operands: [Operand] { [object, target] }
 

--- a/Sources/IR/Operands/Instruction/SubfieldViewInstruction.swift
+++ b/Sources/IR/Operands/Instruction/SubfieldViewInstruction.swift
@@ -12,7 +12,7 @@ public struct SubfieldViewInstruction: Instruction {
   public let subfield: RecordPath
 
   /// The type of the resulting address.
-  public let resultType: IR.LoweredType
+  public let resultType: IRType
 
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
@@ -21,7 +21,7 @@ public struct SubfieldViewInstruction: Instruction {
   fileprivate init(
     base: Operand,
     subfield: RecordPath,
-    subfieldType: IR.LoweredType,
+    subfieldType: IRType,
     site: SourceRange
   ) {
     self.recordAddress = base
@@ -30,7 +30,7 @@ public struct SubfieldViewInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [resultType] }
+  public var types: [IRType] { [resultType] }
 
   public var operands: [Operand] { [recordAddress] }
 

--- a/Sources/IR/Operands/Instruction/SubfieldViewInstruction.swift
+++ b/Sources/IR/Operands/Instruction/SubfieldViewInstruction.swift
@@ -12,7 +12,7 @@ public struct SubfieldViewInstruction: Instruction {
   public let subfield: RecordPath
 
   /// The type of the resulting address.
-  public let resultType: IR.Type_
+  public let resultType: IR.`Type`
 
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
@@ -21,7 +21,7 @@ public struct SubfieldViewInstruction: Instruction {
   fileprivate init(
     base: Operand,
     subfield: RecordPath,
-    subfieldType: IR.Type_,
+    subfieldType: IR.`Type`,
     site: SourceRange
   ) {
     self.recordAddress = base
@@ -30,7 +30,7 @@ public struct SubfieldViewInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [resultType] }
+  public var types: [IR.`Type`] { [resultType] }
 
   public var operands: [Operand] { [recordAddress] }
 

--- a/Sources/IR/Operands/Instruction/SubfieldViewInstruction.swift
+++ b/Sources/IR/Operands/Instruction/SubfieldViewInstruction.swift
@@ -12,7 +12,7 @@ public struct SubfieldViewInstruction: Instruction {
   public let subfield: RecordPath
 
   /// The type of the resulting address.
-  public let resultType: LoweredType
+  public let resultType: IR.LoweredType
 
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
@@ -21,7 +21,7 @@ public struct SubfieldViewInstruction: Instruction {
   fileprivate init(
     base: Operand,
     subfield: RecordPath,
-    subfieldType: LoweredType,
+    subfieldType: IR.LoweredType,
     site: SourceRange
   ) {
     self.recordAddress = base
@@ -30,7 +30,7 @@ public struct SubfieldViewInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [resultType] }
+  public var types: [IR.LoweredType] { [resultType] }
 
   public var operands: [Operand] { [recordAddress] }
 

--- a/Sources/IR/Operands/Instruction/SubfieldViewInstruction.swift
+++ b/Sources/IR/Operands/Instruction/SubfieldViewInstruction.swift
@@ -12,7 +12,7 @@ public struct SubfieldViewInstruction: Instruction {
   public let subfield: RecordPath
 
   /// The type of the resulting address.
-  public let resultType: IRType
+  public let resultType: IR.Type_
 
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
@@ -21,7 +21,7 @@ public struct SubfieldViewInstruction: Instruction {
   fileprivate init(
     base: Operand,
     subfield: RecordPath,
-    subfieldType: IRType,
+    subfieldType: IR.Type_,
     site: SourceRange
   ) {
     self.recordAddress = base
@@ -30,7 +30,7 @@ public struct SubfieldViewInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [resultType] }
+  public var types: [IR.Type_] { [resultType] }
 
   public var operands: [Operand] { [recordAddress] }
 

--- a/Sources/IR/Operands/Instruction/UnreachableInstruction.swift
+++ b/Sources/IR/Operands/Instruction/UnreachableInstruction.swift
@@ -11,7 +11,7 @@ public struct UnrechableInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/UnreachableInstruction.swift
+++ b/Sources/IR/Operands/Instruction/UnreachableInstruction.swift
@@ -11,7 +11,7 @@ public struct UnrechableInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/UnreachableInstruction.swift
+++ b/Sources/IR/Operands/Instruction/UnreachableInstruction.swift
@@ -11,7 +11,7 @@ public struct UnrechableInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/UnreachableInstruction.swift
+++ b/Sources/IR/Operands/Instruction/UnreachableInstruction.swift
@@ -11,7 +11,7 @@ public struct UnrechableInstruction: Terminator {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   public var operands: [Operand] { [] }
 

--- a/Sources/IR/Operands/Instruction/UnsafeCastInstruction.swift
+++ b/Sources/IR/Operands/Instruction/UnsafeCastInstruction.swift
@@ -19,7 +19,7 @@ public struct UnsafeCastInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [.object(target)] }
+  public var types: [IR.LoweredType] { [.object(target)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/UnsafeCastInstruction.swift
+++ b/Sources/IR/Operands/Instruction/UnsafeCastInstruction.swift
@@ -19,7 +19,7 @@ public struct UnsafeCastInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [.object(target)] }
+  public var types: [IRType] { [.object(target)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/UnsafeCastInstruction.swift
+++ b/Sources/IR/Operands/Instruction/UnsafeCastInstruction.swift
@@ -19,7 +19,7 @@ public struct UnsafeCastInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [.object(target)] }
+  public var types: [IR.Type_] { [.object(target)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/UnsafeCastInstruction.swift
+++ b/Sources/IR/Operands/Instruction/UnsafeCastInstruction.swift
@@ -19,7 +19,7 @@ public struct UnsafeCastInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [.object(target)] }
+  public var types: [IR.`Type`] { [.object(target)] }
 
   public var operands: [Operand] { [source] }
 

--- a/Sources/IR/Operands/Instruction/WrapExistentialAddrInstruction.swift
+++ b/Sources/IR/Operands/Instruction/WrapExistentialAddrInstruction.swift
@@ -11,20 +11,20 @@ public struct WrapExistentialAddrInstruction: Instruction {
   public private(set) var table: Operand
 
   /// The type of the existential container.
-  public let interface: LoweredType
+  public let interface: IR.LoweredType
 
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(witness: Operand, table: Operand, interface: LoweredType, site: SourceRange) {
+  fileprivate init(witness: Operand, table: Operand, interface: IR.LoweredType, site: SourceRange) {
     self.witness = witness
     self.table = table
     self.interface = interface
     self.site = site
   }
 
-  public var types: [LoweredType] { [interface] }
+  public var types: [IR.LoweredType] { [interface] }
 
   public var operands: [Operand] { [witness, table] }
 

--- a/Sources/IR/Operands/Instruction/WrapExistentialAddrInstruction.swift
+++ b/Sources/IR/Operands/Instruction/WrapExistentialAddrInstruction.swift
@@ -11,20 +11,20 @@ public struct WrapExistentialAddrInstruction: Instruction {
   public private(set) var table: Operand
 
   /// The type of the existential container.
-  public let interface: IR.LoweredType
+  public let interface: IRType
 
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(witness: Operand, table: Operand, interface: IR.LoweredType, site: SourceRange) {
+  fileprivate init(witness: Operand, table: Operand, interface: IRType, site: SourceRange) {
     self.witness = witness
     self.table = table
     self.interface = interface
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [interface] }
+  public var types: [IRType] { [interface] }
 
   public var operands: [Operand] { [witness, table] }
 

--- a/Sources/IR/Operands/Instruction/WrapExistentialAddrInstruction.swift
+++ b/Sources/IR/Operands/Instruction/WrapExistentialAddrInstruction.swift
@@ -11,20 +11,20 @@ public struct WrapExistentialAddrInstruction: Instruction {
   public private(set) var table: Operand
 
   /// The type of the existential container.
-  public let interface: IRType
+  public let interface: IR.Type_
 
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(witness: Operand, table: Operand, interface: IRType, site: SourceRange) {
+  fileprivate init(witness: Operand, table: Operand, interface: IR.Type_, site: SourceRange) {
     self.witness = witness
     self.table = table
     self.interface = interface
     self.site = site
   }
 
-  public var types: [IRType] { [interface] }
+  public var types: [IR.Type_] { [interface] }
 
   public var operands: [Operand] { [witness, table] }
 

--- a/Sources/IR/Operands/Instruction/WrapExistentialAddrInstruction.swift
+++ b/Sources/IR/Operands/Instruction/WrapExistentialAddrInstruction.swift
@@ -11,20 +11,20 @@ public struct WrapExistentialAddrInstruction: Instruction {
   public private(set) var table: Operand
 
   /// The type of the existential container.
-  public let interface: IR.Type_
+  public let interface: IR.`Type`
 
   /// The site of the code corresponding to that instruction.
   public let site: SourceRange
 
   /// Creates an instance with the given properties.
-  fileprivate init(witness: Operand, table: Operand, interface: IR.Type_, site: SourceRange) {
+  fileprivate init(witness: Operand, table: Operand, interface: IR.`Type`, site: SourceRange) {
     self.witness = witness
     self.table = table
     self.interface = interface
     self.site = site
   }
 
-  public var types: [IR.Type_] { [interface] }
+  public var types: [IR.`Type`] { [interface] }
 
   public var operands: [Operand] { [witness, table] }
 

--- a/Sources/IR/Operands/Instruction/YieldInstruction.swift
+++ b/Sources/IR/Operands/Instruction/YieldInstruction.swift
@@ -19,7 +19,7 @@ public struct YieldInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.LoweredType] { [] }
+  public var types: [IRType] { [] }
 
   public var operands: [Operand] { [projection] }
 

--- a/Sources/IR/Operands/Instruction/YieldInstruction.swift
+++ b/Sources/IR/Operands/Instruction/YieldInstruction.swift
@@ -19,7 +19,7 @@ public struct YieldInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IRType] { [] }
+  public var types: [IR.Type_] { [] }
 
   public var operands: [Operand] { [projection] }
 

--- a/Sources/IR/Operands/Instruction/YieldInstruction.swift
+++ b/Sources/IR/Operands/Instruction/YieldInstruction.swift
@@ -19,7 +19,7 @@ public struct YieldInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [LoweredType] { [] }
+  public var types: [IR.LoweredType] { [] }
 
   public var operands: [Operand] { [projection] }
 

--- a/Sources/IR/Operands/Instruction/YieldInstruction.swift
+++ b/Sources/IR/Operands/Instruction/YieldInstruction.swift
@@ -19,7 +19,7 @@ public struct YieldInstruction: Instruction {
     self.site = site
   }
 
-  public var types: [IR.Type_] { [] }
+  public var types: [IR.`Type`] { [] }
 
   public var operands: [Operand] { [projection] }
 

--- a/Sources/IR/Program.swift
+++ b/Sources/IR/Program.swift
@@ -1,7 +1,7 @@
 import Core
 
 /// A program lowered to Val IR.
-public struct LoweredProgram {
+public struct Program {
 
   /// The high-level form of the program.
   public let syntax: TypedProgram

--- a/Sources/IR/Type.swift
+++ b/Sources/IR/Type.swift
@@ -23,20 +23,20 @@ public struct Type: Hashable {
 
   /// Creates an object type.
   public static func object<T: TypeProtocol>(_ type: T) -> Self {
-    IRType(ast: type, isAddress: false)
+    IR.Type_(ast: type, isAddress: false)
   }
 
   /// Creates and address type.
   public static func address<T: TypeProtocol>(_ type: T) -> Self {
-    IRType(ast: type, isAddress: true)
+    IR.Type_(ast: type, isAddress: true)
   }
 
 }
 
-// workaround for https://github.com/apple/swift/issues/67378
-public typealias IRType = Type
+/// An alias for IR.Type that works around https://github.com/apple/swift/issues/67378
+public typealias Type_ = Type
 
-extension IRType: CustomStringConvertible {
+extension IR.Type_: CustomStringConvertible {
 
   public var description: String {
     if isAddress {

--- a/Sources/IR/Type.swift
+++ b/Sources/IR/Type.swift
@@ -1,6 +1,9 @@
 import Core
 
 /// The lowered (static) type of an entity.
+///
+/// Note: when qualified, this must be spelled IR.`Type`
+/// (https://github.com/apple/swift/issues/67378)
 public struct Type: Hashable {
 
   /// A high-level representation of the type.
@@ -23,20 +26,17 @@ public struct Type: Hashable {
 
   /// Creates an object type.
   public static func object<T: TypeProtocol>(_ type: T) -> Self {
-    IR.Type_(ast: type, isAddress: false)
+    IR.`Type`(ast: type, isAddress: false)
   }
 
   /// Creates and address type.
   public static func address<T: TypeProtocol>(_ type: T) -> Self {
-    IR.Type_(ast: type, isAddress: true)
+    IR.`Type`(ast: type, isAddress: true)
   }
 
 }
 
-/// An alias for IR.Type that works around https://github.com/apple/swift/issues/67378
-public typealias Type_ = Type
-
-extension IR.Type_: CustomStringConvertible {
+extension IR.`Type`: CustomStringConvertible {
 
   public var description: String {
     if isAddress {

--- a/Sources/IR/Type.swift
+++ b/Sources/IR/Type.swift
@@ -1,7 +1,7 @@
 import Core
 
 /// The lowered (static) type of an entity.
-public struct LoweredType: Hashable {
+public struct Type: Hashable {
 
   /// A high-level representation of the type.
   public let ast: AnyType
@@ -23,17 +23,20 @@ public struct LoweredType: Hashable {
 
   /// Creates an object type.
   public static func object<T: TypeProtocol>(_ type: T) -> Self {
-    IR.LoweredType(ast: type, isAddress: false)
+    IRType(ast: type, isAddress: false)
   }
 
   /// Creates and address type.
   public static func address<T: TypeProtocol>(_ type: T) -> Self {
-    IR.LoweredType(ast: type, isAddress: true)
+    IRType(ast: type, isAddress: true)
   }
 
 }
 
-extension IR.LoweredType: CustomStringConvertible {
+// workaround for https://github.com/apple/swift/issues/67378
+public typealias IRType = Type
+
+extension IRType: CustomStringConvertible {
 
   public var description: String {
     if isAddress {

--- a/Sources/ValCommand/ValCommand.swift
+++ b/Sources/ValCommand/ValCommand.swift
@@ -214,13 +214,13 @@ public struct ValCommand: ParsableCommand {
   /// Mandatory IR passes are applied unless `self.outputType` is `.rawIR`.
   private func lower(
     program: TypedProgram, reportingDiagnosticsInto log: inout DiagnosticSet
-  ) throws -> IR.LoweredProgram {
+  ) throws -> IR.Program {
     var loweredModules: [ModuleDecl.ID: IR.Module] = [:]
     for d in program.ast.modules {
       loweredModules[d] = try lower(d, in: program, reportingDiagnosticsInto: &log)
     }
 
-    var ir = IR.LoweredProgram(syntax: program, modules: loweredModules)
+    var ir = IR.Program(syntax: program, modules: loweredModules)
     if let t = transforms {
       for p in t.elements { ir.applyPass(p) }
     }


### PR DESCRIPTION
Note that a Swift bug means we need to say `IR.Type_` rather than `IR.Type`.