### PR TITLE
Emit Intel Assembly

### DIFF
--- a/Docs/CLI.md
+++ b/Docs/CLI.md
@@ -70,11 +70,12 @@ Emit the specified output type (default: `binary`).  Each type represents a stag
 
 | `<output-type>` | Description |
 |--|--|
-| `raw-ast` | AST before type checking |
-| `raw-ir`  | Val IR before mandatory transformations |
-| `ir`      | Val IR |
-| `llvm`    | LLVM IR |
-| `binary`  | Executable binary |
+| `raw-ast`   | AST before type checking |
+| `raw-ir`    | Val IR before mandatory transformations |
+| `ir`        | Val IR |
+| `llvm`      | LLVM IR |
+| `intel-asm` | Intel Assembly |
+| `binary`    | Executable binary |
 
 **Example:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ You can select how deep the compiler should go through the pipeline with the fol
 - `--emit raw-ir`: Lower the typed AST into Val IR and output the result in a file.
 - `--emit ir`: Run mandatory IR passes and output the result in a file.
 - `--emit llvm`: Transpile the program to LLVM and output LLVM IR.
+- `--emit intel-asm`: Output Intel assembly for all user module(s).
 - `--emit binary` (default): Produce an executable.
 
 For example, `valc --emit raw-ast -o main.json main.val` will parse `main.val`, write the untyped AST in `main.json`, and exit the pipeline.

--- a/Sources/ValCommand/ValCommand.swift
+++ b/Sources/ValCommand/ValCommand.swift
@@ -25,6 +25,9 @@ public struct ValCommand: ParsableCommand {
     /// LLVM IR
     case llvm = "llvm"
 
+    /// Intel ASM
+    case intelAsm = "intel-asm"
+
     /// Executable binary.
     case binary = "binary"
   }
@@ -61,7 +64,7 @@ public struct ValCommand: ParsableCommand {
   @Option(
     name: [.customLong("emit")],
     help: ArgumentHelp(
-      "Emit the specified type output files. From: raw-ast, raw-ir, ir, llvm, binary",
+      "Emit the specified type output files. From: raw-ast, raw-ir, ir, llvm, intel-asm, binary",
       valueName: "output-type"))
   private var outputType: OutputType = .binary
 
@@ -186,6 +189,13 @@ public struct ValCommand: ParsableCommand {
     if outputType == .llvm {
       let m = llvmProgram.llvmModules[sourceModule]!
       try m.description.write(to: llvmFile(productName), atomically: true, encoding: .utf8)
+      return
+    }
+
+    // Intel ASM
+
+    if outputType == .intelAsm {
+      try llvmProgram.llvmModules[sourceModule]!.write(.assembly, for: target, to: intelASMFile(productName).path)
       return
     }
 
@@ -383,7 +393,7 @@ public struct ValCommand: ParsableCommand {
   /// A map from executable name to path of the named binary.
   private static var executableLocationCache: [String: String] = [:]
 
-  /// Writes a textual descriptioni of `input` to the given `output` file.
+  /// Writes a textual description of `input` to the given `output` file.
   func write(_ input: AST, to output: URL) throws {
     let encoder = JSONEncoder().forAST
     try encoder.encode(input).write(to: output, options: .atomic)
@@ -405,6 +415,12 @@ public struct ValCommand: ParsableCommand {
   /// selected as the output type.
   private func llvmFile(_ productName: String) -> URL {
     outputURL ?? URL(fileURLWithPath: productName + ".ll")
+  }
+
+  /// Given the desired name of the compiler's product, returns the file to write when "intel-asm" is
+  /// selected as the output type.
+  private func intelASMFile(_ productName: String) -> URL {
+    outputURL ?? URL(fileURLWithPath: productName + ".s")
   }
 
   /// Given the desired name of the compiler's product, returns the file to write when "binary" is

--- a/Tests/ValCommandTests/ValCommandTests.swift
+++ b/Tests/ValCommandTests/ValCommandTests.swift
@@ -52,6 +52,13 @@ final class ValCommandTests: XCTestCase {
     XCTAssert(FileManager.default.fileExists(atPath: result.output.relativePath))
   }
 
+  func testIntelASM() throws {
+    let result = try compile(["--emit", "intel-asm"], newFile(containing: "public fun main() {}"))
+    XCTAssert(result.status.isSuccess)
+    XCTAssert(result.diagnosticText.isEmpty)
+    XCTAssert(FileManager.default.fileExists(atPath: result.output.relativePath))
+  }
+
   func testBinary() throws {
     let result = try compile(["--emit", "binary"], newFile(containing: "public fun main() {}"))
     XCTAssert(result.status.isSuccess)


### PR DESCRIPTION
To support getting Val onto Compiler Explorer, we need a way to emit Intel ASM. This PR adds a simple `--emit` option to the pipeline, updates documentation, and adds a smoke test consistent with other output modes.