### PR TITLE
Update Swifty-LLVM and Swift Syntax packages

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -51,7 +51,7 @@
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
         "branch" : "main",
-        "revision" : "8212815c39c1c66d6400f32f72280f06ef94af83"
+        "revision" : "250b431726c7b05309770caaa9989a4166ea6ba7"
       }
     },
     {
@@ -78,7 +78,7 @@
       "location" : "https://github.com/val-lang/Swifty-LLVM",
       "state" : {
         "branch" : "main",
-        "revision" : "6d3d421cdabcfd761bac91b650ccc839c41a6ee6"
+        "revision" : "4ba25d9615b6931033161ffcfc0a73a06809d781"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "9f39744e025c7d377987f30b03770805dcb0bcd1",
-        "version" : "1.1.4"
+        "revision" : "fee6933f37fde9a5e12a1e4aeaa93fe60116ff2a",
+        "version" : "1.2.2"
       }
     },
     {
@@ -39,10 +39,10 @@
     {
       "identity" : "swift-format",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/val-lang/swift-format",
+      "location" : "https://github.com/apple/swift-format",
       "state" : {
-        "branch" : "main",
-        "revision" : "7fc9c9102e5eeb9e15489d0e1cb769e41cf21fbc"
+        "revision" : "fbfe1869527923dd9f9b2edac148baccfce0dce7",
+        "version" : "508.0.1"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "250b431726c7b05309770caaa9989a4166ea6ba7"
+        "revision" : "2c49d66d34dfd6f8130afdba889de77504b58ec0",
+        "version" : "508.0.1"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-tools-support-core.git",
       "state" : {
-        "revision" : "284a41800b7c5565512ec6ae21ee818aac1f84ac",
-        "version" : "0.4.0"
+        "revision" : "93784c59434dbca8e8a9e4b700d0d6d94551da6a",
+        "version" : "0.5.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,8 +34,8 @@ let package = Package(
       url: "https://github.com/val-lang/Swifty-LLVM",
       branch: "main"),
     .package(
-      url: "https://github.com/val-lang/swift-format",
-      branch: "main"),
+      url: "https://github.com/apple/swift-format",
+      from: "508.0.1"),
   ],
 
   targets: [


### PR DESCRIPTION
The most salient change is [here](https://github.com/val-lang/val/pull/828/files#diff-f913940c58e8744a2af1c68b909bb6383e49007e6c5a12fb03104a9006ae677eR37-R38); the rest is the result of running `swift package update`. 

This change removes our dependency on our [fork of swift-format](https://github.com/val-lang/swift-format), which was put in place to reduce inconsistency between local dependency versions and those available on CI; namely `swift-format` and `swift-syntax`. The inconsistencies would produce build errors on CI which would not show up on local runs of `Tools/run-swift-format.sh -d lint`.

The forked repo attempted to lock the version of swift-format by [committing a `Package.resolved`](https://github.com/apple/swift-format/compare/main...val-lang:swift-format:main) file that specifies particular Git SHAs for its dependencies.

However, this does not seem to be effective. I'm not a SPM expert, but a quick look at Val's [`Package.resolved`](https://github.com/val-lang/val/blob/main/Package.resolved#L54) shows a different SHA for `swift-syntax` than the one [specified in the fork](https://github.com/apple/swift-format/compare/main...val-lang:swift-format:main#diff-3b22d20b6ae7cdf1e2591c647bcae94a3db9ab955f497aeb9d0715f468e6e6ceR18). If anyone with more SPM experience can explain, I'd be curious to know why this didn't work.

As an alternative, this PR simply version locks swift-format to its latest release (508.0.1) in `Package.swift` instead of pointing to `main`. This should achieve the desired effect of version locking swift-format more simply, ensuring consistency between local and CI builds, without the added complexity of a fork.