### PR TITLE
Fix Exponent Tokenization to Handle Missing Integer Part

### DIFF
--- a/Sources/FrontEnd/Parse/Lexer.swift
+++ b/Sources/FrontEnd/Parse/Lexer.swift
@@ -76,8 +76,8 @@ public struct Lexer: IteratorProtocol, Sequence {
       discard()
       if let _ = scanIntegralLiteral(allowingPlus: true) {
         token.kind = .exponent
-        token.site.extend(upTo: index)
       }
+      token.site.extend(upTo: index)
       return token
     }
     previousTokenWasInt = false


### PR DESCRIPTION
This PR corrects the tokenization of exponents that are not followed by a valid integer. Previously, parsing a string like "1e" would incorrectly tokenize the "e" as an empty invalid token. With this correction, the lexer now tokenizes the "e" as an invalid token containing the character "e".

Changes made:
- Adjusted the handling of exponent tokenization to extend the token site even if the integral literal scanning fails.

The following test case now passes:
```
    TokenSpecification(.int, "1"),
    TokenSpecification(.invalid, "e")
```    
for the source `"1e"`


Prior to this PR, the following line was failing:
https://github.com/val-lang/val/blob/7325df1efeb3378a322a43f62709b0d302c49dc1/Tests/ValTests/LexerTests.swift#L112
