### PR TITLE
Fix type inference through generic members

### DIFF
--- a/Library/Val/Core/Bitcast.val
+++ b/Library/Val/Core/Bitcast.val
@@ -1,11 +1,11 @@
 /// Projects `value` with its memory representation reinterpreted as a value of type `U`.
 public subscript unsafe_bitcast<T, U>(_ value: T): U {
   let {
-    let p = Pointer.to[value]
+    let p = Pointer<T>.to[value]
     yield p.value as* (remote let U)
   }
   inout {
-    let p = Pointer.to[value]
+    let p = Pointer<T>.to[value]
     yield &(p.value as* (remote inout U))
   }
 }

--- a/Sources/Core/AST/Decl/Decl.swift
+++ b/Sources/Core/AST/Decl/Decl.swift
@@ -1,2 +1,13 @@
 /// A declaration.
-public protocol Decl: Node {}
+public protocol Decl: Node {
+
+  /// `true` is `Self` is the declaration of a callable entity.
+  static var isCallable: Bool { get }
+
+}
+
+extension Decl {
+
+  public static var isCallable: Bool { false }
+
+}

--- a/Sources/Core/AST/Decl/FunctionDecl.swift
+++ b/Sources/Core/AST/Decl/FunctionDecl.swift
@@ -3,6 +3,8 @@ import Utils
 /// A function declaration.
 public struct FunctionDecl: GenericDecl, GenericScope {
 
+  public static let isCallable = true
+
   public let site: SourceRange
 
   /// The site of the `fun` introducer.

--- a/Sources/Core/AST/Decl/InitializerDecl.swift
+++ b/Sources/Core/AST/Decl/InitializerDecl.swift
@@ -12,6 +12,8 @@ public struct InitializerDecl: GenericDecl, GenericScope {
 
   }
 
+  public static let isCallable = true
+
   public let site: SourceRange
 
   /// The introducer of the declaration.

--- a/Sources/Core/AST/Decl/MethodDecl.swift
+++ b/Sources/Core/AST/Decl/MethodDecl.swift
@@ -3,6 +3,8 @@ public struct MethodDecl: BundleDecl, GenericDecl, GenericScope {
 
   public typealias Variant = MethodImpl
 
+  public static let isCallable = true
+
   public let site: SourceRange
 
   /// The site of the `fun` introducer.

--- a/Sources/Core/AST/Decl/MethodImpl.swift
+++ b/Sources/Core/AST/Decl/MethodImpl.swift
@@ -3,6 +3,8 @@
 /// Instances of this type represent individual variant inside a method declaration.
 public struct MethodImpl: Decl, LexicalScope {
 
+  public static let isCallable = true
+
   public let site: SourceRange
 
   /// The introducer of the method.

--- a/Sources/Core/AST/Decl/ProductTypeDecl.swift
+++ b/Sources/Core/AST/Decl/ProductTypeDecl.swift
@@ -1,5 +1,5 @@
 /// A (nominal) product type declaration.
-public struct ProductTypeDecl: SingleEntityDecl, GenericDecl, TypeScope, GenericScope {
+public struct ProductTypeDecl: SingleEntityDecl, GenericDecl, LexicalScope, GenericScope {
 
   public let site: SourceRange
 

--- a/Sources/Core/AST/Decl/SubscriptDecl.swift
+++ b/Sources/Core/AST/Decl/SubscriptDecl.swift
@@ -13,6 +13,8 @@ public struct SubscriptDecl: BundleDecl, GenericDecl, GenericScope {
 
   }
 
+  public static let isCallable = true
+
   public let site: SourceRange
 
   /// The introducer of the declaration.

--- a/Sources/Core/AST/Decl/SubscriptImpl.swift
+++ b/Sources/Core/AST/Decl/SubscriptImpl.swift
@@ -3,6 +3,8 @@
 /// Instances of this type represent individual variant inside a subscript declaration.
 public struct SubscriptImpl: Decl, LexicalScope {
 
+  public static let isCallable = true
+
   public let site: SourceRange
 
   /// The introducer of the subscript.

--- a/Sources/Core/AST/Decl/TraitDecl.swift
+++ b/Sources/Core/AST/Decl/TraitDecl.swift
@@ -1,7 +1,7 @@
 /// A trait declaration.
 ///
 /// - Note: `TraitDecl` does not conform to `GenericDecl`.
-public struct TraitDecl: SingleEntityDecl, TypeScope {
+public struct TraitDecl: SingleEntityDecl, LexicalScope {
 
   public let site: SourceRange
 

--- a/Sources/Core/AST/Decl/TypeAliasDecl.swift
+++ b/Sources/Core/AST/Decl/TypeAliasDecl.swift
@@ -1,5 +1,5 @@
 /// A type alias declaration.
-public struct TypeAliasDecl: SingleEntityDecl, GenericDecl, TypeScope, GenericScope {
+public struct TypeAliasDecl: SingleEntityDecl, GenericDecl, LexicalScope, GenericScope {
 
   public let site: SourceRange
 

--- a/Sources/Core/AST/TypeScope.swift
+++ b/Sources/Core/AST/TypeScope.swift
@@ -1,2 +1,0 @@
-/// An AST node that outlines a type scope.
-public protocol TypeScope: LexicalScope {}

--- a/Sources/Core/CompileTimeValues/GenericArguments.swift
+++ b/Sources/Core/CompileTimeValues/GenericArguments.swift
@@ -42,6 +42,11 @@ public struct GenericArguments {
     set { contents[key] = newValue }
   }
 
+  /// Accesses the value associated with the given key.
+  public subscript(key: Key, default value: @autoclosure () -> Value) -> Value {
+    contents[key, default: value()]
+  }
+
   /// Returns a new map containing the keys of `self` with the values transformed `transform`.
   public func mapValues(_ transform: (Value) throws -> Value) rethrows -> Self {
     return try .init(contents: contents.mapValues(transform))

--- a/Sources/Core/Program.swift
+++ b/Sources/Core/Program.swift
@@ -271,11 +271,6 @@ extension Program {
     LexicalScopeSequence(scopeToParent: nodeToScope, from: scope)
   }
 
-  /// Returns the innermost type scope containing `d`.
-  public func innermostType<T: DeclID>(containing d: T) -> AnyScopeID? {
-    scopes(from: nodeToScope[d]!).first(where: { $0.kind.value is TypeScope.Type })
-  }
-
   /// Returns the module containing `scope`.
   public func module<S: ScopeID>(containing scope: S) -> ModuleDecl.ID {
     scopes(from: scope).first(ModuleDecl.self)!

--- a/Sources/Core/Types/BoundGenericType.swift
+++ b/Sources/Core/Types/BoundGenericType.swift
@@ -56,6 +56,14 @@ public struct BoundGenericType: TypeProtocol {
       }))
   }
 
+  /// Applies `transform` on `m` and the generic arguments that are part of `self`.
+  public func transformArguments<M>(
+    mutating m: inout M, _ transform: (inout M, any CompileTimeValue) -> any CompileTimeValue
+  ) -> Self {
+    let transformed = arguments.mapValues({ (a) in transform(&m, a) })
+    return .init(base, arguments: transformed)
+  }
+
 }
 
 extension BoundGenericType: Equatable {

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -396,7 +396,7 @@ struct ConstraintSystem {
           unreachable()
         }
 
-        let r = checker.openForUnification(d)
+        let r = openForUnification(d, using: checker)
         let s = schedule(EqualityConstraint(goal.left, ^r, origin: goal.origin.subordinate()))
         return delegate(to: [s])
 
@@ -439,6 +439,27 @@ struct ConstraintSystem {
           : .failure(failureToSolve(goal))
       }
     }
+  }
+
+  /// Returns the type declared by `d` bound to open variables for each generic parameter
+  /// introduced by `d`.
+  ///
+  /// - Requires: `d` is a a generic product type or type alias declaration.
+  private func openForUnification(_ d: AnyDeclID, using checker: TypeChecker) -> BoundGenericType {
+    let parameters: [GenericParameterDecl.ID]
+    if let decl = ProductTypeDecl.ID(d) {
+      parameters = checker.ast[decl].genericClause!.value.parameters
+    } else if let decl = TypeAliasDecl.ID(d) {
+      parameters = checker.ast[decl].genericClause!.value.parameters
+    } else {
+      preconditionFailure()
+    }
+
+    let b = MetatypeType(checker.declTypes[d])!.instance
+    let a = GenericArguments(
+      uniqueKeysWithValues: parameters.map({ (key: $0, value: ^TypeVariable()) }))
+
+    return BoundGenericType(b, arguments: a)
   }
 
   /// Returns a clousre diagnosing a failure to solve `g`.

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -1050,7 +1050,7 @@ struct ConstraintSystem {
     querying checker: inout TypeChecker
   ) -> Bool {
     // Open the right operand.
-    let openedRight = checker.open(type: rhs)
+    let openedRight = checker.open(type: rhs, at: site)
     var constraints = openedRight.constraints
 
     // Create pairwise subtyping constraints on the parameters.

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -532,7 +532,7 @@ struct ConstraintSystem {
     let n = SourceRepresentable(value: goal.memberName, range: goal.origin.site)
 
     let context = NameResolutionContext(
-      type: goal.subject, arguments: [:], receiver: .init(checker.ast[goal.memberExpr].domain))
+      type: goal.subject, receiver: .init(checker.ast[goal.memberExpr].domain))
     let candidates = checker.resolve(
       n, parameterizedBy: [], memberOf: context, exposedTo: scope, usedAs: goal.purpose)
 

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -543,13 +543,9 @@ struct ConstraintSystem {
     }
 
     let selected = candidates.viable.map { (i) in
-      let c = candidates.elements[i]
-      let isRequirement = c.reference.decl.map(default: false, checker.program.isRequirement(_:))
-      return OverloadConstraint.Predicate(
-        reference: c.reference,
-        type: c.type,
-        constraints: c.constraints,
-        penalties: isRequirement ? 1 : 0)
+      let pick = candidates.elements[i]
+      let penalties = pick.reference.decl.map({ checker.program.isRequirement($0) ? 1 : 0 }) ?? 0
+      return OverloadConstraint.Predicate(pick, penalties: penalties)
     }
 
     let s = schedule(

--- a/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
+++ b/Sources/FrontEnd/TypeChecking/ConstraintSystem.swift
@@ -966,7 +966,7 @@ struct ConstraintSystem {
     for i in (0 ..< stale.count).reversed() {
       var changed = false
       goals[stale[i]].modifyTypes({ (type) in
-        let u = typeAssumptions.reify(type, withVariables: .keep)
+        let u = typeAssumptions.reify(type, withVariables: .kept)
         changed = changed || (type != u)
         return u
       })

--- a/Sources/FrontEnd/TypeChecking/Constraints/OverloadConstraint.swift
+++ b/Sources/FrontEnd/TypeChecking/Constraints/OverloadConstraint.swift
@@ -72,6 +72,22 @@ struct OverloadConstraint: DisjunctiveConstraintProtocol, Hashable {
     /// The penalties associated with this choice.
     let penalties: Int
 
+    /// Creates an instance with the given properties.
+    init(reference: DeclReference, type: AnyType, constraints: ConstraintSet, penalties: Int) {
+      self.reference = reference
+      self.type = type
+      self.constraints = constraints
+      self.penalties = penalties
+    }
+
+    /// Creates an instance representing the selection of `pick`, penalized by `penalties`.
+    init(_ pick: NameResolutionResult.Candidate, penalties: Int) {
+      self.reference = pick.reference
+      self.type = pick.type
+      self.constraints = pick.constraints
+      self.penalties = penalties
+    }
+
   }
 
 }

--- a/Sources/FrontEnd/TypeChecking/NameResolutionContext.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionContext.swift
@@ -19,7 +19,7 @@ struct NameResolutionContext {
   let receiver: DeclReference.Receiver?
 
   /// Creates an instance with the given properties.
-  init(type: AnyType, arguments: GenericArguments, receiver: DeclReference.Receiver?) {
+  init(type: AnyType, arguments: GenericArguments = [:], receiver: DeclReference.Receiver?) {
     var a = arguments
 
     if let t = BoundGenericType(type) {

--- a/Sources/FrontEnd/TypeChecking/NameResolutionContext.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionContext.swift
@@ -1,6 +1,12 @@
 import Core
 
 /// The context in which a component of a name expression gets resolved.
+///
+/// This structure is used during name resolution to identify the type of which an entity is member
+/// and the generic arguments captured by that entity. The followin invariants are maintained:
+/// - `arguments` contains the arguments of `type`'s generic parameters (if any) and the arguments
+///   to generic parameters captured by the scope in which name resolution takes place.
+/// - if `type` is a bound generic type, `type.arguments[k] = arguments[k]` for all keys in `type`.
 struct NameResolutionContext {
 
   /// The type of the receiver.
@@ -11,5 +17,28 @@ struct NameResolutionContext {
 
   /// The expression of the receiver, unless it is elided.
   let receiver: DeclReference.Receiver?
+
+  /// Creates an instance with the given properties.
+  init(type: AnyType, arguments: GenericArguments, receiver: DeclReference.Receiver?) {
+    var a = arguments
+
+    if let t = BoundGenericType(type) {
+      if a.isEmpty {
+        a = t.arguments
+      } else {
+        for (k, v) in t.arguments {
+          if let u = a[k] {
+            assert(u.equals(v))
+          } else {
+            a[k] = v
+          }
+        }
+      }
+    }
+
+    self.type = type
+    self.arguments = a
+    self.receiver = receiver
+  }
 
 }

--- a/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
@@ -16,7 +16,7 @@ enum NameResolutionResult {
   /// The payload contains the collection of unresolved components, after the first one.
   ///
   /// - Invariant: `components` is not empty.
-  case inexecutable(_ components: [NameExpr.ID])
+  case canceled(AnyType?, _ components: [NameExpr.ID])
 
   /// The result of name resolution for a single name component.
   struct ResolvedComponent {

--- a/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
+++ b/Sources/FrontEnd/TypeChecking/NameResolutionResult.swift
@@ -12,8 +12,9 @@ enum NameResolutionResult {
   /// Name resolution failed.
   case failed
 
-  /// Name resolution couln't start because the first component of the expression isn't a name
-  /// The payload contains the collection of unresolved components, after the first one.
+  /// Name resolution couldn't complete because the first component of the expression couldn't be
+  /// resolved without type inference. The payload contains the type of the resolved part, unless
+  /// it was left implicit, and the remaning unresolved components.
   ///
   /// - Invariant: `components` is not empty.
   case canceled(AnyType?, _ components: [NameExpr.ID])

--- a/Sources/FrontEnd/TypeChecking/SubstitutionMap.swift
+++ b/Sources/FrontEnd/TypeChecking/SubstitutionMap.swift
@@ -6,11 +6,11 @@ struct SubstitutionMap {
   /// A policy for substituting type variales during reification.
   enum SubstitutionPolicy {
 
-    /// Substitute free variables by error types.
-    case substituteByError
+    /// Free variables are substituted by errors.
+    case substitutedByError
 
-    /// Do not substitute free variables.
-    case keep
+    /// Free variables are kept.
+    case kept
 
   }
 
@@ -73,20 +73,20 @@ struct SubstitutionMap {
   /// having built a complete solution and therefore don't expect its result to still contain open
   /// type variables.
   func reify(
-    _ type: AnyType,
-    withVariables substitutionPolicy: SubstitutionPolicy = .substituteByError
+    _ type: AnyType, withVariables substitutionPolicy: SubstitutionPolicy = .substitutedByError
   ) -> AnyType {
-    func _impl(type: AnyType) -> TypeTransformAction {
+    return type.transform(transform(type:))
+
+    func transform(type: AnyType) -> TypeTransformAction {
       if type.base is TypeVariable {
-        // Walk `type`.
         let walked = self[type]
 
         // Substitute `walked` for `type`.
         if walked.base is TypeVariable {
           switch substitutionPolicy {
-          case .substituteByError:
-            return .stepInto(.error)
-          case .keep:
+          case .substitutedByError:
+            return .stepOver(.error)
+          case .kept:
             return .stepOver(type)
           }
         } else {
@@ -100,8 +100,6 @@ struct SubstitutionMap {
         return .stepInto(type)
       }
     }
-
-    return type.transform(_impl(type:))
   }
 
   /// Returns `r` where each type variable occuring in its generic arguments of `r` are replaced by

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -965,3 +965,28 @@ extension TypeChecker {
   }
 
 }
+
+extension TypeChecker.InferenceFacts: CustomStringConvertible {
+
+  var description: String {
+    var result = ""
+
+    result.append("inferredTypes:\n")
+    for (k, v) in inferredTypes.storage {
+      result.append("  \(k) : \(v)\n")
+    }
+
+    result.append("inferredBindings:\n")
+    for (k, v) in inferredBindings {
+      result.append("  \(k) : \(v)\n")
+    }
+
+    result.append("constraints:\n")
+    for c in constraints {
+      result.append("  \(c)\n")
+    }
+
+    return result
+  }
+
+}

--- a/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker+ConstraintGeneration.swift
@@ -764,7 +764,6 @@ extension TypeChecker {
             SubtypingConstraint(
               subjectType, t,
               origin: ConstraintOrigin(.annotation, at: ast[subject].site)))
-
         }
         subpatternType = subjectType
       } else {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -159,8 +159,7 @@ public struct TypeChecker {
 
   /// Returns `s` extended with traits refined by the elements of `s` in `useScope`.
   private mutating func derivedTraits(
-    of s: Set<TraitType>,
-    in useScope: AnyScopeID
+    of s: Set<TraitType>, in useScope: AnyScopeID
   ) -> Set<TraitType> {
     s.reduce(into: Set<TraitType>()) { (r, t) in
       r.formUnion(conformedTraits(of: ^t, in: useScope))
@@ -1654,9 +1653,10 @@ public struct TypeChecker {
       var candidateDiagnostics = DiagnosticSet()
       let candidateParameters = genericParameters(introducedBy: m)
 
-      guard var candidateArguments = associateGenericParameters(
-        candidateParameters, of: name, to: arguments,
-        reportingDiagnosticsTo: &candidateDiagnostics)
+      guard
+        var candidateArguments = associateGenericParameters(
+          candidateParameters, of: name, to: arguments,
+          reportingDiagnosticsTo: &candidateDiagnostics)
       else {
         continue
       }
@@ -3523,7 +3523,7 @@ public struct TypeChecker {
     }
 
     let shape = subject.transform(instantiate(type:))
-    return InstantiatedType(shape:shape, constraints: [])
+    return InstantiatedType(shape: shape, constraints: [])
   }
 
   /// Returns `true` iff `p` is declared in a scope containing `context`.

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -3448,26 +3448,6 @@ public struct TypeChecker {
     instantiate(type, in: ast.coreLibrary!, cause: .init(.structural, at: site))
   }
 
-  /// Returns the type declared by `d` bound to open variables for each generic parameter
-  /// introduced by `d`.
-  ///
-  /// - Requires: `d` is a a generic product type or type alias declaration.
-  func openForUnification(_ d: AnyDeclID) -> BoundGenericType {
-    let parameters: [GenericParameterDecl.ID]
-    if let decl = ProductTypeDecl.ID(d) {
-      parameters = ast[decl].genericClause!.value.parameters
-    } else if let decl = TypeAliasDecl.ID(d) {
-      parameters = ast[decl].genericClause!.value.parameters
-    } else {
-      preconditionFailure()
-    }
-
-    let b = MetatypeType(declTypes[d])!.instance
-    let a = GenericArguments(
-      uniqueKeysWithValues: parameters.map({ (key: $0, value: ^TypeVariable()) }))
-
-    return BoundGenericType(b, arguments: a)
-  }
 
   /// Replaces the generic parameters in `subject` by skolems or fresh variables depending on the
   /// whether their declaration is contained in `useScope`.

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -3308,11 +3308,9 @@ public struct TypeChecker {
     if program.isContained(program[c].scope, in: d) { return false }
     if program.isGlobal(c) { return false }
     if program.isMember(c) {
-      // Since the use collector doesn't visit type scopes, if `c` is member then we know that `d`
-      // is also a member. If `c` and `d` don't belong to the same type, then the capture is an
-      // illegal reference to a foreign receiver.
-      assert(program.isMember(d))
-      if program.innermostType(containing: c) != program.innermostType(containing: AnyDeclID(d)) {
+      let lhs = realizeReceiver(in: program[c].scope)
+      let rhs = realizeReceiver(in: program[d].scope)
+      if lhs != rhs {
         return false
       }
     }

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1544,7 +1544,7 @@ public struct TypeChecker {
       case is TypeVariable:
         return .canceled(p, unresolved)
       default:
-        parent = .init(type: p, arguments: [:], receiver: .init(domain))
+        parent = .init(type: p, receiver: .init(domain))
       }
     }
 

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -3696,13 +3696,18 @@ private struct CaptureVisitor: ASTWalkObserver {
   }
 
   mutating func willEnter(_ n: AnyNodeID, in ast: AST) -> Bool {
-    if let e = InoutExpr.ID(n) {
-      return visit(inoutExpr: e, in: ast)
+    switch n.kind {
+    case InoutExpr.self:
+      return visit(inoutExpr: .init(n)!, in: ast)
+    case NameExpr.self:
+      return visit(nameExpr: .init(n)!, in: ast)
+    case ProductTypeDecl.self, TraitDecl.self, TypeAliasDecl.self:
+      return false
+    case ConformanceDecl.self, ExtensionDecl.self:
+      return false
+    default:
+      return true
     }
-    if let e = NameExpr.ID(n) {
-      return visit(nameExpr: e, in: ast)
-    }
-    return !(n.kind.value is TypeScope)
   }
 
   private mutating func visit(inoutExpr e: InoutExpr.ID, in ast: AST) -> Bool {

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1520,11 +1520,10 @@ public struct TypeChecker {
   /// been resolved or one components requires overload resolution.
   ///
   /// If `name` is prefixed by a non-nominal component, `resolveNonNominalPrefix` is called with a
-  /// mutable projection of `self` and the leftmost nominal component `l` of `name`, expecting the
-  /// type `T` of `l`'s domain. If a type is returned, name resolution proceeds, looking for `l` as
-  /// a member of `T`. Otherwise, name resolution is cancled and `.inexecutable` is returned.
-  ///
-  /// - Postcondition: `r[i].candidates` has a single element for `0 < i < r.count`.
+  /// mutable projection of `self` and the leftmost nominal component `lhs` of `name`, expecting
+  /// the type `T` of `lhs`'s domain. If a type is returned, name resolution proceeds, looking for
+  /// `lhs` as a member of `T`. Otherwise, the method returns `.canceled(T, u)` is returned, where
+  /// `u` is the nominal suffix of `name`, starting from `lhs`.
   mutating func resolve(
     _ name: NameExpr.ID,
     usedAs purpose: NameUse = .unapplied,

--- a/Sources/FrontEnd/TypeChecking/TypeChecker.swift
+++ b/Sources/FrontEnd/TypeChecking/TypeChecker.swift
@@ -1482,12 +1482,12 @@ public struct TypeChecker {
     }
 
     for (n, r) in solution.bindingAssumptions {
-      var s = solution.typeAssumptions.reify(r, withVariables: .keep)
+      var s = solution.typeAssumptions.reify(r, withVariables: .kept)
 
       // https://github.com/apple/swift/issues/65844
       if s.arguments.values.contains(where: { $0.isTypeVariable }) {
         report(.error(notEnoughContextToInferArgumentsAt: ast[n].site))
-        s = solution.typeAssumptions.reify(s, withVariables: .substituteByError)
+        s = solution.typeAssumptions.reify(s, withVariables: .substitutedByError)
       }
       referredDecls[n] = s
     }

--- a/Tests/EndToEndTests/TestCases/AddressOf.val
+++ b/Tests/EndToEndTests/TestCases/AddressOf.val
@@ -2,6 +2,6 @@
 
 public fun main() {
   let x = 42
-  let y = Pointer.to[x]
+  let y = Pointer<Int>.to[x]
   y.with_pointee(fun(_ i) -> Void { precondition(i == 42) })
 }

--- a/Tests/ValTests/TestCases/TypeChecking/NestedGenerics.val
+++ b/Tests/ValTests/TestCases/TypeChecking/NestedGenerics.val
@@ -1,0 +1,24 @@
+//- typeCheck expecting: success
+
+type M<T> {
+  public var x: T
+  public memberwise init
+
+  public type P: Deinitializable {
+    public var y: T
+    public memberwise init
+
+    public subscript (): T {
+      let { yield y }
+      inout { yield &y }
+    }
+
+    public fun g() -> T { y }
+  }
+
+  public fun f() -> P { P(y: x) }
+}
+
+fun test(x: M<Int>) -> Int {
+  return &x.f().g()
+}


### PR DESCRIPTION
This PR refactors name resolution to enforce the invariants mentioned in #765 and fix type inference through generic members.

It introduces one regression: generic arguments to static declarations nested in generic members can no longer be inferred. However, the fact that it was working with a few select examples was a happy coincidence. A proper implementation will require a general strategy to describe when and where generic arguments can be elided. In the meantime, we can workaround the regression by providing explicit arguments. See `Bitcast.val` and `AddressOf.val` for examples.