### PR TITLE
Use YAML "folded" literals in build-and-test.yml

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Build and Test
       uses: devcontainers/ci@v0.3
       with:
-        runCmd: |
+        runCmd: >
           swift package resolve &&
           .build/checkouts/Swifty-LLVM/Tools/make-pkgconfig.sh llvm.pc &&
           export PKG_CONFIG_PATH=$PWD &&
@@ -99,18 +99,18 @@ jobs:
     - run: llvm-config --version
 
     - name: Generate LLVM pkgconfig file
-      run: |
+      run: >
         swift package resolve &&
         .build/checkouts/Swifty-LLVM/Tools/make-pkgconfig.sh llvm.pc &&
         cat llvm.pc
 
     - name: Build (${{ matrix.configuration }})
-      run: |
+      run: >
         export PKG_CONFIG_PATH=$PWD &&
         swift build -c ${{ matrix.configuration }} ${{ matrix.host.build-options }}
 
     - name: Test (${{ matrix.configuration }})
-      run: |
+      run: >
         export PKG_CONFIG_PATH=$PWD &&
         swift test -c ${{ matrix.configuration }} ${{ matrix.host.test-options }} |
           tee testoutput.txt && (


### PR DESCRIPTION
See [this stack overflow post](https://stackoverflow.com/questions/59954185/github-action-split-long-command-into-multiple-lines). We've been misusing YAML's "literal block scalar" when writing commands.