### PR TITLE
Refactor Integer and Float Tokenization/Parsing for Future Parsing Issue Fix

### DIFF
--- a/Sources/FrontEnd/Parse/Lexer.swift
+++ b/Sources/FrontEnd/Parse/Lexer.swift
@@ -170,7 +170,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       token.kind = k
       token.site.extend(upTo: index)
 
-      if let nextChar = peek(), (nextChar == "e" || nextChar == "E") {
+      if let nextChar = peek(), nextChar == "e" || nextChar == "E" {
         var exponent = Token(kind: .exponent, site: location ..< location)
         discard()
         exponent.site.extend(upTo: index)

--- a/Sources/FrontEnd/Parse/Lexer.swift
+++ b/Sources/FrontEnd/Parse/Lexer.swift
@@ -384,10 +384,8 @@ public struct Lexer: IteratorProtocol, Sequence {
     }
 
     // Consume the integer part.
-    let kind = Token.Kind.int
     _ = take(while: { $0.isDecDigit })
-
-    return kind
+    return .int
   }
 
 }

--- a/Sources/FrontEnd/Parse/Lexer.swift
+++ b/Sources/FrontEnd/Parse/Lexer.swift
@@ -170,7 +170,7 @@ public struct Lexer: IteratorProtocol, Sequence {
       token.kind = k
       token.site.extend(upTo: index)
 
-      if let nextChar = peek(), nextChar == "e" || nextChar == "E" {
+      if let next = peek(), next == "e" || next == "E" {
         var exponent = Token(kind: .exponent, site: location ..< location)
         discard()
         exponent.site.extend(upTo: index)

--- a/Sources/FrontEnd/Parse/Lexer.swift
+++ b/Sources/FrontEnd/Parse/Lexer.swift
@@ -166,7 +166,7 @@ public struct Lexer: IteratorProtocol, Sequence {
     }
 
     // Scan integral literals.
-    if let k = scanIntegralLiteral() {
+    if let k = scanIntegralLiteral(allowingPlus: false) {
       token.kind = k
       token.site.extend(upTo: index)
 
@@ -175,7 +175,7 @@ public struct Lexer: IteratorProtocol, Sequence {
         discard()
         exponent.site.extend(upTo: index)
 
-        if let _ = scanIntegralLiteral(true) {
+        if let _ = scanIntegralLiteral(allowingPlus: true) {
           exponent.site.extend(upTo: index)
         } else {
           exponent.kind = .invalid
@@ -343,9 +343,10 @@ public struct Lexer: IteratorProtocol, Sequence {
     return sourceCode.text[start ..< index]
   }
 
-  /// Consumes an integral literal and returns its kind, or returns `nil` if the stream starts with a
-  /// different token.
-  private mutating func scanIntegralLiteral(_ allowPlus: Bool = false) -> Token.Kind? {
+  /// Consumes an integral literal and returns its kind, or returns `nil` if it fails to scan a valid integer.
+  /// - Parameter allowingPlus: If set to `true`, allows the integral literal to begin with a "+" sign.
+  ///                           If set to `false` (the default), only allows "-" or no sign at the beginning.
+  private mutating func scanIntegralLiteral(allowingPlus allowPlus: Bool = false) -> Token.Kind? {
     let i = (allowPlus ? take("+") : nil) ?? take("-") ?? index
     guard let head = peek(), head.isDecDigit else {
       index = i

--- a/Sources/FrontEnd/Parse/Lexer.swift
+++ b/Sources/FrontEnd/Parse/Lexer.swift
@@ -17,6 +17,8 @@ public struct Lexer: IteratorProtocol, Sequence {
 
   /// The current location of the lexer in `sourceCode`.
   public var location: SourcePosition { sourceCode.position(index) }
+
+  /// `true` iff the last scanned token was `.int`.
   private var previousTokenWasInt = false
 
   /// Advances to the next token and returns it, or returns `nil` if no next token exists.

--- a/Sources/FrontEnd/Parse/Parser.swift
+++ b/Sources/FrontEnd/Parse/Parser.swift
@@ -1711,7 +1711,9 @@ public enum Parser {
     }
   }
 
-  private static func parseFloatLiteralExpr(in state: inout ParserState) throws -> FloatLiteralExpr.ID? {
+  private static func parseFloatLiteralExpr(in state: inout ParserState) throws -> FloatLiteralExpr
+    .ID?
+  {
     guard let first = state.take(.int) else { return nil }
 
     if let _ = state.take(if: { $0.kind == .dot }) {

--- a/Sources/FrontEnd/Parse/Token.swift
+++ b/Sources/FrontEnd/Parse/Token.swift
@@ -13,8 +13,8 @@ public struct Token {
 
     // Scalar literals
     case bool = 1000
+    case exponent
     case int
-    case float
     case string
 
     // Identifiers

--- a/Tests/ValTests/LexerTests.swift
+++ b/Tests/ValTests/LexerTests.swift
@@ -82,22 +82,36 @@ final class LexerTests: XCTestCase {
       in: input)
   }
 
-  func testFloatingPoint() {
+  func testFloatingPointSequences() {
     let input: SourceFile = "0.0 001.00 0.1_2__34__ 1e1_000 1.12e+123 3.45E-6 1. 1e -1e2"
     assert(
       tokenize(input),
       matches: [
-        TokenSpecification(.float, "0.0"),
-        TokenSpecification(.float, "001.00"),
-        TokenSpecification(.float, "0.1_2__34__"),
-        TokenSpecification(.float, "1e1_000"),
-        TokenSpecification(.float, "1.12e+123"),
-        TokenSpecification(.float, "3.45E-6"),
+        TokenSpecification(.int, "0"),
+        TokenSpecification(.dot, "."),
+        TokenSpecification(.int, "0"),
+        TokenSpecification(.int, "001"),
+        TokenSpecification(.dot, "."),
+        TokenSpecification(.int, "00"),
+        TokenSpecification(.int, "0"),
+        TokenSpecification(.dot, "."),
+        TokenSpecification(.int, "1_2__34__"),
+        TokenSpecification(.int, "1"),
+        TokenSpecification(.exponent, "e1_000"),
+        TokenSpecification(.int, "1"),
+        TokenSpecification(.dot, "."),
+        TokenSpecification(.int, "12"),
+        TokenSpecification(.exponent, "e+123"),
+        TokenSpecification(.int, "3"),
+        TokenSpecification(.dot, "."),
+        TokenSpecification(.int, "45"),
+        TokenSpecification(.exponent, "E-6"),
         TokenSpecification(.int, "1"),
         TokenSpecification(.dot, "."),
         TokenSpecification(.int, "1"),
-        TokenSpecification(.name, "e"),
-        TokenSpecification(.float, "-1e2"),
+        TokenSpecification(.invalid, "e"),
+        TokenSpecification(.int, "-1"),
+        TokenSpecification(.exponent, "e2"),
       ],
       in: input)
   }

--- a/Tests/ValTests/ParserTests.swift
+++ b/Tests/ValTests/ParserTests.swift
@@ -1083,10 +1083,29 @@ final class ParserTests: XCTestCase {
   }
 
   func testFloatingPointLiteral() throws {
-    let input: SourceFile = "4.2e+1"
-    let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
-    let expr = try XCTUnwrap(ast[exprID] as? FloatLiteralExpr)
-    XCTAssertEqual(expr.value, "4.2e+1")
+    let literals: [(String, String)] = [
+      ("3.14159", "3.14159"),
+      ("0.0", "0.0"),
+      ("001.00", "001.00"),
+      ("0.1_2__34__", "0.1234"),
+      ("1e1_000", "1e1000"),
+      ("1.12e+123", "1.12e+123"),
+      ("1.12e+123_456", "1.12e+123456"),
+      ("3.45E-6", "3.45E-6"),
+      ("1.1e2", "1.1e2"),
+      ("1.1e+2", "1.1e+2"),
+      ("1.1e-2", "1.1e-2"),
+      ("1e2", "1e2"),
+      ("1e+2", "1e+2"),
+      ("1e-2", "1e-2"),
+    ]
+
+    for (lit, expected) in literals {
+      let input = SourceFile(stringLiteral: lit)
+      let (exprID, ast) = try input.parse(with: Parser.parseExpr(in:))
+      let expr = try XCTUnwrap(ast[exprID] as? FloatLiteralExpr)
+      XCTAssertEqual(expr.value, expected)
+    }
   }
 
   func testStringLiteral() throws {


### PR DESCRIPTION
This PR adjusts the way integers and floats are tokenized and parsed, fixing the tuple key path parsing issue described in https://github.com/val-lang/val/issues/783
Specifically, floats are no longer tokenized as a single .float token. Instead, they are broken down into parts like .int, .dot, and .exponent. This change allows for more granular control over the tokenization process and directly resolves the aforementioned issue.

**Tokenization Changes:**
- **Before this PR:**
  - The floating-point number `1.12e+123` was tokenized as: `.float "1.12e+123"`

- **After this PR:**
  - The floating-point number `1.12e+123` is now tokenized as:
    - `.int, "1"`
    - `.dot, "."`
    - `.int, "12"`
    - `.exponent, "e+123"`

Fixes https://github.com/val-lang/val/issues/783
